### PR TITLE
docs: Fix broken link in testing guide

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -713,4 +713,4 @@ Add to `.vscode/launch.json`:
 
 - [Contributing Guide](contributing.md) - How to contribute code
 - [API Reference](api-reference.md) - Testing API endpoints
-- [CI/CD](../reference/ci-cd.md) - Automated testing pipeline
+- [Architecture](architecture.md) - System overview


### PR DESCRIPTION
Replace broken link to non-existent ci-cd.md with valid link to architecture.md This fixes the GitHub Actions strict mode failure.

Fixes GitHub Actions error:
WARNING - Doc file 'development/testing.md' contains a link '../reference/ci-cd.md', but the target 'reference/ci-cd.md' is not found among documentation files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)