### PR TITLE
feat: Add homepage carousel customization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,23 +139,42 @@ _No items currently at high priority._
 
 ## Homepage Carousel Customization
 
-- **Status**: Blocked
+- **Status**: Fixed
 - **Priority**: Low
-- **Description**: Add more carousel types and allow user customization
-- **Current State**: ⚠️ **BLOCKED - Needs manual inspection to document existing carousels**
-- **Needed Work**:
-  - ⚠️ **TODO**: Document currently implemented carousel types
-  - Add additional carousel types (Recently Added, Trending, By Studio, By Performer, Random, etc.)
-  - Create user settings page for carousel preferences
-  - Toggle to enable/disable specific carousels
-  - Drag-and-drop to reorder carousels
-  - Store carousel preferences per user in database
-  - Add API endpoints for saving/loading carousel preferences
-- **Technical Notes**:
-  - Files: `client/src/components/pages/Home.jsx`
-  - Database: Add `user_preferences` table or JSON field in User model
-  - Consider carousel templates vs. dynamic configuration
-- **Benefit**: Personalized homepage, better content discovery
+- **Description**: Allow user customization of homepage carousels
+- **Completed Work**:
+  - Added `carouselPreferences` JSON field to User database schema
+  - Created database migration for the new field
+  - Set default carousel preferences on user creation (8 carousels, all enabled)
+  - Updated getUserSettings and updateUserSettings API endpoints to handle carousel preferences
+  - Added comprehensive validation for carousel preference format (id/enabled/order)
+  - Created CarouselSettings component with HTML5 drag-and-drop for reordering
+  - Toggle carousel visibility with eye icon button
+  - Save/Cancel buttons appear only when changes are made
+  - Homepage fetches user preferences and filters/sorts carousels accordingly
+  - Integrated carousel settings into user settings page
+  - All 8 existing carousel types are customizable
+- **Current Carousels**:
+  - High Rated - Top rated scenes
+  - Recently Added - Newly added content
+  - Feature Length - Longer duration scenes
+  - High Bitrate - Highest quality videos
+  - Barely Legal - 18 year old performers
+  - Favorite Performers - Scenes with favorite performers
+  - Favorite Studios - Content from favorite studios
+  - Favorite Tags - Scenes with favorite tags
+- **Technical Implementation**:
+  - Database: `server/prisma/schema.prisma` - added carouselPreferences JSON field
+  - Migration: `server/prisma/migrations/20250118000000_add_carousel_preferences/migration.sql`
+  - Backend: `server/controllers/user.ts` - carousel preference handling with validation
+  - Component: `client/src/components/settings/CarouselSettings.jsx` - drag-and-drop UI
+  - Updated: `client/src/components/pages/Home.jsx` - fetches and applies user preferences
+  - Updated: `client/src/components/pages/Settings.jsx` - integrated carousel settings section
+  - Carousel preferences stored as JSON array: `[{id: string, enabled: boolean, order: number}]`
+  - Default preferences inlined in user.ts to avoid ESM loading issues
+  - Homepage filters disabled carousels and sorts by user's preferred order
+  - Drag-and-drop uses native HTML5 events with visual feedback (opacity changes)
+- **Benefit**: Personalized homepage, users control which carousels they see and in what order
 
 ## Loading State Improvements
 

--- a/client/src/components/pages/Settings.jsx
+++ b/client/src/components/pages/Settings.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 import { usePageTitle } from "../../hooks/usePageTitle.js";
+import CarouselSettings from "../settings/CarouselSettings.jsx";
 
 const api = axios.create({
   baseURL: "/api",
@@ -18,6 +19,7 @@ const Settings = () => {
   const [preferredQuality, setPreferredQuality] = useState("auto");
   const [preferredPlaybackMode, setPreferredPlaybackMode] = useState("auto");
   const [theme, setTheme] = useState("dark");
+  const [carouselPreferences, setCarouselPreferences] = useState([]);
 
   // Password change state
   const [currentPassword, setCurrentPassword] = useState("");
@@ -39,10 +41,28 @@ const Settings = () => {
       setPreferredQuality(settings.preferredQuality || "auto");
       setPreferredPlaybackMode(settings.preferredPlaybackMode || "auto");
       setTheme(settings.theme || "dark");
+      setCarouselPreferences(settings.carouselPreferences || []);
     } catch {
       setError("Failed to load settings");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const saveCarouselPreferences = async (newPreferences) => {
+    try {
+      setMessage(null);
+      setError(null);
+
+      await api.put("/user/settings", {
+        carouselPreferences: newPreferences,
+      });
+
+      setCarouselPreferences(newPreferences);
+      setMessage("Carousel preferences saved successfully!");
+      setTimeout(() => setMessage(null), 3000);
+    } catch {
+      setError("Failed to save carousel preferences");
     }
   };
 
@@ -291,6 +311,22 @@ const Settings = () => {
                 </div>
               </div>
             </form>
+          </div>
+
+          {/* Carousel Settings */}
+          <div
+            className="card mb-6"
+            style={{
+              backgroundColor: "var(--bg-card)",
+              border: "1px solid var(--border-color)",
+            }}
+          >
+            <div className="card-body">
+              <CarouselSettings
+                carouselPreferences={carouselPreferences}
+                onSave={saveCarouselPreferences}
+              />
+            </div>
           </div>
 
           {/* Password Change */}

--- a/client/src/components/settings/CarouselSettings.jsx
+++ b/client/src/components/settings/CarouselSettings.jsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from "react";
+import { GripVertical, Eye, EyeOff } from "lucide-react";
+
+/**
+ * Carousel metadata mapping fetchKey to display information
+ */
+const CAROUSEL_METADATA = {
+  highRatedScenes: { title: "High Rated", description: "Top rated scenes" },
+  recentlyAddedScenes: { title: "Recently Added", description: "Newly added content" },
+  longScenes: { title: "Feature Length", description: "Longer duration scenes" },
+  highBitrateScenes: { title: "High Bitrate", description: "Highest quality videos" },
+  barelyLegalScenes: { title: "Barely Legal", description: "18 year old performers" },
+  favoritePerformerScenes: { title: "Favorite Performers", description: "Scenes with your favorite performers" },
+  favoriteStudioScenes: { title: "Favorite Studios", description: "Content from your favorite studios" },
+  favoriteTagScenes: { title: "Favorite Tags", description: "Scenes with your favorite tags" },
+};
+
+/**
+ * CarouselSettings Component
+ * Allows users to enable/disable and reorder homepage carousels via drag-and-drop
+ */
+const CarouselSettings = ({ carouselPreferences = [], onSave }) => {
+  const [preferences, setPreferences] = useState([]);
+  const [draggedIndex, setDraggedIndex] = useState(null);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  useEffect(() => {
+    // Sort by order on initial load
+    const sorted = [...carouselPreferences].sort((a, b) => a.order - b.order);
+    setPreferences(sorted);
+  }, [carouselPreferences]);
+
+  const handleDragStart = (e, index) => {
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleDragOver = (e, index) => {
+    e.preventDefault();
+
+    if (draggedIndex === null || draggedIndex === index) {
+      return;
+    }
+
+    const newPreferences = [...preferences];
+    const [draggedItem] = newPreferences.splice(draggedIndex, 1);
+    newPreferences.splice(index, 0, draggedItem);
+
+    // Update order values
+    const reordered = newPreferences.map((pref, idx) => ({
+      ...pref,
+      order: idx,
+    }));
+
+    setPreferences(reordered);
+    setDraggedIndex(index);
+    setHasChanges(true);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+  };
+
+  const toggleEnabled = (id) => {
+    const updated = preferences.map((pref) =>
+      pref.id === id ? { ...pref, enabled: !pref.enabled } : pref
+    );
+    setPreferences(updated);
+    setHasChanges(true);
+  };
+
+  const handleSave = () => {
+    onSave(preferences);
+    setHasChanges(false);
+  };
+
+  const handleReset = () => {
+    const sorted = [...carouselPreferences].sort((a, b) => a.order - b.order);
+    setPreferences(sorted);
+    setHasChanges(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold mb-2" style={{ color: "var(--text-primary)" }}>
+          Homepage Carousels
+        </h3>
+        <p className="text-sm mb-4" style={{ color: "var(--text-secondary)" }}>
+          Drag to reorder carousels, click the eye icon to toggle visibility
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {preferences.map((pref, index) => {
+          const metadata = CAROUSEL_METADATA[pref.id] || { title: pref.id, description: "" };
+
+          return (
+            <div
+              key={pref.id}
+              draggable
+              onDragStart={(e) => handleDragStart(e, index)}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDragEnd={handleDragEnd}
+              className={`
+                flex items-center justify-between p-4 rounded-lg border
+                transition-all duration-200 cursor-move
+                ${draggedIndex === index ? "opacity-50" : "opacity-100"}
+                ${pref.enabled ? "" : "opacity-60"}
+              `}
+              style={{
+                backgroundColor: "var(--bg-card)",
+                borderColor: "var(--border-color)",
+              }}
+            >
+              <div className="flex items-center space-x-3 flex-1">
+                <GripVertical
+                  className="w-5 h-5 flex-shrink-0"
+                  style={{ color: "var(--text-secondary)" }}
+                />
+
+                <div className="flex-1">
+                  <div className="font-medium" style={{ color: "var(--text-primary)" }}>
+                    {metadata.title}
+                  </div>
+                  <div className="text-sm" style={{ color: "var(--text-secondary)" }}>
+                    {metadata.description}
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={() => toggleEnabled(pref.id)}
+                className="p-2 rounded-lg hover:bg-opacity-80 transition-colors"
+                style={{
+                  backgroundColor: pref.enabled ? "var(--accent-primary)" : "var(--bg-secondary)",
+                  color: pref.enabled ? "white" : "var(--text-secondary)",
+                }}
+                title={pref.enabled ? "Hide carousel" : "Show carousel"}
+              >
+                {pref.enabled ? (
+                  <Eye className="w-5 h-5" />
+                ) : (
+                  <EyeOff className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {hasChanges && (
+        <div className="flex items-center justify-end space-x-3 pt-4 border-t" style={{ borderColor: "var(--border-color)" }}>
+          <button
+            onClick={handleReset}
+            className="px-4 py-2 border rounded-md text-sm hover:bg-opacity-80 transition-colors"
+            style={{
+              backgroundColor: "var(--bg-secondary)",
+              borderColor: "var(--border-color)",
+              color: "var(--text-primary)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-6 py-2 rounded-md text-sm font-medium transition-colors hover:opacity-90"
+            style={{
+              backgroundColor: "var(--accent-primary)",
+              color: "white",
+            }}
+          >
+            Save Changes
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CarouselSettings;

--- a/server/prisma/migrations/20250118000000_add_carousel_preferences/migration.sql
+++ b/server/prisma/migrations/20250118000000_add_carousel_preferences/migration.sql
@@ -1,0 +1,4 @@
+-- Add carouselPreferences column to User table
+-- Stores user's homepage carousel preferences as JSON
+-- Format: [{id: string, enabled: boolean, order: number}]
+ALTER TABLE User ADD COLUMN carouselPreferences TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
     preferredQuality    String?     @default("auto")    // "auto", "1080p", "720p", "480p", "360p"
     preferredPlaybackMode String?   @default("auto")    // "auto", "direct", "transcode"
     theme              String?     @default("dark")    // "dark", "light", "purple", etc.
+    carouselPreferences Json?       // Array of {id, enabled, order} for homepage carousels
 
     // Future features
     watchHistory WatchHistory[]

--- a/server/utils/carouselDefaults.ts
+++ b/server/utils/carouselDefaults.ts
@@ -1,0 +1,32 @@
+/**
+ * Default carousel configuration for new users
+ * Defines all available carousels and their default state
+ */
+
+export interface CarouselPreference {
+  id: string;
+  enabled: boolean;
+  order: number;
+}
+
+export const DEFAULT_CAROUSELS = [
+  { id: "highRatedScenes", enabled: true, order: 0 },
+  { id: "recentlyAddedScenes", enabled: true, order: 1 },
+  { id: "longScenes", enabled: true, order: 2 },
+  { id: "highBitrateScenes", enabled: true, order: 3 },
+  { id: "barelyLegalScenes", enabled: true, order: 4 },
+  { id: "favoritePerformerScenes", enabled: true, order: 5 },
+  { id: "favoriteStudioScenes", enabled: true, order: 6 },
+  { id: "favoriteTagScenes", enabled: true, order: 7 },
+];
+
+/**
+ * Get default carousel preferences for a new user
+ */
+export function getDefaultCarouselPreferences(): CarouselPreference[] {
+  return DEFAULT_CAROUSELS.map(({ id, enabled, order }) => ({
+    id,
+    enabled,
+    order,
+  }));
+}


### PR DESCRIPTION
Enable users to customize which homepage carousels they see and reorder them via drag-and-drop interface in their settings page.

**Changes**:
- Added `carouselPreferences` JSON field to User schema to store carousel preferences
- Created database migration for the new field
- Set default carousel preferences on user creation (8 carousels, all enabled)
- Updated getUserSettings and updateUserSettings API endpoints to handle carousel preferences
- Added comprehensive validation for carousel preference format
- Created CarouselSettings component with HTML5 drag-and-drop for reordering
- Updated Home.jsx to fetch and apply user's carousel preferences
- Integrated carousel settings into user settings page

**Implementation Details**:
- Carousel preferences stored as JSON array: [{id: string, enabled: boolean, order: number}]
- Default carousels: High Rated, Recently Added, Feature Length, High Bitrate, Barely Legal, Favorite Performers, Favorite Studios, Favorite Tags
- Drag-and-drop UI with visual feedback (opacity changes, cursor changes)
- Toggle visibility with eye icon button
- Save/Cancel buttons appear only when changes are made
- Homepage filters disabled carousels and sorts by user's preferred order

**Files Modified**:
- server/prisma/schema.prisma - Added carouselPreferences JSON field
- server/controllers/user.ts - Added carousel preference handling and validation
- client/src/components/pages/Home.jsx - Fetch and apply user preferences
- client/src/components/pages/Settings.jsx - Integrated carousel settings

**Files Created**:
- server/prisma/migrations/20250118000000_add_carousel_preferences/migration.sql
- client/src/components/settings/CarouselSettings.jsx - Drag-and-drop carousel customization UI
- server/utils/carouselDefaults.ts - Default carousel configuration (later inlined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)