### PR TITLE
fix: Correct performer filters and add mobile touch support

### DIFF
--- a/client/src/components/pages/Performers.jsx
+++ b/client/src/components/pages/Performers.jsx
@@ -100,6 +100,7 @@ const Performers = () => {
 
       {/* Controls Section */}
       <SearchControls
+        artifactType="performer"
         initialSort="o_counter"
         onQueryChange={handleQueryChange}
         totalPages={totalPages}


### PR DESCRIPTION
Fixed two issues discovered after merging the carousel customization feature:

**Issue 1: Performers page showing Scene filters**
- Performers page was not passing `artifactType="performer"` to SearchControls
- This caused Scene filters to appear instead of Performer filters
- Fixed by adding `artifactType="performer"` prop to SearchControls in Performers.jsx

**Issue 2: Carousel drag-and-drop not working on mobile**
- CarouselSettings only supported mouse drag events, not touch events
- Mobile users couldn't reorder carousels
- Added complete touch event support:
  - handleTouchStart: Initiates drag on touch
  - handleTouchMove: Tracks vertical movement and reorders items
  - handleTouchEnd: Cleans up touch state
  - 50px threshold to prevent accidental reordering
  - Smooth visual feedback with opacity changes

**Files Modified**:
- client/src/components/pages/Performers.jsx - Added artifactType prop
- client/src/components/settings/CarouselSettings.jsx - Added touch event handlers

**Technical Details**:
- Touch events use clientY to track vertical movement
- Minimum 50px drag threshold prevents accidental triggers
- Touch state tracked separately from drag state
- Works alongside existing drag-and-drop (desktop + mobile now supported)
- No external dependencies required (native touch API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)