### PR TITLE
feat: Add public endpoint for first admin user creation in setup wizard

### DIFF
--- a/client/src/components/pages/SetupWizard.jsx
+++ b/client/src/components/pages/SetupWizard.jsx
@@ -264,14 +264,13 @@ const SetupWizard = ({ onSetupComplete }) => {
     setError("");
 
     try {
-      // The admin user with default password "admin" is created by server on startup
-      // We'll change the password via auth API
-      const response = await fetch("/api/auth/first-time-password", {
+      // Create first admin user via setup API
+      const response = await fetch("/api/setup/create-admin", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           username: "admin",
-          newPassword: adminPassword,
+          password: adminPassword,
         }),
       });
 
@@ -279,10 +278,10 @@ const SetupWizard = ({ onSetupComplete }) => {
         setCurrentStep(4);
       } else {
         const data = await response.json();
-        setError(data.error || "Failed to set password");
+        setError(data.error || "Failed to create admin user");
       }
     } catch (err) {
-      setError("Failed to set admin password: " + (err.message || "Unknown error"));
+      setError("Failed to create admin user: " + (err.message || "Unknown error"));
     } finally {
       setLoading(false);
     }

--- a/server/controllers/setup.ts
+++ b/server/controllers/setup.ts
@@ -4,8 +4,21 @@ import getStash from "../stash.js";
 import fs from "fs";
 import { logger } from "../utils/logger.js";
 import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
+
+// Default carousel preferences for new users
+const getDefaultCarouselPreferences = () => [
+  { id: "highRatedScenes", enabled: true, order: 0 },
+  { id: "recentlyAddedScenes", enabled: true, order: 1 },
+  { id: "longScenes", enabled: true, order: 2 },
+  { id: "highBitrateScenes", enabled: true, order: 3 },
+  { id: "barelyLegalScenes", enabled: true, order: 4 },
+  { id: "favoritePerformerScenes", enabled: true, order: 5 },
+  { id: "favoriteStudioScenes", enabled: true, order: 6 },
+  { id: "favoriteTagScenes", enabled: true, order: 7 },
+];
 
 /**
  * Get all configured path mappings
@@ -233,6 +246,71 @@ export const getSetupStatus = async (req: Request, res: Response) => {
     logger.error("Failed to get setup status", { error });
     res.status(500).json({
       error: "Failed to get setup status",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * Create first admin user (public endpoint for setup wizard)
+ * Only works if NO users exist yet
+ */
+export const createFirstAdmin = async (req: Request, res: Response) => {
+  try {
+    // Check if any users already exist
+    const userCount = await prisma.user.count();
+
+    if (userCount > 0) {
+      return res.status(403).json({
+        error: "Users already exist. Use the regular user management to create additional users.",
+      });
+    }
+
+    const { username, password } = req.body;
+
+    if (!username || !password) {
+      return res.status(400).json({
+        error: "Username and password are required",
+      });
+    }
+
+    if (password.length < 6) {
+      return res.status(400).json({
+        error: "Password must be at least 6 characters",
+      });
+    }
+
+    // Hash password
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    // Create first admin user with default carousel preferences
+    const newUser = await prisma.user.create({
+      data: {
+        username,
+        password: hashedPassword,
+        role: "ADMIN",
+        carouselPreferences: getDefaultCarouselPreferences() as any,
+      },
+      select: {
+        id: true,
+        username: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    logger.info("First admin user created via setup wizard", {
+      username: newUser.username,
+    });
+
+    res.status(201).json({
+      success: true,
+      user: newUser,
+    });
+  } catch (error) {
+    logger.error("Failed to create first admin user", { error });
+    res.status(500).json({
+      error: "Failed to create admin user",
       message: error instanceof Error ? error.message : String(error),
     });
   }

--- a/server/routes/setup.ts
+++ b/server/routes/setup.ts
@@ -8,6 +8,7 @@ import {
   updatePathMapping,
   deletePathMapping,
   testPath,
+  createFirstAdmin,
 } from "../controllers/setup.js";
 
 const router = express.Router();
@@ -18,6 +19,7 @@ router.get("/discover-libraries", discoverStashLibraries);
 router.post("/test-path", testPath);
 router.get("/path-mappings", getPathMappings);
 router.post("/path-mappings", addPathMapping);
+router.post("/create-admin", createFirstAdmin);
 
 // Protected routes (auth required - for Settings page path management)
 router.put("/path-mappings/:id", authenticateToken, updatePathMapping);


### PR DESCRIPTION
The setup wizard was failing with "Admin user not found" because the frontend was calling `/api/auth/first-time-password` which expected an admin user to already exist. Since we removed automatic admin creation on startup, this endpoint no longer works during initial setup.

**Backend Changes**:
- Added `createFirstAdmin()` endpoint in `server/controllers/setup.ts`
  - Public endpoint (no auth required) that only works when no users exist
  - Validates username and password (min 6 characters)
  - Hashes password with bcrypt
  - Creates admin user with default carousel preferences
  - Returns 403 if users already exist (prevents abuse)
- Added route `POST /api/setup/create-admin` in `server/routes/setup.ts`

**Frontend Changes**:
- Updated `SetupWizard.jsx` to call new `/api/setup/create-admin` endpoint
- Changed from "update password" approach to "create user" approach
- Updated error messages to reflect user creation instead of password change

**Setup Flow**:
1. User completes path mapping configuration
2. User enters admin username (fixed as "admin") and password
3. Frontend calls `/api/setup/create-admin` with username + password
4. Backend creates first admin user if no users exist
5. Setup complete - user can now log in

🤖 Generated with [Claude Code](https://claude.com/claude-code)