### PR TITLE
feat: Increase Stash sync timeout from 10 to 15 minutes

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,7 +22,7 @@ server {
 
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
-        proxy_read_timeout 600s;  # 10 minutes for Stash sync operations
+        proxy_read_timeout 900s;  # 15 minutes for Stash sync operations
     }
 
     # Proxy API requests to backend (standard timeout)


### PR DESCRIPTION
Increase nginx proxy_read_timeout for sync endpoint from 600s to 900s to accommodate very large libraries that may take longer to sync.

This change is optional and can be merged if sync timeouts continue to be an issue.