### PR TITLE
feat: Add configurable navigation menu preferences

### DIFF
--- a/client/src/components/pages/Settings.jsx
+++ b/client/src/components/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { usePageTitle } from "../../hooks/usePageTitle.js";
 import { useTheme } from "../../themes/useTheme.js";
 import { PageLayout } from "../ui/index.js";
 import CarouselSettings from "../settings/CarouselSettings.jsx";
+import NavigationSettings from "../settings/NavigationSettings.jsx";
 import Button from "../ui/Button.jsx";
 import Paper from "../ui/Paper.jsx";
 import SuccessMessage from "../ui/SuccessMessage.jsx";
@@ -12,6 +13,7 @@ import ErrorMessage from "../ui/ErrorMessage.jsx";
 import InfoMessage from "../ui/InfoMessage.jsx";
 import { showSuccess, showError } from "../../utils/toast.jsx";
 import { migrateCarouselPreferences } from "../../constants/carousels.js";
+import { migrateNavPreferences } from "../../constants/navigation.js";
 
 const api = axios.create({
   baseURL: "/api",
@@ -29,6 +31,7 @@ const Settings = () => {
   const [preferredQuality, setPreferredQuality] = useState("auto");
   const [preferredPlaybackMode, setPreferredPlaybackMode] = useState("auto");
   const [carouselPreferences, setCarouselPreferences] = useState([]);
+  const [navPreferences, setNavPreferences] = useState([]);
   const [minimumPlayPercent, setMinimumPlayPercent] = useState(20);
 
   // Password change state
@@ -52,8 +55,12 @@ const Settings = () => {
       setPreferredPlaybackMode(settings.preferredPlaybackMode || "auto");
 
       // Migrate carousel preferences to include any new carousels
-      const migratedPrefs = migrateCarouselPreferences(settings.carouselPreferences);
-      setCarouselPreferences(migratedPrefs);
+      const migratedCarouselPrefs = migrateCarouselPreferences(settings.carouselPreferences);
+      setCarouselPreferences(migratedCarouselPrefs);
+
+      // Migrate navigation preferences to include any new nav items
+      const migratedNavPrefs = migrateNavPreferences(settings.navPreferences);
+      setNavPreferences(migratedNavPrefs);
 
       setMinimumPlayPercent(settings.minimumPlayPercent ?? 20);
     } catch {
@@ -75,6 +82,24 @@ const Settings = () => {
       showSuccess("Carousel preferences saved successfully!");
     } catch (err) {
       showError(err.response?.data?.error || "Failed to save carousel preferences");
+    }
+  };
+
+  const saveNavPreferences = async (newPreferences) => {
+    try {
+      setError(null);
+
+      await api.put("/user/settings", {
+        navPreferences: newPreferences,
+      });
+
+      setNavPreferences(newPreferences);
+      showSuccess("Navigation preferences saved successfully!");
+
+      // Reload the page to apply nav changes immediately
+      window.location.reload();
+    } catch (err) {
+      showError(err.response?.data?.error || "Failed to save navigation preferences");
     }
   };
 
@@ -336,6 +361,16 @@ const Settings = () => {
             <CarouselSettings
               carouselPreferences={carouselPreferences}
               onSave={saveCarouselPreferences}
+            />
+          </Paper.Body>
+        </Paper>
+
+        {/* Navigation Settings */}
+        <Paper className="mb-6">
+          <Paper.Body>
+            <NavigationSettings
+              navPreferences={navPreferences}
+              onSave={saveNavPreferences}
             />
           </Paper.Body>
         </Paper>

--- a/client/src/components/settings/NavigationSettings.jsx
+++ b/client/src/components/settings/NavigationSettings.jsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from "react";
+import { Eye, EyeOff, ChevronUp, ChevronDown } from "lucide-react";
+import { NAV_DEFINITIONS, getNavDefinition } from "../../constants/navigation.js";
+import Button from "../ui/Button.jsx";
+import { ThemedIcon } from "../icons/index.js";
+
+/**
+ * NavigationSettings component
+ * Allows users to toggle visibility and reorder navigation menu items
+ */
+const NavigationSettings = ({ navPreferences, onSave }) => {
+  const [preferences, setPreferences] = useState([]);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  useEffect(() => {
+    // Sort by order on initial load
+    const sorted = [...(navPreferences || [])].sort((a, b) => a.order - b.order);
+    setPreferences(sorted);
+    setHasChanges(false);
+  }, [navPreferences]);
+
+  const moveUp = (index) => {
+    if (index === 0) return;
+
+    const newPreferences = [...preferences];
+    [newPreferences[index - 1], newPreferences[index]] = [
+      newPreferences[index],
+      newPreferences[index - 1],
+    ];
+
+    // Re-normalize order values
+    const reordered = newPreferences.map((pref, idx) => ({
+      ...pref,
+      order: idx,
+    }));
+
+    setPreferences(reordered);
+    setHasChanges(true);
+  };
+
+  const moveDown = (index) => {
+    if (index === preferences.length - 1) return;
+
+    const newPreferences = [...preferences];
+    [newPreferences[index], newPreferences[index + 1]] = [
+      newPreferences[index + 1],
+      newPreferences[index],
+    ];
+
+    // Re-normalize order values
+    const reordered = newPreferences.map((pref, idx) => ({
+      ...pref,
+      order: idx,
+    }));
+
+    setPreferences(reordered);
+    setHasChanges(true);
+  };
+
+  const toggleEnabled = (id) => {
+    const updated = preferences.map((pref) =>
+      pref.id === id ? { ...pref, enabled: !pref.enabled } : pref
+    );
+    setPreferences(updated);
+    setHasChanges(true);
+  };
+
+  const handleSave = () => {
+    onSave(preferences);
+    setHasChanges(false);
+  };
+
+  const handleReset = () => {
+    const sorted = [...navPreferences].sort((a, b) => a.order - b.order);
+    setPreferences(sorted);
+    setHasChanges(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3
+          className="text-lg font-semibold mb-2"
+          style={{ color: "var(--text-primary)" }}
+        >
+          Navigation Menu
+        </h3>
+        <p className="text-sm mb-4" style={{ color: "var(--text-secondary)" }}>
+          Use arrow buttons to reorder navigation items, click the eye icon to toggle visibility
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {preferences.map((pref, index) => {
+          const definition = getNavDefinition(pref.id);
+          if (!definition) return null;
+
+          return (
+            <div
+              key={pref.id}
+              className={`
+                flex items-center justify-between p-4 rounded-lg border
+                transition-all duration-200
+                ${pref.enabled ? "" : "opacity-60"}
+              `}
+              style={{
+                backgroundColor: "var(--bg-card)",
+                borderColor: "var(--border-color)",
+              }}
+            >
+              <div className="flex items-center space-x-3 flex-1">
+                {/* Reorder buttons */}
+                <div className="flex flex-col space-y-1">
+                  <Button
+                    onClick={() => moveUp(index)}
+                    disabled={index === 0}
+                    variant="secondary"
+                    className="p-1"
+                    icon={<ChevronUp className="w-4 h-4" />}
+                    title="Move up"
+                  />
+                  <Button
+                    onClick={() => moveDown(index)}
+                    disabled={index === preferences.length - 1}
+                    variant="secondary"
+                    className="p-1"
+                    icon={<ChevronDown className="w-4 h-4" />}
+                    title="Move down"
+                  />
+                </div>
+
+                {/* Icon */}
+                <div className="flex-shrink-0">
+                  <ThemedIcon name={definition.icon} size={24} />
+                </div>
+
+                {/* Name and description */}
+                <div className="flex-1">
+                  <div
+                    className="font-medium"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    {definition.name}
+                  </div>
+                  <div
+                    className="text-sm"
+                    style={{ color: "var(--text-secondary)" }}
+                  >
+                    {definition.description}
+                  </div>
+                </div>
+              </div>
+
+              {/* Toggle visibility */}
+              <Button
+                onClick={() => toggleEnabled(pref.id)}
+                variant={pref.enabled ? "primary" : "secondary"}
+                className="p-2"
+                icon={
+                  pref.enabled ? (
+                    <Eye className="w-5 h-5" />
+                  ) : (
+                    <EyeOff className="w-5 h-5" />
+                  )
+                }
+                title={pref.enabled ? "Hide from menu" : "Show in menu"}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Save/Cancel buttons - always visible */}
+      <div
+        className="flex items-center justify-end space-x-3 pt-4 border-t"
+        style={{ borderColor: "var(--border-color)" }}
+      >
+        <Button
+          disabled={!hasChanges}
+          onClick={handleReset}
+          variant="secondary"
+        >
+          Cancel
+        </Button>
+        <Button disabled={!hasChanges} onClick={handleSave} variant="primary">
+          Save Changes
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default NavigationSettings;

--- a/client/src/components/ui/GlobalLayout.jsx
+++ b/client/src/components/ui/GlobalLayout.jsx
@@ -1,13 +1,35 @@
+import { useState, useEffect } from "react";
 import Navigation from "./Navigation.jsx";
+import { apiGet } from "../../services/api.js";
+import { migrateNavPreferences } from "../../constants/navigation.js";
 
 /**
  * GlobalLayout - Top-level layout with navigation
  * Wraps the entire application to provide consistent navigation structure
  */
 const GlobalLayout = ({ children }) => {
+  const [navPreferences, setNavPreferences] = useState([]);
+
+  useEffect(() => {
+    const loadNavPreferences = async () => {
+      try {
+        const response = await apiGet("/user/settings");
+        const { settings } = response;
+        const migratedPrefs = migrateNavPreferences(settings.navPreferences);
+        setNavPreferences(migratedPrefs);
+      } catch (error) {
+        console.error("Failed to load navigation preferences:", error);
+        // Use defaults on error
+        setNavPreferences(migrateNavPreferences([]));
+      }
+    };
+
+    loadNavPreferences();
+  }, []);
+
   return (
     <div className="layout-container">
-      <Navigation />
+      <Navigation navPreferences={navPreferences} />
       {/* Spacer to prevent content from going under fixed navbar */}
       <div style={{ height: '60px' }} />
       <main className="w-full">{children}</main>

--- a/client/src/components/ui/Navigation.jsx
+++ b/client/src/components/ui/Navigation.jsx
@@ -5,50 +5,28 @@ import UserMenu from "./UserMenu.jsx";
 import { ThemedIcon } from "../icons/index.js";
 import { useAuth } from "../../hooks/useAuth.js";
 import { useScrollDirection } from "../../hooks/useScrollDirection.js";
+import { getOrderedNavItems } from "../../constants/navigation.js";
 import Button from "./Button.jsx";
 
-const Navigation = () => {
+const Navigation = ({ navPreferences = [] }) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
   const { user } = useAuth();
   const scrollDirection = useScrollDirection(100);
 
+  // Get ordered and filtered nav items based on user preferences
+  const navItems = getOrderedNavItems(navPreferences);
+
   // Get current page from React Router location
   const getCurrentPage = () => {
     const path = location.pathname;
-    switch (path) {
-      case "/scenes":
-        return "Scenes";
-      case "/recommended":
-        return "Recommended";
-      case "/performers":
-        return "Performers";
-      case "/studios":
-        return "Studios";
-      case "/tags":
-        return "Tags";
-      case "/galleries":
-        return "Galleries";
-      case "/playlists":
-        return "Playlists";
-      case "/":
-        return null; // Home page - no nav item should be highlighted
-      default:
-        return null; // Unknown pages - no nav item should be highlighted
-    }
+
+    // Find matching nav item by path
+    const matchingItem = navItems.find(item => item.path === path);
+    return matchingItem ? matchingItem.name : null;
   };
 
   const currentPage = getCurrentPage();
-
-  const navItems = [
-    { name: "Scenes", path: "/scenes", icon: "clapperboard" },
-    { name: "Recommended", path: "/recommended", icon: "sparkles" },
-    { name: "Performers", path: "/performers", icon: "user-star" },
-    { name: "Studios", path: "/studios", icon: "spotlight" },
-    { name: "Tags", path: "/tags", icon: "tags" },
-    { name: "Galleries", path: "/galleries", icon: "images" },
-    { name: "Playlists", path: "/playlists", icon: "list" },
-  ];
 
   // Determine if navbar should be visible
   const isVisible = scrollDirection === 'top' || scrollDirection === 'up';

--- a/client/src/constants/navigation.js
+++ b/client/src/constants/navigation.js
@@ -1,0 +1,123 @@
+/**
+ * Navigation item definitions with stable keys
+ * These keys should NEVER change even if display names or paths are updated
+ */
+export const NAV_DEFINITIONS = [
+  {
+    key: "scenes",
+    name: "Scenes",
+    path: "/scenes",
+    icon: "clapperboard",
+    description: "Browse all scenes in your library",
+  },
+  {
+    key: "recommended",
+    name: "Recommended",
+    path: "/recommended",
+    icon: "sparkles",
+    description: "AI-recommended scenes based on your preferences",
+  },
+  {
+    key: "performers",
+    name: "Performers",
+    path: "/performers",
+    icon: "user-star",
+    description: "Browse performers in your library",
+  },
+  {
+    key: "studios",
+    name: "Studios",
+    path: "/studios",
+    icon: "spotlight",
+    description: "Browse studios in your library",
+  },
+  {
+    key: "tags",
+    name: "Tags",
+    path: "/tags",
+    icon: "tags",
+    description: "Browse tags in your library",
+  },
+  {
+    key: "galleries",
+    name: "Galleries",
+    path: "/galleries",
+    icon: "images",
+    description: "Browse image galleries in your library",
+  },
+  {
+    key: "playlists",
+    name: "Playlists",
+    path: "/playlists",
+    icon: "list",
+    description: "Manage your custom playlists",
+  },
+];
+
+/**
+ * Migrate navigation preferences to include any new items
+ * @param {Array} savedPreferences - User's saved nav preferences
+ * @returns {Array} Migrated preferences with all current nav items
+ */
+export const migrateNavPreferences = (savedPreferences) => {
+  let prefs = savedPreferences;
+
+  // If no preferences exist, create defaults (all enabled, in order)
+  if (!prefs || prefs.length === 0) {
+    return NAV_DEFINITIONS.map((def, idx) => ({
+      id: def.key,
+      enabled: true,
+      order: idx,
+    }));
+  }
+
+  // Add any new nav items that don't exist in saved preferences
+  const existingIds = new Set(prefs.map((p) => p.id));
+  const missingNavItems = NAV_DEFINITIONS.filter(
+    (def) => !existingIds.has(def.key)
+  );
+
+  missingNavItems.forEach((def) => {
+    const newPref = {
+      id: def.key,
+      enabled: true,
+      order: prefs.length, // Add to end
+    };
+    prefs.push(newPref);
+  });
+
+  // Re-normalize order values (ensure sequential 0, 1, 2, ...)
+  prefs.sort((a, b) => a.order - b.order);
+  prefs = prefs.map((pref, idx) => ({ ...pref, order: idx }));
+
+  return prefs;
+};
+
+/**
+ * Get navigation definition by key
+ * @param {string} key - Navigation item key
+ * @returns {Object|undefined} Navigation definition
+ */
+export const getNavDefinition = (key) => {
+  return NAV_DEFINITIONS.find((def) => def.key === key);
+};
+
+/**
+ * Get ordered and filtered nav items based on user preferences
+ * @param {Array} preferences - User's nav preferences
+ * @returns {Array} Ordered array of enabled nav items
+ */
+export const getOrderedNavItems = (preferences) => {
+  if (!preferences || preferences.length === 0) {
+    return NAV_DEFINITIONS;
+  }
+
+  // Sort by order
+  const sortedPrefs = [...preferences].sort((a, b) => a.order - b.order);
+
+  // Map to definitions and filter by enabled
+  return sortedPrefs
+    .filter((pref) => pref.enabled)
+    .map((pref) => getNavDefinition(pref.id))
+    .filter(Boolean); // Remove any undefined (in case of deleted nav items)
+};

--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -39,6 +39,7 @@ export const getUserSettings = async (req: AuthenticatedRequest, res: Response) 
         theme: true,
         customTheme: true,
         carouselPreferences: true,
+        navPreferences: true,
         filterPresets: true,
         minimumPlayPercent: true,
         syncToStash: true,
@@ -56,6 +57,7 @@ export const getUserSettings = async (req: AuthenticatedRequest, res: Response) 
         theme: user.theme,
         customTheme: user.customTheme,
         carouselPreferences: user.carouselPreferences || getDefaultCarouselPreferences(),
+        navPreferences: user.navPreferences || null,
         minimumPlayPercent: user.minimumPlayPercent,
         syncToStash: user.syncToStash,
       },
@@ -90,7 +92,7 @@ export const updateUserSettings = async (req: AuthenticatedRequest, res: Respons
       targetUserId = parseInt(req.params.userId);
     }
 
-    const { preferredQuality, preferredPlaybackMode, theme, customTheme, carouselPreferences, minimumPlayPercent, syncToStash } = req.body;
+    const { preferredQuality, preferredPlaybackMode, theme, customTheme, carouselPreferences, navPreferences, minimumPlayPercent, syncToStash } = req.body;
 
     // Validate values
     const validQualities = ["auto", "1080p", "720p", "480p", "360p"];
@@ -130,6 +132,20 @@ export const updateUserSettings = async (req: AuthenticatedRequest, res: Respons
       }
     }
 
+    // Validate navigation preferences if provided
+    if (navPreferences !== undefined) {
+      if (!Array.isArray(navPreferences)) {
+        return res.status(400).json({ error: "Navigation preferences must be an array" });
+      }
+
+      // Validate each navigation preference
+      for (const pref of navPreferences) {
+        if (typeof pref.id !== 'string' || typeof pref.enabled !== 'boolean' || typeof pref.order !== 'number') {
+          return res.status(400).json({ error: "Invalid navigation preference format" });
+        }
+      }
+    }
+
     const updatedUser = await prisma.user.update({
       where: { id: targetUserId },
       data: {
@@ -138,6 +154,7 @@ export const updateUserSettings = async (req: AuthenticatedRequest, res: Respons
         ...(theme !== undefined && { theme }),
         ...(customTheme !== undefined && { customTheme }),
         ...(carouselPreferences !== undefined && { carouselPreferences }),
+        ...(navPreferences !== undefined && { navPreferences }),
         ...(minimumPlayPercent !== undefined && { minimumPlayPercent }),
         ...(syncToStash !== undefined && { syncToStash }),
       },
@@ -150,6 +167,7 @@ export const updateUserSettings = async (req: AuthenticatedRequest, res: Respons
         theme: true,
         customTheme: true,
         carouselPreferences: true,
+        navPreferences: true,
         minimumPlayPercent: true,
         syncToStash: true,
       },
@@ -163,6 +181,7 @@ export const updateUserSettings = async (req: AuthenticatedRequest, res: Respons
         theme: updatedUser.theme,
         customTheme: updatedUser.customTheme,
         carouselPreferences: updatedUser.carouselPreferences || getDefaultCarouselPreferences(),
+        navPreferences: updatedUser.navPreferences || null,
         minimumPlayPercent: updatedUser.minimumPlayPercent,
         syncToStash: updatedUser.syncToStash,
       },

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
     preferredPlaybackMode String?   @default("auto")    // "auto", "direct", "transcode"
     theme              String?     @default("dark")    // "dark", "light", "purple", etc.
     carouselPreferences Json?       // Array of {id, enabled, order} for homepage carousels
+    navPreferences     Json?       // Array of {id, enabled, order} for navigation menu items
     filterPresets      Json?       // Object with keys: scene, performer, studio, tag - each containing array of saved presets
 
     // Watch history settings


### PR DESCRIPTION
Allow users to customize which navigation items appear in their menu and reorder them according to their preferences. User and server settings icons remain fixed and cannot be reordered.

Frontend Changes:
- Add navigation.js constants with stable keys for all nav items
- Implement migrateNavPreferences() to auto-add new nav items
- Create NavigationSettings component matching CarouselSettings design
- Update Navigation component to accept and use navPreferences prop
- Modify GlobalLayout to fetch and pass nav preferences
- Integrate NavigationSettings into Settings page
- Add large nav icons (24px) for better visibility
- Green buttons for enabled items, gray for disabled
- Always-visible save/cancel buttons positioned on right

Backend Changes:
- Add navPreferences JSON field to User model
- Update getUserSettings to return navPreferences
- Update updateUserSettings to validate and save navPreferences
- Database schema updated with new field

Features:
- Toggle visibility of nav items (hide unused sections)
- Reorder nav items with up/down arrows
- Stable keys prevent breakage if display names change
- Auto-migration for future nav items
- Page reloads after save to apply changes immediately
- Consistent UI with CarouselSettings

Use Cases:
- Hide Galleries if you don't use image galleries
- Hide all except Galleries if you only use galleries
- Reorder frequently-used items to the front

🤖 Generated with [Claude Code](https://claude.com/claude-code)