### PR TITLE
feat: Auto-scroll to top pagination when navigating pages

### DIFF
--- a/client/src/components/ui/SearchControls.jsx
+++ b/client/src/components/ui/SearchControls.jsx
@@ -77,6 +77,7 @@ const SearchControls = ({
   const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const lastSyncedUrl = useRef(""); // Empty initially so first URL sync always runs
+  const topPaginationRef = useRef(null); // Ref for top pagination element
 
   // Get filter options for this artifact type
   const filterOptions = useMemo(() => {
@@ -342,6 +343,22 @@ const SearchControls = ({
     };
 
     onQueryChange(query);
+
+    // Scroll to top pagination if it's not in view
+    setTimeout(() => {
+      if (topPaginationRef.current) {
+        const rect = topPaginationRef.current.getBoundingClientRect();
+        const isInView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+
+        // Only scroll if not already in view
+        if (!isInView) {
+          topPaginationRef.current.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }
+      }
+    }, 50);
   };
 
   const handleChangeSearchText = (searchStr) => {
@@ -531,7 +548,7 @@ const SearchControls = ({
 
       {/* Top Pagination */}
       {totalPages >= 1 && (
-        <div className="mt-4 mb-4">
+        <div ref={topPaginationRef} className="mt-4 mb-4">
           <Pagination
             currentPage={currentPage}
             onPageChange={handlePageChange}


### PR DESCRIPTION
When using pagination controls to navigate pages, automatically scroll to the top pagination if it's not currently in view. This resets the grid position to the top for better UX.

Implementation:
- Add ref to top pagination element in SearchControls
- Check if top pagination is in view after page change
- Smoothly scroll to top pagination if not visible
- Only scrolls when needed (skips if already in view)

Benefits:
- Better navigation experience, especially on mobile
- User doesn't have to manually scroll back to top after pagination
- Consistent behavior across all entity list pages
- Smooth scroll animation for natural feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)