### PR TITLE
feat: Add AirPlay and Chromecast support to video player

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "peek-client",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peek-client",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "dependencies": {
+        "@silvermine/videojs-airplay": "^1.2.0",
+        "@silvermine/videojs-chromecast": "^1.4.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
@@ -1436,6 +1438,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@silvermine/videojs-airplay": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@silvermine/videojs-airplay/-/videojs-airplay-1.3.0.tgz",
+      "integrity": "sha512-Oxq31DIEuKVt0qLj8/n5aaC9RRAc0hryarPVD9SFxPwCQ3A9Ef7bkRkGJz2i7XQxpIhPQ4SkM9BudUj6oHsPzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "video.js": ">= 6.0.0"
+      }
+    },
+    "node_modules/@silvermine/videojs-chromecast": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@silvermine/videojs-chromecast/-/videojs-chromecast-1.5.0.tgz",
+      "integrity": "sha512-oDWu0WT6NORWqpUHf5xg+GoLlxA/YV7guNDOGsDV51gOqYiKb2HoPXodDfhdzwHczUmPFmbyPwfSC1E+etAOmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "webcomponents.js": "git+https://git@github.com/webcomponents/webcomponentsjs.git#v0.7.24"
+      },
+      "peerDependencies": {
+        "video.js": ">= 6 < 9"
+      }
     },
     "node_modules/@tailwindcss/aspect-ratio": {
       "version": "0.4.2",
@@ -5288,6 +5311,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/webcomponents.js": {
+      "version": "0.7.24",
+      "resolved": "git+https://git@github.com/webcomponents/webcomponentsjs.git#8a2e40557b177e2cca0def2553f84c8269c8f93e",
+      "license": "BSD-3-Clause"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,8 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@silvermine/videojs-airplay": "^1.2.0",
+    "@silvermine/videojs-chromecast": "^1.4.1",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",

--- a/client/src/components/video-player/useVideoPlayerLifecycle.js
+++ b/client/src/components/video-player/useVideoPlayerLifecycle.js
@@ -1,6 +1,14 @@
 import { useEffect } from "react";
 import videojs from "video.js";
+import airplay from "@silvermine/videojs-airplay";
+import chromecast from "@silvermine/videojs-chromecast";
 import "./vtt-thumbnails.js";
+import "@silvermine/videojs-airplay/dist/silvermine-videojs-airplay.css";
+import "@silvermine/videojs-chromecast/dist/silvermine-videojs-chromecast.css";
+
+// Register Video.js plugins
+airplay(videojs);
+chromecast(videojs);
 
 /**
  * useVideoPlayerLifecycle
@@ -42,6 +50,7 @@ export function useVideoPlayerLifecycle({
       preload: "none", // Match Stash - don't load until user interacts
       liveui: false,
       playsinline: true, // Match Stash
+      techOrder: ["chromecast", "html5"], // Enable Chromecast and AirPlay
       html5: {
         vhs: {
           overrideNative: !videojs.browser.IS_SAFARI,
@@ -55,6 +64,8 @@ export function useVideoPlayerLifecycle({
         nativeVideoTracks: false,
       },
       plugins: {
+        airPlay: {},
+        chromecast: {},
         qualityLevels: {},
         vttThumbnails: {
           showTimestamp: true,


### PR DESCRIPTION
Add @silvermine/videojs-airplay and @silvermine/videojs-chromecast plugins to enable casting to AirPlay and Chromecast devices, matching Stash's video player functionality.

Changes:
- Add @silvermine/videojs-airplay (^1.2.0) and @silvermine/videojs-chromecast (^1.4.1) dependencies
- Import and register both plugins in useVideoPlayerLifecycle.js
- Add plugin CSS imports for control bar buttons
- Update Video.js configuration with techOrder: ["chromecast", "html5"]
- Add airPlay and chromecast to plugins configuration

Benefits:
- AirPlay button appears when Apple devices are detected on network
- Chromecast button appears when Chromecast devices are available
- Works with both Direct Play and HLS transcoded videos
- Matches Stash's casting capabilities

Fixes user-reported issue where AirPlay was not available in Peek but worked in Stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)