### PR TITLE
feat: Add default filter presets with simplified URL sync architecture

### DIFF
--- a/client/src/components/video-player/PlaybackControls.jsx
+++ b/client/src/components/video-player/PlaybackControls.jsx
@@ -4,14 +4,8 @@ import OCounterButton from "../ui/OCounterButton.jsx";
 import RatingControls from "../ui/RatingControls.jsx";
 
 const PlaybackControls = () => {
-  const {
-    scene,
-    sceneLoading,
-    videoLoading,
-    quality,
-    oCounter,
-    dispatch,
-  } = useScenePlayer();
+  const { scene, sceneLoading, videoLoading, quality, oCounter, dispatch } =
+    useScenePlayer();
 
   // Don't render if no scene data yet
   if (!scene) {
@@ -20,7 +14,7 @@ const PlaybackControls = () => {
 
   const isLoading = sceneLoading || videoLoading;
   return (
-    <section className="container-fluid py-4 mt-6">
+    <section className="py-4 mt-6">
       <div
         className="p-4 rounded-lg"
         style={{
@@ -35,7 +29,9 @@ const PlaybackControls = () => {
           <div className="flex items-center justify-between md:justify-start gap-4 md:flex-1">
             <select
               value={quality}
-              onChange={(e) => dispatch({ type: 'SET_QUALITY', payload: e.target.value })}
+              onChange={(e) =>
+                dispatch({ type: "SET_QUALITY", payload: e.target.value })
+              }
               disabled={isLoading}
               className="btn text-sm"
               style={{
@@ -75,7 +71,9 @@ const PlaybackControls = () => {
             <OCounterButton
               sceneId={scene?.id}
               initialCount={oCounter}
-              onIncrement={(newCount) => dispatch({ type: 'SET_O_COUNTER', payload: newCount })}
+              onIncrement={(newCount) =>
+                dispatch({ type: "SET_O_COUNTER", payload: newCount })
+              }
               disabled={isLoading}
             />
           </div>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,7 +22,8 @@ model User {
     theme              String?     @default("dark")    // "dark", "light", "purple", etc.
     carouselPreferences Json?       // Array of {id, enabled, order} for homepage carousels
     navPreferences     Json?       // Array of {id, enabled, order} for navigation menu items
-    filterPresets      Json?       // Object with keys: scene, performer, studio, tag - each containing array of saved presets
+    filterPresets      Json?       // Object with keys: scene, performer, studio, tag, group, gallery - each containing array of saved presets
+    defaultFilterPresets Json?      // Object with keys: scene, performer, studio, tag, group, gallery - values are preset IDs
 
     // Watch history settings
     minimumPlayPercent Int         @default(20)        // Percent of video to watch before incrementing play_count (0-100)

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -11,6 +11,8 @@ import {
   getFilterPresets,
   saveFilterPreset,
   deleteFilterPreset,
+  getDefaultFilterPresets,
+  setDefaultFilterPreset,
   syncFromStash,
   getUserRestrictions,
   updateUserRestrictions,
@@ -35,6 +37,10 @@ router.delete(
   "/filter-presets/:artifactType/:presetId",
   authenticated(deleteFilterPreset)
 );
+
+// Default filter preset routes
+router.get("/default-presets", authenticated(getDefaultFilterPresets));
+router.put("/default-preset", authenticated(setDefaultFilterPreset));
 
 // Admin-only user management routes
 router.get("/all", requireAdmin, authenticated(getAllUsers));


### PR DESCRIPTION
Implement user-configurable default filter presets for all 6 artifact types (Scenes, Performers, Studios, Tags, Collections, Galleries) with a refactored, more reliable URL sync system.

Backend Changes:
- Add defaultFilterPresets field to User model (stores preset ID per artifact type)
- Add DefaultFilterPresets TypeScript interface
- Update saveFilterPreset: Support setAsDefault parameter to set preset as default
- Update deleteFilterPreset: Clear default if deleted preset was the default
- Add getDefaultFilterPresets controller: Fetch user's default presets
- Add setDefaultFilterPreset controller: Set/clear default with validation
- Add GET /api/user/default-presets and PUT /api/user/default-preset routes

Frontend - FilterPresets UI:
- Add "Set as Default" checkbox in save preset dialog
- Add star icon button to each preset in dropdown (filled when default)
- Add handleToggleDefault function to set/unset default presets
- Fetch both presets and defaults on mount
- Show visual indicator (yellow star) for current default preset

Frontend - SearchControls Architecture Refactor:
- Remove fragile bidirectional URL sync (eliminates race conditions and infinite loops)
- Remove circuit breaker pattern with lastSyncedUrl ref
- Implement clean initialization priority system:
  1. URL parameters (when navigating with filters) → Use URL
  2. No URL params → Fetch default preset → Use default
  3. No default preset → Use hardcoded application defaults
- One-way URL sync after initialization: State → URL only
- Add loading state while fetching defaults (prevents flicker)
- Trigger query AFTER initialization completes with correct preset values
- Initialize isLoadingDefaults based on needsDefaultPreset (no flicker)

Architecture Improvements:
- Simplified URL sync: No more bidirectional sync, no circuit breakers needed
- Eliminated race conditions from parallel URL ↔ State sync effects
- Loading UX: Smooth spinner prevents filter flicker on mount
- Query triggered once with correct values (not twice with wrong then right)

Benefits:
- Users can set per-artifact-type default filters (e.g., default "Favorite" filter for Scenes)
- Defaults applied on every fresh page load (no URL params needed)
- More reliable URL sync without infinite loop protection hacks
- Cleaner initialization flow with proper async handling
- Better UX: No flicker, loading feedback, results match preset immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)