### PR TITLE
feat: Overhaul recommendations algorithm with diminishing returns and…

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -11,5 +11,4 @@
 
 ## Improvements
 
-- Improve Recommendations logic. Right now it seems to unfairly favor items that simply have a lot of metadata items attached to them.
 - Add actual unit test coverage to prevent regressions when making code changes

--- a/client/src/components/ui/Tooltip.jsx
+++ b/client/src/components/ui/Tooltip.jsx
@@ -48,11 +48,17 @@ const Tooltip = ({
     let left = 0;
 
     // Auto-flip vertical position if not enough space
-    if (position === "top" && spaceAbove < tooltipRect.height + GAP + EDGE_PADDING) {
+    if (
+      position === "top" &&
+      spaceAbove < tooltipRect.height + GAP + EDGE_PADDING
+    ) {
       if (spaceBelow > spaceAbove) {
         finalPosition = "bottom";
       }
-    } else if (position === "bottom" && spaceBelow < tooltipRect.height + GAP + EDGE_PADDING) {
+    } else if (
+      position === "bottom" &&
+      spaceBelow < tooltipRect.height + GAP + EDGE_PADDING
+    ) {
       if (spaceAbove > spaceBelow) {
         finalPosition = "top";
       }
@@ -144,12 +150,12 @@ const Tooltip = ({
 
     const handleReposition = () => calculatePosition();
 
-    window.addEventListener('resize', handleReposition);
-    window.addEventListener('scroll', handleReposition, true); // Use capture to catch all scroll events
+    window.addEventListener("resize", handleReposition);
+    window.addEventListener("scroll", handleReposition, true); // Use capture to catch all scroll events
 
     return () => {
-      window.removeEventListener('resize', handleReposition);
-      window.removeEventListener('scroll', handleReposition, true);
+      window.removeEventListener("resize", handleReposition);
+      window.removeEventListener("scroll", handleReposition, true);
     };
   }, [isVisible, calculatePosition]);
 
@@ -168,12 +174,12 @@ const Tooltip = ({
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('touchstart', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('touchstart', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
     };
   }, [clickable, isVisible]);
 
@@ -233,8 +239,8 @@ const Tooltip = ({
       onMouseLeave={handleTooltipMouseLeave}
       className="fixed z-[9999] px-4 py-3 text-sm rounded-lg shadow-xl"
       style={{
-        backgroundColor: "var(--bg-tooltip, #1f2937)",
-        color: "var(--text-tooltip, white)",
+        backgroundColor: "var(--bg-tertiary)",
+        color: "var(--text-primary)",
         border: "1px solid var(--border-color)",
         minWidth: "200px",
         maxWidth: "calc(100vw - 32px)", // Use nearly full width on all screens
@@ -243,11 +249,12 @@ const Tooltip = ({
         wordWrap: "break-word",
         top: `${tooltipPosition.top || 0}px`,
         left: `${tooltipPosition.left || 0}px`,
-        transform: (tooltipPosition.finalPosition === "top")
-          ? "translateY(-100%)"
-          : (tooltipPosition.finalPosition === "left")
-          ? "translateX(-100%)"
-          : "none",
+        transform:
+          tooltipPosition.finalPosition === "top"
+            ? "translateY(-100%)"
+            : tooltipPosition.finalPosition === "left"
+            ? "translateX(-100%)"
+            : "none",
       }}
     >
       {typeof content === "string" ? (
@@ -259,14 +266,14 @@ const Tooltip = ({
       <div
         className={`absolute w-2 h-2 transform rotate-45`}
         style={{
-          backgroundColor: "var(--bg-tooltip, #1f2937)",
+          backgroundColor: "var(--bg-card)",
           borderColor: "var(--border-color)",
           borderWidth:
-            (tooltipPosition.finalPosition === "top")
+            tooltipPosition.finalPosition === "top"
               ? "0 1px 1px 0"
-              : (tooltipPosition.finalPosition === "bottom")
+              : tooltipPosition.finalPosition === "bottom"
               ? "1px 0 0 1px"
-              : (tooltipPosition.finalPosition === "left")
+              : tooltipPosition.finalPosition === "left"
               ? "1px 1px 0 0"
               : "0 0 1px 1px",
           // Position arrow based on actual position
@@ -299,7 +306,7 @@ const Tooltip = ({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
-        style={clickable ? { cursor: 'pointer' } : undefined}
+        style={clickable ? { cursor: "pointer" } : undefined}
       >
         {children}
       </div>


### PR DESCRIPTION
… diversity

Completely rewrite recommendations scoring to prevent metadata-rich scenes from unfairly dominating results and add variety to top recommendations.

Recommendations Algorithm Changes:
- **Diminishing Returns**: Use sqrt scaling instead of linear for performers and tags
  - Before: 5 favorite performers = 25 points (5×5)
  - After: 5 favorite performers = 11.2 points (5×√5)
  - Prevents scenes with many performers/tags from dominating unfairly

- **Tag Source Weighting**: Different weights based on tag origin to reduce "squashing" inflation
  - Scene tags: 1.0x weight (full value)
  - Performer tags: 0.3x weight (inherited, less relevant)
  - Studio tags: 0.5x weight (medium relevance)
  - Prevents double-counting tags across scene + performers + studio

- **Reduced Watch Status Weight**: Lower dominance of watch history bonuses/penalties
  - Before: +100 unwatched, -100 very recent (overwhelmed all other scoring)
  - After: +30 unwatched, -30 very recent (balanced with metadata scoring)
  - Allows great metadata matches (50+ pts) to compete with unwatched status

- **Score Tier Randomization**: Add variety while maintaining quality order
  - Group recommendations into 10 score tiers (10% bands)
  - Randomize order within each tier using Fisher-Yates shuffle
  - Result: Different order on each page load, top 100 no longer identical

Additional Changes:
- Replace flat tag squashing with source-separated tag collection
- Cap recommendations at top 500 (was unlimited)
- Update UPCOMING.md to remove completed task

Tooltip Color Fix:
- Fix tooltips using hardcoded navy blue instead of theme colors
- Update Tooltip.jsx to use --bg-tertiary and --text-primary from theme
- Remove incorrect --bg-tooltip/--text-tooltip CSS variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)