### PR TITLE
feat: Add comprehensive rating sync to Stash with image support

### DIFF
--- a/client/src/components/pages/ServerSettings.jsx
+++ b/client/src/components/pages/ServerSettings.jsx
@@ -502,6 +502,23 @@ const ServerSettings = () => {
               </div>
             </Paper.Header>
             <Paper.Body padding="none">
+              {/* Sync to Stash Warning */}
+              <div
+                className="px-6 py-4 text-sm"
+                style={{
+                  backgroundColor: "rgba(245, 158, 11, 0.1)",
+                  borderBottom: "1px solid var(--border-color)",
+                  color: "rgb(245, 158, 11)",
+                }}
+              >
+                <div className="font-semibold mb-1">⚠️ Sync to Stash Policy</div>
+                <div className="text-xs leading-relaxed" style={{ color: "var(--text-secondary)" }}>
+                  When enabled, user ratings and favorites will sync to Stash.<br/>
+                  <strong>O Counters AGGREGATE</strong> (multiple users increment the same counter).<br/>
+                  <strong>Ratings OVERWRITE</strong> (last user to rate wins, no aggregation).<br/>
+                  Be cautious enabling for multiple users to avoid conflicts.
+                </div>
+              </div>
               <div className="overflow-x-auto">
                 <div className="md:hidden px-4 py-3 text-xs" style={{ color: "var(--text-muted)", borderBottom: "1px solid var(--border-color)" }}>
                   ← Swipe to see more →

--- a/client/src/components/ui/RatingSlider.jsx
+++ b/client/src/components/ui/RatingSlider.jsx
@@ -11,11 +11,12 @@ const RatingSlider = ({
   label = "Rating",
   showClearButton = true,
 }) => {
-  const [value, setValue] = useState((rating ?? 0) / 10); // Convert 0-100 to 0-10
+  // Track whether item is rated (null = unrated, number = rated)
+  const [value, setValue] = useState(rating === null || rating === undefined ? null : rating / 10);
   const debounceTimerRef = useRef(null);
 
   useEffect(() => {
-    setValue((rating ?? 0) / 10);
+    setValue(rating === null || rating === undefined ? null : rating / 10);
   }, [rating]);
 
   // Clean up timer on unmount
@@ -28,6 +29,11 @@ const RatingSlider = ({
   }, []);
 
   const getRatingGradient = (val) => {
+    // Unrated: neutral gray
+    if (val === null || val === undefined) {
+      return "linear-gradient(90deg, #6B7280 0%, #4B5563 100%)"; // Neutral gray
+    }
+    // Rated: metallic gradients
     if (val < 3.5) {
       return "linear-gradient(90deg, #CD7F32 0%, #B87333 100%)"; // Copper
     } else if (val < 7.0) {
@@ -48,12 +54,14 @@ const RatingSlider = ({
 
     // Set new timer to call onChange after 300ms of no changes
     debounceTimerRef.current = setTimeout(() => {
-      onChange(Math.round(newValue * 10)); // Convert back to 0-100
+      const ratingValue = Math.round(newValue * 10); // Convert back to 0-100
+      // If user drags to 0, treat as clearing the rating
+      onChange(ratingValue === 0 ? null : ratingValue);
     }, 300);
   };
 
   const handleClear = () => {
-    setValue(0);
+    setValue(null);
     onChange(null); // Clear rating
   };
 
@@ -67,9 +75,9 @@ const RatingSlider = ({
         <div className="flex items-center gap-3">
           <span
             className="text-lg font-semibold min-w-[3rem] text-right"
-            style={{ color: "var(--text-primary)" }}
+            style={{ color: value === null ? "var(--text-muted)" : "var(--text-primary)" }}
           >
-            {value.toFixed(1)}
+            {value === null ? "--" : value.toFixed(1)}
           </span>
           {showClearButton && rating !== null && rating !== undefined && (
             <button
@@ -98,7 +106,7 @@ const RatingSlider = ({
         min="0"
         max="10"
         step="0.1"
-        value={value}
+        value={value ?? 0}
         onChange={handleChange}
         className="w-full h-3 rounded-lg appearance-none cursor-pointer"
         style={{

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -286,6 +286,7 @@ export const libraryApi = {
       studio: ratingsApi.updateStudioRating,
       gallery: ratingsApi.updateGalleryRating,
       group: ratingsApi.updateGroupRating,
+      image: ratingsApi.updateImageRating,
     };
 
     const method = methodMap[entityType.toLowerCase()];
@@ -298,7 +299,7 @@ export const libraryApi = {
 
   /**
    * Update favorite status for any entity type
-   * @param {string} entityType - Entity type (scene, performer, tag, studio, gallery, group)
+   * @param {string} entityType - Entity type (scene, performer, tag, studio, gallery, group, image)
    * @param {string} entityId - Entity ID
    * @param {boolean} favorite - Favorite status
    * @returns {Promise<Object>} Updated favorite object
@@ -311,6 +312,7 @@ export const libraryApi = {
       studio: ratingsApi.updateStudioRating,
       gallery: ratingsApi.updateGalleryRating,
       group: ratingsApi.updateGroupRating,
+      image: ratingsApi.updateImageRating,
     };
 
     const method = methodMap[entityType.toLowerCase()];
@@ -606,4 +608,14 @@ export const ratingsApi = {
    * @returns {Promise<{success: boolean, rating: Object}>}
    */
   updateGroupRating: (groupId, data) => apiPut(`/ratings/group/${groupId}`, data),
+
+  /**
+   * Update rating and/or favorite for an image
+   * @param {string} imageId - Image ID
+   * @param {Object} data - Rating data
+   * @param {number|null} data.rating - Rating value (0-100) or null
+   * @param {boolean} data.favorite - Favorite status
+   * @returns {Promise<{success: boolean, rating: Object}>}
+   */
+  updateImageRating: (imageId, data) => apiPut(`/ratings/image/${imageId}`, data),
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peek-server",
-  "version": "1.3.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peek-server",
-      "version": "1.3.2",
+      "version": "1.4.3",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.17.0",
@@ -18,7 +18,7 @@
         "graphql-tag": "^2.12.6",
         "jsonwebtoken": "^9.0.2",
         "node-cache": "^5.1.2",
-        "stashapp-api": "^0.3.14"
+        "stashapp-api": "^0.3.15"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -4604,9 +4604,9 @@
       "license": "MIT"
     },
     "node_modules/stashapp-api": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.14.tgz",
-      "integrity": "sha512-Lc8n5jk6+RmYGiIRI7/J3zXbsGXeZbJWHnfk35qENVZD+EbYA5dsy+E7TeCtq1SXXGPwxKZN76Uaf493svSh4Q==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.15.tgz",
+      "integrity": "sha512-/xVV0+iBmLNoNBTPIPuxozsIZpQjEwMuAX8yFe/msgX5NhwcTcALrit2AZ2BerfBk7b4g0rGd/hAv4VFCy4uGw==",
       "license": "MIT",
       "dependencies": {
         "graphql": "^16.11.0",

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,6 @@
     "graphql-tag": "^2.12.6",
     "jsonwebtoken": "^9.0.2",
     "node-cache": "^5.1.2",
-    "stashapp-api": "^0.3.14"
+    "stashapp-api": "^0.3.15"
   }
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
     tagRatings       TagRating[]
     galleryRatings   GalleryRating[]
     groupRatings     GroupRating[]
+    imageRatings     ImageRating[]
 
     // Content restrictions
     contentRestrictions UserContentRestriction[]
@@ -238,6 +239,24 @@ model GroupRating {
     @@unique([userId, groupId])
     @@index([userId])
     @@index([groupId])
+    @@index([favorite])
+    @@index([rating])
+}
+
+model ImageRating {
+    id          Int         @id @default(autoincrement())
+    userId      Int
+    imageId     String      // Stash image ID
+    rating      Int?        // 0-100, null if not rated
+    favorite    Boolean     @default(false)
+    createdAt   DateTime    @default(now())
+    updatedAt   DateTime    @updatedAt
+
+    user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+    @@unique([userId, imageId])
+    @@index([userId])
+    @@index([imageId])
     @@index([favorite])
     @@index([rating])
 }

--- a/server/routes/ratings.ts
+++ b/server/routes/ratings.ts
@@ -7,6 +7,7 @@ import {
   updateTagRating,
   updateGalleryRating,
   updateGroupRating,
+  updateImageRating,
 } from "../controllers/ratings.js";
 
 const router = express.Router();
@@ -21,5 +22,6 @@ router.put("/studio/:studioId", updateStudioRating);
 router.put("/tag/:tagId", updateTagRating);
 router.put("/gallery/:galleryId", updateGalleryRating);
 router.put("/group/:groupId", updateGroupRating);
+router.put("/image/:imageId", updateImageRating);
 
 export default router;


### PR DESCRIPTION
Expand rating sync functionality to support all entity types and add image rating/favorite support throughout the application.

**stashapp-api Updates (v0.3.15)**:
- Add galleryUpdate, groupUpdate, imageUpdate GraphQL mutations
- Export new update methods from package
- Support rating sync for galleries, groups, and images

**Backend Changes**:
- Add ImageRating model to Prisma schema with user relationship
- Implement rating sync for all entities when user.syncToStash enabled
- Add updateImageRating endpoint to ratings controller
- Merge images with user rating/favorite data in getGalleryImages
- Update all rating endpoints to sync to Stash (scenes, performers, studios, tags, galleries, groups, images)

**Frontend Enhancements**:
- Add compact Lightbox controls for mobile optimization
  - Relocate image counter to bottom-left to avoid control conflicts
  - Icon-only play/pause button for slideshow
  - Rating badge with popover instead of full slider
  - Right-aligned control layout with medium gaps
- Fix RatingSlider to properly display unrated items
  - Show "--" and neutral gray for null ratings (not "0.0" bronze)
  - Preserve null state throughout component lifecycle
  - Treat dragging to 0 as clearing the rating
- Fix RatingSliderDialog popover positioning
  - Smart positioning: above badge when space available, below otherwise
  - Prevent off-screen rendering on right and left edges
  - Adaptive vertical positioning based on viewport space
- Add rating/favorite controls to Lightbox for images
  - Optimistic updates with error reversion
  - Persist ratings/favorites across page refreshes
- Add sync policy warning to Server Settings
  - Explain O Counter aggregation vs Rating overwrite behavior
  - Caution about multi-user conflicts

**API Updates**:
- Add updateImageRating to ratingsApi
- Add image support to updateRating/updateFavorite helpers
- Integrate stashapp-api v0.3.15 for new mutations

**Sync Behavior**:
- O Counters: AGGREGATE (multiple users increment same counter)
- Ratings: OVERWRITE (last user to rate wins, no aggregation)
- Only sync fields supported by Stash per entity type
  - Scenes: rating only (use o_counter for favorites)
  - Performers, Studios, Tags: rating and favorite
  - Galleries, Groups: rating only (no favorite in Stash)
  - Images: rating only (no favorite in Stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)