### PR TITLE
feat: Implement playlist controls and volume persistence

### DIFF
--- a/client/src/components/pages/PlaylistDetail.jsx
+++ b/client/src/components/pages/PlaylistDetail.jsx
@@ -248,20 +248,28 @@ const PlaylistDetail = () => {
     // Play first scene in playlist with playlist context
     if (scenes.length > 0 && scenes[0].exists && scenes[0].scene) {
       const validScenes = scenes.filter((s) => s.exists && s.scene);
-      navigate(`/scene/${scenes[0].sceneId}`, {
+
+      // If shuffle is enabled, pick a random scene to start with
+      const startIndex = shuffle ? Math.floor(Math.random() * validScenes.length) : 0;
+      const startScene = validScenes[startIndex];
+
+      navigate(`/scene/${startScene.sceneId}`, {
         state: {
-          scene: scenes[0].scene,
+          scene: startScene.scene,
+          shouldAutoplay: true, // Start playing immediately when entering from playlist
           playlist: {
             id: playlistId,
             name: playlist.name,
+            autoplayNext: true, // Default to autoplay enabled
             shuffle,
             repeat,
+            shuffleHistory: [], // Initialize empty history
             scenes: validScenes.map((s, idx) => ({
               sceneId: s.sceneId,
               scene: s.scene,
               position: idx,
             })),
-            currentIndex: 0,
+            currentIndex: startIndex,
           },
         },
       });

--- a/client/src/components/pages/Scene.jsx
+++ b/client/src/components/pages/Scene.jsx
@@ -246,6 +246,9 @@ const Scene = () => {
   // useVideoPlayerSources will switch to 480p if browser can't play the codec
   const initialQuality = "direct";
 
+  // Extract shouldAutoplay from location state (set by PlaylistDetail's Play button)
+  const shouldAutoplayFromState = location.state?.shouldAutoplay ?? false;
+
   return (
     <ScenePlayerProvider
       sceneId={sceneId}
@@ -253,6 +256,7 @@ const Scene = () => {
       shouldResume={shouldResume}
       compatibility={compatibility}
       initialQuality={initialQuality}
+      initialShouldAutoplay={shouldAutoplayFromState}
     >
       <SceneContent />
     </ScenePlayerProvider>

--- a/client/src/components/playlist/PlaylistSidebar.jsx
+++ b/client/src/components/playlist/PlaylistSidebar.jsx
@@ -1,9 +1,10 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import {
   ChevronDown,
   ChevronUp,
   List,
   Play,
+  PlayCircle,
   Repeat,
   Repeat1,
   Shuffle,
@@ -17,12 +18,15 @@ import { Button } from "../ui/index.js";
  * @param {number} maxHeight - Maximum height in pixels to match left column
  */
 const PlaylistSidebar = ({ maxHeight }) => {
-  const { playlist, currentIndex, gotoSceneIndex } = useScenePlayer();
+  const {
+    playlist,
+    currentIndex,
+    gotoSceneIndex,
+    toggleAutoplayNext,
+    toggleShuffle,
+    toggleRepeat,
+  } = useScenePlayer();
   const [isExpanded, setIsExpanded] = useState(true);
-
-  // Shuffle and repeat state
-  const [shuffle, setShuffle] = useState(playlist?.shuffle || false);
-  const [repeat, setRepeat] = useState(playlist?.repeat || "none");
 
   if (!playlist || !playlist.scenes || playlist.scenes.length === 0) {
     return null;
@@ -55,7 +59,7 @@ const PlaylistSidebar = ({ maxHeight }) => {
   const navigateToScene = (index) => {
     if (index < 0 || index >= totalScenes) return;
 
-    // Check if video is playing and set autoplay flag
+    // Check if video is currently playing
     const videoElements = document.querySelectorAll("video");
     let isPlaying = false;
 
@@ -65,9 +69,8 @@ const PlaylistSidebar = ({ maxHeight }) => {
       }
     });
 
+    // Preserve fullscreen state
     if (isPlaying) {
-      sessionStorage.setItem("videoPlayerAutoplay", "true");
-
       const isFullscreen =
         document.fullscreenElement ||
         document.webkitFullscreenElement ||
@@ -78,21 +81,12 @@ const PlaylistSidebar = ({ maxHeight }) => {
       }
     }
 
-    gotoSceneIndex(index);
+    // Navigate with autoplay flag if video is currently playing
+    gotoSceneIndex(index, isPlaying);
   };
 
   const goToPlaylist = () => {
     window.location.href = `/playlist/${playlist.id}`;
-  };
-
-  const toggleShuffle = () => {
-    setShuffle(!shuffle);
-  };
-
-  const toggleRepeat = () => {
-    const repeatModes = ["none", "all", "one"];
-    const currentIdx = repeatModes.indexOf(repeat);
-    setRepeat(repeatModes[(currentIdx + 1) % repeatModes.length]);
   };
 
   return (
@@ -156,45 +150,69 @@ const PlaylistSidebar = ({ maxHeight }) => {
         {/* Control buttons */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
+            {/* Autoplay Next */}
+            <button
+              onClick={toggleAutoplayNext}
+              className="p-1.5 rounded transition-colors focus:outline-none"
+              style={{
+                backgroundColor: playlist.autoplayNext
+                  ? "var(--accent-primary)"
+                  : "transparent",
+                color: playlist.autoplayNext
+                  ? "white"
+                  : "var(--text-secondary)",
+                border: "1px solid var(--border-color)",
+              }}
+              title={
+                playlist.autoplayNext ? "Autoplay: On" : "Autoplay: Off"
+              }
+            >
+              <PlayCircle size={14} />
+            </button>
+
             {/* Shuffle */}
-            <Button
+            <button
               onClick={toggleShuffle}
-              variant="secondary"
-              size="sm"
-              className="p-1.5"
-              {...(shuffle && {
-                style: {
-                  border: "2px solid var(--status-info)",
-                  color: "var(--status-info)",
-                },
-              })}
-              icon={<Shuffle size={14} />}
-              title={shuffle ? "Shuffle: On" : "Shuffle: Off"}
-            />
+              className="p-1.5 rounded transition-colors focus:outline-none"
+              style={{
+                backgroundColor: playlist.shuffle
+                  ? "var(--accent-primary)"
+                  : "transparent",
+                color: playlist.shuffle ? "white" : "var(--text-secondary)",
+                border: "1px solid var(--border-color)",
+              }}
+              title={playlist.shuffle ? "Shuffle: On" : "Shuffle: Off"}
+            >
+              <Shuffle size={14} />
+            </button>
 
             {/* Repeat */}
-            <Button
+            <button
               onClick={toggleRepeat}
-              variant="secondary"
-              size="sm"
-              className="p-1.5"
-              {...(repeat !== "none" && {
-                style: {
-                  border: "2px solid var(--status-info)",
-                  color: "var(--status-info)",
-                },
-              })}
-              icon={
-                repeat === "one" ? <Repeat1 size={14} /> : <Repeat size={14} />
-              }
+              className="p-1.5 rounded transition-colors focus:outline-none"
+              style={{
+                backgroundColor:
+                  playlist.repeat !== "none"
+                    ? "var(--accent-primary)"
+                    : "transparent",
+                color:
+                  playlist.repeat !== "none" ? "white" : "var(--text-secondary)",
+                border: "1px solid var(--border-color)",
+              }}
               title={
-                repeat === "one"
+                playlist.repeat === "one"
                   ? "Repeat: One"
-                  : repeat === "all"
+                  : playlist.repeat === "all"
                     ? "Repeat: All"
                     : "Repeat: Off"
               }
-            />
+            >
+              {playlist.repeat === "one" ? (
+                <Repeat1 size={14} />
+              ) : (
+                <Repeat size={14} />
+              )}
+            </button>
           </div>
 
           <div

--- a/client/src/contexts/ScenePlayerContext.jsx
+++ b/client/src/contexts/ScenePlayerContext.jsx
@@ -25,6 +25,7 @@ export function ScenePlayerProvider({
   shouldResume = false,
   compatibility = null,
   initialQuality = "direct",
+  initialShouldAutoplay = false,
 }) {
   const [state, dispatch] = useReducer(scenePlayerReducer, initialState);
 
@@ -37,9 +38,10 @@ export function ScenePlayerProvider({
         currentIndex: playlist?.currentIndex || 0,
         compatibility,
         initialQuality,
+        initialShouldAutoplay,
       },
     });
-  }, [playlist, compatibility, initialQuality]);
+  }, [playlist, compatibility, initialQuality, initialShouldAutoplay]);
 
   // ============================================================================
   // ACTION CREATORS (with side effects)
@@ -163,8 +165,24 @@ export function ScenePlayerProvider({
     dispatch({ type: "PREV_SCENE" });
   }, []);
 
-  const gotoSceneIndex = useCallback((index) => {
-    dispatch({ type: "GOTO_SCENE_INDEX", payload: index });
+  const gotoSceneIndex = useCallback((index, shouldAutoplay = false) => {
+    dispatch({
+      type: "GOTO_SCENE_INDEX",
+      payload: { index, shouldAutoplay },
+    });
+  }, []);
+
+  // Playlist control toggles
+  const toggleAutoplayNext = useCallback(() => {
+    dispatch({ type: "TOGGLE_AUTOPLAY_NEXT" });
+  }, []);
+
+  const toggleShuffle = useCallback(() => {
+    dispatch({ type: "TOGGLE_SHUFFLE" });
+  }, []);
+
+  const toggleRepeat = useCallback(() => {
+    dispatch({ type: "TOGGLE_REPEAT" });
   }, []);
 
   // ============================================================================
@@ -239,6 +257,11 @@ export function ScenePlayerProvider({
     nextScene,
     prevScene,
     gotoSceneIndex,
+
+    // Playlist control toggles
+    toggleAutoplayNext,
+    toggleShuffle,
+    toggleRepeat,
   };
 
   return (

--- a/client/src/contexts/scenePlayerReducer.js
+++ b/client/src/contexts/scenePlayerReducer.js
@@ -26,6 +26,12 @@ export const initialState = {
   playlist: null,
   currentIndex: 0,
 
+  // Playlist controls
+  autoplayNext: true, // Auto-advance to next scene when current ends
+  shuffle: false, // Play scenes in random order
+  repeat: "none", // "none" | "all" | "one"
+  shuffleHistory: [], // Track played scenes to avoid immediate repeats
+
   // Compatibility (codec support)
   compatibility: null,
 
@@ -119,56 +125,168 @@ export function scenePlayerReducer(state, action) {
       };
 
     // Playlist navigation
-    case "NEXT_SCENE":
+    case "NEXT_SCENE": {
+      if (!state.playlist || !state.playlist.scenes) {
+        return state;
+      }
+
+      let nextIndex = null;
+      const totalScenes = state.playlist.scenes.length;
+
+      if (state.shuffle) {
+        // Shuffle mode: pick random unplayed scene
+        const unplayedScenes = [];
+
+        for (let i = 0; i < totalScenes; i++) {
+          if (
+            i !== state.currentIndex &&
+            !state.shuffleHistory.includes(i)
+          ) {
+            unplayedScenes.push(i);
+          }
+        }
+
+        if (unplayedScenes.length > 0) {
+          // Pick random from unplayed
+          nextIndex =
+            unplayedScenes[Math.floor(Math.random() * unplayedScenes.length)];
+        } else if (state.repeat === "all") {
+          // All scenes played, reset shuffle history and start over
+          const candidates = Array.from({ length: totalScenes }, (_, i) =>
+            i
+          ).filter((i) => i !== state.currentIndex);
+          nextIndex = candidates[Math.floor(Math.random() * candidates.length)];
+
+          // Also return updated shuffle history
+          return {
+            ...state,
+            currentIndex: nextIndex,
+            shuffleHistory: [state.currentIndex], // Start new history
+            playlist: {
+              ...state.playlist,
+              shuffleHistory: [state.currentIndex],
+            },
+            video: null,
+            sessionId: null,
+            isInitializing: false,
+            ready: false,
+          };
+        }
+        // else: no more scenes and repeat is not "all", stay on current
+      } else {
+        // Sequential mode
+        if (state.currentIndex < totalScenes - 1) {
+          nextIndex = state.currentIndex + 1;
+        } else if (state.repeat === "all") {
+          nextIndex = 0; // Loop back to start
+        }
+        // else: last scene and repeat is not "all", stay on current
+      }
+
+      if (nextIndex === null) {
+        return state; // Can't advance
+      }
+
+      // Update shuffle history if in shuffle mode
+      const newHistory = state.shuffle
+        ? [...state.shuffleHistory, state.currentIndex]
+        : state.shuffleHistory;
+
+      return {
+        ...state,
+        currentIndex: nextIndex,
+        shuffleHistory: newHistory,
+        playlist: state.playlist
+          ? { ...state.playlist, shuffleHistory: newHistory }
+          : null,
+        video: null,
+        sessionId: null,
+        isInitializing: false,
+        ready: false,
+      };
+    }
+
+    case "PREV_SCENE": {
+      if (!state.playlist || !state.playlist.scenes) {
+        return state;
+      }
+
+      let prevIndex = null;
+      const totalScenes = state.playlist.scenes.length;
+
+      if (state.shuffle) {
+        // In shuffle mode, go back to last played scene (from history)
+        if (state.shuffleHistory.length > 0) {
+          prevIndex = state.shuffleHistory[state.shuffleHistory.length - 1];
+
+          // Remove last item from history
+          const newHistory = state.shuffleHistory.slice(0, -1);
+
+          return {
+            ...state,
+            currentIndex: prevIndex,
+            shuffleHistory: newHistory,
+            playlist: state.playlist
+              ? { ...state.playlist, shuffleHistory: newHistory }
+              : null,
+            video: null,
+            sessionId: null,
+            isInitializing: false,
+            ready: false,
+          };
+        } else if (state.repeat === "all") {
+          // No history, but repeat all is on - go to last scene
+          prevIndex = totalScenes - 1;
+        }
+        // else: no history and no repeat, stay on current
+      } else {
+        // Sequential mode
+        if (state.currentIndex > 0) {
+          prevIndex = state.currentIndex - 1;
+        } else if (state.repeat === "all") {
+          prevIndex = totalScenes - 1; // Loop to end
+        }
+        // else: first scene and repeat is not "all", stay on current
+      }
+
+      if (prevIndex === null) {
+        return state; // Can't go back
+      }
+
+      return {
+        ...state,
+        currentIndex: prevIndex,
+        video: null,
+        sessionId: null,
+        isInitializing: false,
+        ready: false,
+      };
+    }
+
+    case "GOTO_SCENE_INDEX": {
+      const index = action.payload?.index ?? action.payload;
+      const shouldAutoplay = action.payload?.shouldAutoplay ?? false;
+
       if (
         !state.playlist ||
-        state.currentIndex >= state.playlist.scenes.length - 1
+        index < 0 ||
+        index >= state.playlist.scenes.length
       ) {
         return state;
       }
 
       return {
         ...state,
-        currentIndex: state.currentIndex + 1,
+        currentIndex: index,
         // Clear video data - will be fetched for new scene
         video: null,
         sessionId: null,
         isInitializing: false,
         ready: false, // Reset ready state for new scene
+        // Set shouldAutoplay based on payload
+        shouldAutoplay: shouldAutoplay,
       };
-
-    case "PREV_SCENE":
-      if (!state.playlist || state.currentIndex <= 0) {
-        return state;
-      }
-
-      return {
-        ...state,
-        currentIndex: state.currentIndex - 1,
-        // Clear video data - will be fetched for new scene
-        video: null,
-        sessionId: null,
-        isInitializing: false,
-        ready: false, // Reset ready state for new scene
-      };
-
-    case "GOTO_SCENE_INDEX":
-      if (
-        !state.playlist ||
-        action.payload < 0 ||
-        action.payload >= state.playlist.scenes.length
-      ) {
-        return state;
-      }
-      return {
-        ...state,
-        currentIndex: action.payload,
-        // Clear video data - will be fetched for new scene
-        video: null,
-        sessionId: null,
-        isInitializing: false,
-        ready: false, // Reset ready state for new scene
-      };
+    }
 
     // Player state
     case "SET_INITIALIZING":
@@ -227,15 +345,81 @@ export function scenePlayerReducer(state, action) {
         oCounter: action.payload,
       };
 
-    // Initialize from props
-    case "INITIALIZE":
+    // Playlist controls
+    case "TOGGLE_AUTOPLAY_NEXT":
       return {
         ...state,
-        playlist: action.payload.playlist || null,
+        autoplayNext: !state.autoplayNext,
+        // Update playlist object as well
+        playlist: state.playlist
+          ? { ...state.playlist, autoplayNext: !state.autoplayNext }
+          : null,
+      };
+
+    case "TOGGLE_SHUFFLE":
+      const newShuffle = !state.shuffle;
+      return {
+        ...state,
+        shuffle: newShuffle,
+        // Reset shuffle history when toggling
+        shuffleHistory: newShuffle ? [] : state.shuffleHistory,
+        // Update playlist object as well
+        playlist: state.playlist
+          ? {
+              ...state.playlist,
+              shuffle: newShuffle,
+              shuffleHistory: newShuffle ? [] : state.shuffleHistory,
+            }
+          : null,
+      };
+
+    case "TOGGLE_REPEAT":
+      // Cycle through: none → all → one → none
+      const repeatModes = ["none", "all", "one"];
+      const currentIdx = repeatModes.indexOf(state.repeat);
+      const nextRepeat = repeatModes[(currentIdx + 1) % repeatModes.length];
+      return {
+        ...state,
+        repeat: nextRepeat,
+        // Update playlist object as well
+        playlist: state.playlist
+          ? { ...state.playlist, repeat: nextRepeat }
+          : null,
+      };
+
+    case "SET_SHUFFLE_HISTORY":
+      return {
+        ...state,
+        shuffleHistory: action.payload,
+        // Update playlist object as well
+        playlist: state.playlist
+          ? { ...state.playlist, shuffleHistory: action.payload }
+          : null,
+      };
+
+    // Initialize from props
+    case "INITIALIZE": {
+      const playlist = action.payload.playlist;
+
+      // Get shouldAutoplay from props (passed via location.state)
+      // Preserve existing value if already set (for re-initialization)
+      const shouldAutoplay = action.payload.initialShouldAutoplay || state.shouldAutoplay || false;
+
+      return {
+        ...state,
+        playlist: playlist || null,
         currentIndex: action.payload.currentIndex || 0,
         compatibility: action.payload.compatibility || null,
         quality: action.payload.initialQuality || "direct",
+        // Initialize playlist controls from playlist object
+        autoplayNext: playlist?.autoplayNext ?? true,
+        shuffle: playlist?.shuffle ?? false,
+        repeat: playlist?.repeat ?? "none",
+        shuffleHistory: playlist?.shuffleHistory ?? [],
+        // Use the determined shouldAutoplay value
+        shouldAutoplay: shouldAutoplay,
       };
+    }
 
     default:
       return state;


### PR DESCRIPTION
Add comprehensive playlist control functionality including:
- Volume and mute state persistence across scenes using localStorage
- Shuffle mode with history tracking to avoid immediate repeats
- Repeat modes (none/all/one) with proper behavior in all contexts
- Autoplay Next toggle to control auto-advance behavior
- Centralized playlist state management in reducer

Fixes:
- Autoplay when entering from playlist Play button now works correctly
- Navigation autoplay preserves playing state when switching scenes
- Shuffle starts with random scene when entering via Play button
- All playlist controls (Next/Previous/thumbnails) respect shuffle/repeat settings
- Ended event properly advances to next scene with autoplay enabled

Implementation details:
- Moved autoplay flag from sessionStorage to React Router location.state to avoid timing issues with React StrictMode
- Unified navigation logic in reducer to ensure consistent behavior
- Added shouldAutoplay parameter to GOTO_SCENE_INDEX for atomic state updates
- Implemented smart shuffle algorithm that tracks history and resets when all scenes played

🤖 Generated with [Claude Code](https://claude.com/claude-code)