### PR TITLE
refactor: Remove High Bitrate, Barely Legal, and Feature Length carou…

### DIFF
--- a/client/src/constants/carousels.js
+++ b/client/src/constants/carousels.js
@@ -1,19 +1,19 @@
 import {
-  Calendar,
   Clock,
-  Film,
   Heart,
   PlayCircle,
   Star,
   Tag,
   Video,
-  Zap,
 } from "lucide-react";
 
 /**
  * Shared carousel definitions for homepage and settings
  * Order: Continue Watching, Recently Added, High Rated, Favorite Performers,
- *        Favorite Tags, Favorite Studios, Barely Legal, Feature Length, High Bitrate
+ *        Favorite Tags, Favorite Studios
+ *
+ * Note: Some carousels (High Bitrate, Barely Legal, Feature Length) have been removed.
+ * In the future, users will be able to create custom carousels using a filter builder.
  */
 export const CAROUSEL_DEFINITIONS = [
   {
@@ -62,33 +62,6 @@ export const CAROUSEL_DEFINITIONS = [
     iconProps: { className: "w-6 h-6", style: { color: "var(--status-info)" } },
     fetchKey: "favoriteStudioScenes",
   },
-  {
-    title: "Barely Legal",
-    iconComponent: Calendar,
-    iconProps: {
-      className: "w-6 h-6",
-      style: { color: "var(--status-warning)" },
-    },
-    fetchKey: "barelyLegalScenes",
-  },
-  {
-    title: "Feature Length",
-    iconComponent: Film,
-    iconProps: {
-      className: "w-6 h-6",
-      style: { color: "var(--accent-secondary)" },
-    },
-    fetchKey: "longScenes",
-  },
-  {
-    title: "High Bitrate",
-    iconComponent: Zap,
-    iconProps: {
-      className: "w-6 h-6",
-      style: { color: "var(--status-success)" },
-    },
-    fetchKey: "highBitrateScenes",
-  },
 ];
 
 /**
@@ -107,6 +80,10 @@ export const migrateCarouselPreferences = (savedPreferences) => {
       order: idx,
     }));
   }
+
+  // Filter out removed carousels (barelyLegalScenes, longScenes, highBitrateScenes)
+  const validIds = new Set(CAROUSEL_DEFINITIONS.map((def) => def.fetchKey));
+  prefs = prefs.filter((pref) => validIds.has(pref.id));
 
   // Migrate: Add any new carousels that don't exist in saved preferences
   const existingIds = new Set(prefs.map((p) => p.id));

--- a/client/src/hooks/useHomeCarouselQueries.js
+++ b/client/src/hooks/useHomeCarouselQueries.js
@@ -2,13 +2,6 @@ import { commonFilters, libraryApi } from "../services/api";
 
 export const useHomeCarouselQueries = (perCarousel = 12) => {
   return {
-    barelyLegalScenes: async () => {
-      const response = await libraryApi.findScenes(
-        commonFilters.barelyLegalScenes(1, perCarousel)
-      );
-      // Extract scenes from server response structure
-      return response?.findScenes?.scenes || [];
-    },
     favoritePerformerScenes: async () => {
       const response = await libraryApi.findScenes(
         commonFilters.favoritePerformerScenes(1, perCarousel)
@@ -78,26 +71,11 @@ export const useHomeCarouselQueries = (perCarousel = 12) => {
 
       return scenesResponse?.findScenes?.scenes || [];
     },
-    highBitrateScenes: async () => {
-      const response = await libraryApi.findScenes(
-        commonFilters.highBitrateScenes(1, perCarousel)
-      );
-
-      // Extract scenes from server response structure
-      return response?.findScenes?.scenes || [];
-    },
     highRatedScenes: async () => {
       const response = await libraryApi.findScenes(
         commonFilters.highRatedScenes(1, perCarousel)
       );
 
-      // Extract scenes from server response structure
-      return response?.findScenes?.scenes || [];
-    },
-    longScenes: async () => {
-      const response = await libraryApi.findScenes(
-        commonFilters.longScenes(1, perCarousel)
-      );
       // Extract scenes from server response structure
       return response?.findScenes?.scenes || [];
     },

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -384,37 +384,11 @@ export const commonFilters = {
     scene_filter: {},
   }),
 
-  /** Get highest bitrate scenes
-   */
-  highBitrateScenes: (page = 1, perPage = 24) => ({
-    filter: filterHelpers.pagination(page, perPage, "random", "ASC"),
-    scene_filter: {
-      bitrate: { modifier: "GREATER_THAN", value: 14000000 },
-    },
-  }),
-
-  /** Get barely legal scenes
-   */
-  barelyLegalScenes: (page = 1, perPage = 24) => ({
-    filter: filterHelpers.pagination(page, perPage, "random", "ASC"),
-    scene_filter: { performer_age: { modifier: "EQUALS", value: 18 } },
-  }),
-
-  /** Get barely legal scenes
+  /** Get favorite performer scenes
    */
   favoritePerformerScenes: (page = 1, perPage = 24) => ({
     filter: filterHelpers.pagination(page, perPage, "random", "ASC"),
     scene_filter: { performer_favorite: true },
-  }),
-
-  /**
-   * Get long scenes (over 30 minutes)
-   */
-  longScenes: (page = 1, perPage = 24) => ({
-    filter: filterHelpers.pagination(page, perPage, "random", "ASC"),
-    scene_filter: {
-      duration: { modifier: "GREATER_THAN", value: 4800 },
-    },
   }),
 
   /**

--- a/server/utils/carouselDefaults.ts
+++ b/server/utils/carouselDefaults.ts
@@ -12,12 +12,9 @@ export interface CarouselPreference {
 export const DEFAULT_CAROUSELS = [
   { id: "highRatedScenes", enabled: true, order: 0 },
   { id: "recentlyAddedScenes", enabled: true, order: 1 },
-  { id: "longScenes", enabled: true, order: 2 },
-  { id: "highBitrateScenes", enabled: true, order: 3 },
-  { id: "barelyLegalScenes", enabled: true, order: 4 },
-  { id: "favoritePerformerScenes", enabled: true, order: 5 },
-  { id: "favoriteStudioScenes", enabled: true, order: 6 },
-  { id: "favoriteTagScenes", enabled: true, order: 7 },
+  { id: "favoritePerformerScenes", enabled: true, order: 2 },
+  { id: "favoriteStudioScenes", enabled: true, order: 3 },
+  { id: "favoriteTagScenes", enabled: true, order: 4 },
 ];
 
 /**


### PR DESCRIPTION
…sels

Removed three problematic carousels that will eventually be replaced by a custom carousel builder using Scene Search filters.

Changes:
- Removed carousel definitions from CAROUSEL_DEFINITIONS array
- Updated migrateCarouselPreferences to filter out removed carousel IDs
- Removed query functions from useHomeCarouselQueries hook
- Removed commonFilters definitions (highBitrateScenes, barelyLegalScenes, longScenes)
- Updated DEFAULT_CAROUSELS on server to exclude removed carousels
- Removed unused icon imports (Calendar, Film, Zap)

User Impact:
- Users with these carousels enabled will have them automatically filtered out
- No database migration required - migration function handles gracefully
- Remaining carousels: Continue Watching, Recently Added, High Rated, Favorite Performers, Favorite Tags, Favorite Studios

🤖 Generated with [Claude Code](https://claude.com/claude-code)