### PR TITLE
feat: Add per entity-type Scene grid filter defaults

### DIFF
--- a/client/src/components/pages/GroupDetail.jsx
+++ b/client/src/components/pages/GroupDetail.jsx
@@ -156,6 +156,7 @@ const GroupDetail = () => {
         {/* Scenes Section */}
         <div className="mt-8">
           <SceneSearch
+            context="scene_group"
             initialSort="scene_index"
             permanentFilters={{
               groups: { value: [parseInt(groupId, 10)], modifier: "INCLUDES" },

--- a/client/src/components/pages/PerformerDetail.jsx
+++ b/client/src/components/pages/PerformerDetail.jsx
@@ -217,6 +217,7 @@ const PerformerDetail = () => {
         {/* Scenes Section */}
         <div className="mt-8">
           <SceneSearch
+            context="scene_performer"
             permanentFilters={{
               performers: {
                 value: [parseInt(performerId, 10)],

--- a/client/src/components/pages/Scenes.jsx
+++ b/client/src/components/pages/Scenes.jsx
@@ -13,6 +13,7 @@ const Scenes = () => {
   return (
     <div ref={pageRef}>
       <SceneSearch
+        context="scene"
         initialSort="created_at"
         subtitle="Browse your complete scene library"
         title="All Scenes"

--- a/client/src/components/pages/StudioDetail.jsx
+++ b/client/src/components/pages/StudioDetail.jsx
@@ -153,6 +153,7 @@ const StudioDetail = () => {
         {/* Scenes Section */}
         <div className="mt-8">
           <SceneSearch
+            context="scene_studio"
             permanentFilters={{
               studios: {
                 value: [parseInt(studioId, 10)],

--- a/client/src/components/pages/TagDetail.jsx
+++ b/client/src/components/pages/TagDetail.jsx
@@ -188,6 +188,7 @@ const TagDetail = () => {
         {/* Scenes Section */}
         <div className="mt-8">
           <SceneSearch
+            context="scene_tag"
             permanentFilters={{
               tags: { value: [parseInt(tagId, 10)], modifier: "INCLUDES" },
             }}

--- a/client/src/components/scene-search/SceneSearch.jsx
+++ b/client/src/components/scene-search/SceneSearch.jsx
@@ -21,6 +21,7 @@ import SceneGrid from "./SceneGrid.jsx";
  * a Performer, Studio, or Tag page for instance), and default sorting options.
  */
 const SceneSearch = ({
+  context, // Optional context for filter preset defaults (scene_performer, scene_tag, etc.)
   initialSort = "o_counter",
   permanentFilters = {},
   permanentFiltersMetadata = {},
@@ -134,6 +135,7 @@ const SceneSearch = ({
 
       <SearchControls
         artifactType="scene"
+        context={context}
         initialSort={initialSort}
         onQueryChange={handleQueryChange}
         permanentFilters={permanentFilters}

--- a/client/src/components/ui/SearchControls.jsx
+++ b/client/src/components/ui/SearchControls.jsx
@@ -65,6 +65,7 @@ const getSortOptions = (artifactType) => {
 
 const SearchControls = ({
   artifactType = "scene",
+  context, // Optional context override (e.g., "scene_performer", "scene_tag")
   children,
   initialSort = "o_counter",
   onQueryChange,
@@ -74,6 +75,8 @@ const SearchControls = ({
   totalCount,
   syncToUrl = true,
 }) => {
+  // Use context if provided, otherwise fall back to artifactType
+  const effectiveContext = context || artifactType;
   const [searchParams, setSearchParams] = useSearchParams();
   const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -164,10 +167,14 @@ const SearchControls = ({
 
           const allPresets = presetsResponse?.presets || {};
           const defaults = defaultsResponse?.defaults || {};
-          const defaultPresetId = defaults[artifactType];
+          const defaultPresetId = defaults[effectiveContext];
 
-          // Find the default preset for this artifact type
-          const presets = allPresets[artifactType] || [];
+          // Find the default preset for this context
+          // Scene grid contexts (scene_performer, etc.) use "scene" presets
+          const presetArtifactType = effectiveContext.startsWith("scene_")
+            ? "scene"
+            : effectiveContext;
+          const presets = allPresets[presetArtifactType] || [];
           const defaultPreset = presets.find((p) => p.id === defaultPresetId);
 
           if (defaultPreset) {
@@ -610,9 +617,11 @@ const SearchControls = ({
           {/* Filter Presets */}
           <FilterPresets
             artifactType={artifactType}
+            context={effectiveContext}
             currentFilters={filters}
             currentSort={sortField}
             currentDirection={sortDirection}
+            permanentFilters={permanentFilters}
             onLoadPreset={handleLoadPreset}
           />
         </div>


### PR DESCRIPTION
Users can now set independent default filter presets for different Scene grid contexts:
- Main Scenes page (context: "scene")
- Performer detail pages (context: "scene_performer")
- Tag detail pages (context: "scene_tag")
- Studio detail pages (context: "scene_studio")
- Group detail pages (context: "scene_group")

Key features:
- Saved presets remain shared across all contexts
- Each context can have its own default preset
- Permanent filters (e.g., performer ID) are excluded from saved presets
- Permanent filters are automatically merged when loading presets
- UI clearly indicates which context the default applies to

Backend changes:
- Updated setDefaultFilterPreset to accept 'context' parameter
- Updated saveFilterPreset to use context when setting defaults
- Added validation for new scene grid contexts

Frontend changes:
- Added context prop to SceneSearch, SearchControls, and FilterPresets
- FilterPresets strips permanent filters before saving
- FilterPresets merges permanent filters when loading
- Updated all detail pages to pass appropriate context

🤖 Generated with [Claude Code](https://claude.com/claude-code)