### PR TITLE
bugfix: Add Sidebar User Menu with Keyboard Navigation

### DIFF
--- a/client/src/components/ui/SceneCard.jsx
+++ b/client/src/components/ui/SceneCard.jsx
@@ -220,6 +220,12 @@ const SceneCard = forwardRef(
     }, []);
 
     const handleKeyDown = (e) => {
+      // Only handle keyboard events if this card is actually the focused element
+      // This prevents handling events when focus is on other elements (like sidebar)
+      if (e.currentTarget !== document.activeElement && !e.currentTarget.contains(document.activeElement)) {
+        return;
+      }
+
       const target = e.target;
       const isInputField =
         target.tagName === "INPUT" ||

--- a/client/src/components/ui/Sidebar.jsx
+++ b/client/src/components/ui/Sidebar.jsx
@@ -103,7 +103,9 @@ const Sidebar = ({ navPreferences = [] }) => {
 
   // Keyboard navigation when mainNav is active
   useEffect(() => {
-    if (!isTVMode || !isMainNavActive) return;
+    if (!isTVMode || !isMainNavActive) {
+      return;
+    }
 
     const handleKeyDown = (e) => {
       switch (e.key) {
@@ -116,7 +118,6 @@ const Sidebar = ({ navPreferences = [] }) => {
           }
           if (newIndex >= 0) {
             setFocusedIndex(newIndex);
-            console.log(`🔼 Sidebar: Focused item ${newIndex} (${allNavItems[newIndex]?.name})`);
           }
           break;
         }
@@ -130,7 +131,6 @@ const Sidebar = ({ navPreferences = [] }) => {
           }
           if (newIndex < allNavItems.length) {
             setFocusedIndex(newIndex);
-            console.log(`🔽 Sidebar: Focused item ${newIndex} (${allNavItems[newIndex]?.name})`);
           }
           break;
         }
@@ -143,19 +143,14 @@ const Sidebar = ({ navPreferences = [] }) => {
           if (item) {
             if (item.name === "Help") {
               setIsHelpModalOpen(true);
-              console.log("✅ Sidebar: Opened Help modal");
             } else if (item.isUserMenu) {
               setIsUserMenuExpanded(!isUserMenuExpanded);
-              console.log(`✅ Sidebar: ${isUserMenuExpanded ? 'Collapsed' : 'Expanded'} user menu`);
             } else if (item.name === "TV Mode") {
               toggleTVMode();
-              console.log("✅ Sidebar: Toggled TV Mode");
             } else if (item.name === "Sign Out") {
               logout();
-              console.log("✅ Sidebar: Logged out");
             } else if (item.path) {
               navigate(item.path);
-              console.log(`✅ Sidebar: Navigated to ${item.path}`);
             }
           }
           break;

--- a/client/src/hooks/useGridPageTVNavigation.js
+++ b/client/src/hooks/useGridPageTVNavigation.js
@@ -42,28 +42,25 @@ export const useGridPageTVNavigation = ({
     enabled: isTVMode && tvNavigation.isZoneActive("grid"),
     onSelect: onItemSelect,
     onEscapeUp: useCallback(() => {
-      const moved = tvNavigation.goToPreviousZone();
-      console.log(
-        moved
-          ? `🔼 Moved to previous zone: ${tvNavigation.currentZone}`
-          : "🔼 Already at first zone"
-      );
+      // Blur the currently focused element before switching zones
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
+      tvNavigation.goToPreviousZone();
     }, [tvNavigation]),
     onEscapeDown: useCallback(() => {
-      const moved = tvNavigation.goToNextZone();
-      console.log(
-        moved
-          ? `🔽 Moved to next zone: ${tvNavigation.currentZone}`
-          : "🔽 Already at last zone"
-      );
+      // Blur the currently focused element before switching zones
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
+      tvNavigation.goToNextZone();
     }, [tvNavigation]),
     onEscapeLeft: useCallback(() => {
-      const moved = tvNavigation.goToZone("mainNav");
-      console.log(
-        moved
-          ? `⬅️ Moved to sidebar: ${tvNavigation.currentZone}`
-          : "⬅️ Could not move to mainNav"
-      );
+      // Blur the currently focused element before switching zones
+      if (document.activeElement) {
+        document.activeElement.blur();
+      }
+      tvNavigation.goToZone("mainNav");
     }, [tvNavigation]),
   });
 


### PR DESCRIPTION
## Add Sidebar User Menu with Keyboard Navigation

### Summary
Added a collapsible user menu to the Sidebar matching the TopBar's UserMenu functionality, with full keyboard navigation support for TV mode. Fixed a critical bug where keyboard events from the grid interfered with sidebar navigation.

### Changes

**Sidebar User Menu:**
- Added expandable/collapsible user menu showing username (xl+ screens) or user icon (lg-xl screens)
- User menu contains 4 nested items: Watch History, My Settings, TV Mode toggle, Sign Out
- Nested items are fully keyboard navigable with arrow keys when menu is expanded
- TV Mode toggle shows checkmark when active
- Sign Out button has red styling for visual distinction

**Keyboard Navigation Fix:**
- Fixed bug where pressing Space/Enter on Sidebar user menu would open the previously focused Scene
- Root cause: SceneCard maintained DOM focus even after navigating to sidebar
- Solution: Blur focused grid items when escaping from grid zone (ArrowLeft, ArrowUp, ArrowDown)
- Ensures DOM focus and visual navigation state stay synchronized

**Code Quality:**
- Cleaned up all debug logging from navigation hooks
- Added comments explaining focus management strategy

### Files Modified
- `client/src/components/ui/Sidebar.jsx` - Added collapsible user menu with keyboard navigation
- `client/src/components/ui/SceneCard.jsx` - Added focus check to prevent event handling when not focused
- `client/src/hooks/useGridPageTVNavigation.js` - Added blur before zone transitions
- `client/src/hooks/useSpatialNavigation.js` - Removed debug logging
- `client/src/hooks/useHorizontalNavigation.js` - Removed debug logging

### Testing
- ✅ User menu expands/collapses with Space/Enter on Sidebar
- ✅ Arrow keys navigate through nested menu items when expanded
- ✅ No interference from SceneCard keyboard events
- ✅ Works correctly on all grid pages (Scenes, Performers, Studios, etc.)
- ✅ TV Mode toggle and Sign Out function correctly
- ✅ Navigation from grid to sidebar works smoothly