### PR TITLE
fix: sync DOM focus with visual navigation state in TV mode

### DIFF
--- a/client/src/hooks/useHorizontalNavigation.js
+++ b/client/src/hooks/useHorizontalNavigation.js
@@ -36,14 +36,17 @@ export const useHorizontalNavigation = ({
     }
   }, [items.length, focusedIndex]);
 
-  // Scroll focused item into view
+  // Scroll focused item into view and update DOM focus
   useEffect(() => {
     if (enabled && itemRefs.current[focusedIndex]) {
-      itemRefs.current[focusedIndex]?.scrollIntoView({
+      const element = itemRefs.current[focusedIndex];
+      element?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "nearest",
       });
+      // Update DOM focus to match visual navigation state
+      element?.focus();
     }
   }, [focusedIndex, enabled]);
 

--- a/client/src/hooks/useSpatialNavigation.js
+++ b/client/src/hooks/useSpatialNavigation.js
@@ -44,14 +44,17 @@ export const useSpatialNavigation = ({
     }
   }, [items.length, focusedIndex]);
 
-  // Scroll focused item into view
+  // Scroll focused item into view and update DOM focus
   useEffect(() => {
     if (enabled && itemRefs.current[focusedIndex]) {
-      itemRefs.current[focusedIndex]?.scrollIntoView({
+      const element = itemRefs.current[focusedIndex];
+      element?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "nearest",
       });
+      // Update DOM focus to match visual navigation state
+      element?.focus();
     }
   }, [focusedIndex, enabled]);
 


### PR DESCRIPTION
Fixed issue where pressing Enter on any grid card would open the first scene instead of the visually focused card. Root cause was DOM focus remaining on the first card while visual navigation state (focusedIndex) updated correctly.

Changes:
- useSpatialNavigation: Added element.focus() when focusedIndex changes
- useHorizontalNavigation: Added element.focus() when focusedIndex changes

Now DOM focus and visual navigation state stay synchronized:
- Arrow key navigation updates both focusedIndex AND document.activeElement
- SceneCard's focus check (e.currentTarget === document.activeElement) works correctly
- Pressing Enter triggers the action on the visually focused card, not the first card

🤖 Generated with [Claude Code](https://claude.com/claude-code)