### PR TITLE
feat: add comprehensive entity navigation via clickable card indicators

### DIFF
--- a/client/src/components/pages/Studios.jsx
+++ b/client/src/components/pages/Studios.jsx
@@ -164,6 +164,8 @@ const Studios = () => {
 
 const StudioCard = forwardRef(
   ({ studio, tabIndex, isTVMode = false, referrerUrl, ...others }, ref) => {
+    const navigate = useNavigate();
+
     return (
       <GridCard
         description={studio.description}
@@ -171,10 +173,31 @@ const StudioCard = forwardRef(
         imagePath={studio.image_path}
         indicators={[
           { type: "PLAY_COUNT", count: studio.play_count },
-          { type: "SCENES", count: studio.scene_count },
-          { type: "IMAGES", count: studio.image_count },
-          { type: "GALLERIES", count: studio.gallery_count },
-          { type: "PERFORMERS", count: studio.performer_count },
+          {
+            type: "SCENES",
+            count: studio.scene_count,
+            onClick: studio.scene_count > 0 ? () => navigate(`/scenes?studioId=${studio.id}`) : undefined,
+          },
+          {
+            type: "IMAGES",
+            count: studio.image_count,
+            onClick: studio.image_count > 0 ? () => navigate(`/images?studioId=${studio.id}`) : undefined,
+          },
+          {
+            type: "GALLERIES",
+            count: studio.gallery_count,
+            onClick: studio.gallery_count > 0 ? () => navigate(`/galleries?studioId=${studio.id}`) : undefined,
+          },
+          {
+            type: "PERFORMERS",
+            count: studio.performer_count,
+            onClick: studio.performer_count > 0 ? () => navigate(`/performers?studioId=${studio.id}`) : undefined,
+          },
+          {
+            type: "TAGS",
+            count: studio.tags?.length || 0,
+            onClick: studio.tags?.length > 0 ? () => navigate(`/tags?studioId=${studio.id}`) : undefined,
+          },
         ]}
         linkTo={`/studio/${studio.id}`}
         ratingControlsProps={{

--- a/client/src/components/ui/CardCountIndicators.jsx
+++ b/client/src/components/ui/CardCountIndicators.jsx
@@ -55,6 +55,10 @@ const CARD_COUNT_INDICATOR_TYPES = {
     icon: LucideList,
     iconColor: hueify("var(--status-warning)", "darker"),
   },
+  STUDIOS: {
+    icon: LucideClapperboard,
+    iconColor: hueify("var(--accent-secondary)", "lighter", 8),
+  },
 };
 
 export const CardCountIndicators = ({
@@ -85,6 +89,7 @@ export const CardCountIndicators = ({
             iconSize={size}
             textSize={textSize}
             tooltipContent={indicator.tooltipContent}
+            onClick={indicator.onClick}
           />
         );
       })}
@@ -99,11 +104,21 @@ const CardCountIndicator = ({
   iconSize = 20,
   textSize = "sm",
   tooltipContent = null,
+  onClick = null,
 }) => {
   const Icon = icon;
 
   const guts = (
-    <div className="flex items-center gap-1">
+    <div
+      className={`flex items-center gap-1 ${onClick ? 'cursor-pointer hover:opacity-70 transition-opacity' : ''}`}
+      onClick={(e) => {
+        if (onClick) {
+          e.stopPropagation(); // Prevent card click
+          e.preventDefault(); // Prevent link navigation
+          onClick(e);
+        }
+      }}
+    >
       <span
         className="flex items-center justify-center"
         style={{ color: iconColor }}

--- a/client/src/components/ui/EntityGrid.jsx
+++ b/client/src/components/ui/EntityGrid.jsx
@@ -1,13 +1,13 @@
 import { forwardRef, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { STANDARD_GRID_CONTAINER_CLASSNAMES } from "../../constants/grids.js";
-import { galleryTitle } from "../../utils/gallery.js";
 import { libraryApi } from "../../services/api.js";
+import { galleryTitle } from "../../utils/gallery.js";
 import EmptyState from "./EmptyState.jsx";
-import LoadingSpinner from "./LoadingSpinner.jsx";
 import { GridCard } from "./GridCard.jsx";
-import PerformerCard from "./PerformerCard.jsx";
+import LoadingSpinner from "./LoadingSpinner.jsx";
 import Pagination from "./Pagination.jsx";
+import PerformerCard from "./PerformerCard.jsx";
 
 /**
  * EntityGrid - Generic grid component for displaying entities (galleries, images, groups, etc.)
@@ -24,7 +24,7 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
   const [totalCount, setTotalCount] = useState(0);
 
   // Pagination from URL
-  const currentPage = parseInt(searchParams.get('page')) || 1;
+  const currentPage = parseInt(searchParams.get("page")) || 1;
   const perPage = 24;
 
   useEffect(() => {
@@ -41,32 +41,32 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
         };
 
         switch (entityType) {
-          case 'gallery':
+          case "gallery":
             result = await libraryApi.findGalleries(queryParams);
             setData(result.findGalleries?.galleries || []);
             setTotalCount(result.findGalleries?.count || 0);
             break;
-          case 'group':
+          case "group":
             result = await libraryApi.findGroups(queryParams);
             setData(result.findGroups?.groups || []);
             setTotalCount(result.findGroups?.count || 0);
             break;
-          case 'performer':
+          case "performer":
             result = await libraryApi.findPerformers(queryParams);
             setData(result.findPerformers?.performers || []);
             setTotalCount(result.findPerformers?.count || 0);
             break;
-          case 'studio':
+          case "studio":
             result = await libraryApi.findStudios(queryParams);
             setData(result.findStudios?.studios || []);
             setTotalCount(result.findStudios?.count || 0);
             break;
-          case 'tag':
+          case "tag":
             result = await libraryApi.findTags(queryParams);
             setData(result.findTags?.tags || []);
             setTotalCount(result.findTags?.count || 0);
             break;
-          case 'image':
+          case "image":
             result = await libraryApi.findImages(queryParams);
             setData(result.findImages?.images || []);
             setTotalCount(result.findImages?.count || 0);
@@ -87,12 +87,12 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
   const handlePageChange = (newPage) => {
     const newParams = new URLSearchParams(searchParams);
     if (newPage === 1) {
-      newParams.delete('page');
+      newParams.delete("page");
     } else {
-      newParams.set('page', newPage.toString());
+      newParams.set("page", newPage.toString());
     }
     setSearchParams(newParams);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   if (isLoading) {
@@ -104,11 +104,7 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
   }
 
   if (!data || data.length === 0) {
-    return (
-      <EmptyState
-        title={emptyMessage || `No ${entityType}s found`}
-      />
-    );
+    return <EmptyState title={emptyMessage || `No ${entityType}s found`} />;
   }
 
   const totalPages = Math.ceil(totalCount / perPage);
@@ -117,17 +113,15 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
     <>
       <div className={STANDARD_GRID_CONTAINER_CLASSNAMES}>
         {data.map((item) => {
-          if (entityType === 'performer') {
+          if (entityType === "performer") {
             return (
-              <PerformerCard
-                key={item.id}
-                performer={item}
-                tabIndex={-1}
-              />
+              <PerformerCard key={item.id} performer={item} tabIndex={-1} />
             );
           }
 
-          return <EntityCard key={item.id} entity={item} entityType={entityType} />;
+          return (
+            <EntityCard key={item.id} entity={item} entityType={entityType} />
+          );
         })}
       </div>
 
@@ -146,10 +140,11 @@ const EntityGrid = ({ entityType, filters, emptyMessage }) => {
 
 // Card component for non-performer entities
 const EntityCard = forwardRef(({ entity, entityType, ...others }, ref) => {
+  const navigate = useNavigate();
   let imagePath, title, subtitle, indicators, linkTo, description;
 
   switch (entityType) {
-    case 'gallery':
+    case "gallery":
       imagePath = entity.paths?.cover || null;
       title = galleryTitle(entity);
       description = entity.description;
@@ -179,7 +174,7 @@ const EntityCard = forwardRef(({ entity, entityType, ...others }, ref) => {
       linkTo = `/gallery/${entity.id}`;
       break;
 
-    case 'group':
+    case "group":
       imagePath = entity.front_image_path || entity.back_image_path;
       title = entity.name;
       description = entity.description;
@@ -194,33 +189,117 @@ const EntityCard = forwardRef(({ entity, entityType, ...others }, ref) => {
         return null;
       })();
       indicators = [
-        { type: "SCENES", count: entity.scene_count },
-        { type: "GROUPS", count: entity.sub_group_count },
+        {
+          type: "SCENES",
+          count: entity.scene_count,
+          onClick:
+            entity.scene_count > 0
+              ? () => navigate(`/scenes?groupIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "GROUPS",
+          count: entity.sub_group_count,
+          onClick:
+            entity.sub_group_count > 0
+              ? () => navigate(`/collections?groupIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "PERFORMERS",
+          count: entity.performer_count,
+          onClick:
+            entity.performer_count > 0
+              ? () => navigate(`/performers?groupIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "TAGS",
+          count: entity.tag_count,
+          onClick:
+            entity.tag_count > 0
+              ? () => navigate(`/tags?groupIds=${entity.id}`)
+              : undefined,
+        },
       ];
       linkTo = `/collection/${entity.id}`;
       break;
 
-    case 'studio':
+    case "studio":
+      console.log('[EntityGrid] Studio entity:', {
+        id: entity.id,
+        name: entity.name,
+        tags: entity.tags,
+        tagsLength: entity.tags?.length,
+        tag_count: entity.tag_count,
+      });
       imagePath = entity.image_path;
       title = entity.name;
       description = entity.details;
       indicators = [
-        { type: "SCENES", count: entity.scene_count },
+        {
+          type: "SCENES",
+          count: entity.scene_count,
+          onClick:
+            entity.scene_count > 0
+              ? () => navigate(`/scenes?studioId=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "TAGS",
+          count: entity.tags?.length || 0,
+          onClick:
+            entity.tags?.length > 0
+              ? () => navigate(`/tags?studioId=${entity.id}`)
+              : undefined,
+        },
       ];
+      console.log('[EntityGrid] Studio indicators:', indicators);
       linkTo = `/studio/${entity.id}`;
       break;
 
-    case 'tag':
+    case "tag":
       imagePath = entity.image_path;
       title = entity.name;
       description = entity.description;
       indicators = [
-        { type: "SCENES", count: entity.scene_count },
+        {
+          type: "SCENES",
+          count: entity.scene_count,
+          onClick:
+            entity.scene_count > 0
+              ? () => navigate(`/scenes?tagIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "STUDIOS",
+          count: entity.studio_count,
+          onClick:
+            entity.studio_count > 0
+              ? () => navigate(`/studios?tagIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "PERFORMERS",
+          count: entity.performer_count,
+          onClick:
+            entity.performer_count > 0
+              ? () => navigate(`/performers?tagIds=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "GALLERIES",
+          count: entity.gallery_count,
+          onClick:
+            entity.gallery_count > 0
+              ? () => navigate(`/galleries?tagIds=${entity.id}`)
+              : undefined,
+        },
       ];
       linkTo = `/tags/${entity.id}`;
       break;
 
-    case 'image':
+    case "image":
       imagePath = entity.paths?.thumbnail || entity.paths?.image;
       title = entity.title || `Image ${entity.id}`;
       description = null;
@@ -256,6 +335,6 @@ const EntityCard = forwardRef(({ entity, entityType, ...others }, ref) => {
   );
 });
 
-EntityCard.displayName = 'EntityCard';
+EntityCard.displayName = "EntityCard";
 
 export default EntityGrid;

--- a/client/src/components/ui/PerformerCard.jsx
+++ b/client/src/components/ui/PerformerCard.jsx
@@ -1,9 +1,12 @@
 import { forwardRef } from "react";
+import { useNavigate } from "react-router-dom";
 import GenderIcon from "./GenderIcon.jsx";
 import { GridCard } from "./GridCard.jsx";
 
 const PerformerCard = forwardRef(
   ({ performer, referrerUrl, isTVMode, tabIndex, ...others }, ref) => {
+    const navigate = useNavigate();
+
     return (
       <GridCard
         entityType="performer"
@@ -12,11 +15,31 @@ const PerformerCard = forwardRef(
         hideSubtitle
         indicators={[
           { type: "PLAY_COUNT", count: performer.play_count },
-          { type: "SCENES", count: performer.scene_count },
-          { type: "GROUPS", count: performer.group_count },
-          { type: "IMAGES", count: performer.image_count },
-          { type: "GALLERIES", count: performer.gallery_count },
-          { type: "TAGS", count: performer.tag_count },
+          {
+            type: "SCENES",
+            count: performer.scene_count,
+            onClick: performer.scene_count > 0 ? () => navigate(`/scenes?performerIds=${performer.id}`) : undefined,
+          },
+          {
+            type: "GROUPS",
+            count: performer.group_count,
+            onClick: performer.group_count > 0 ? () => navigate(`/collections?performerIds=${performer.id}`) : undefined,
+          },
+          {
+            type: "IMAGES",
+            count: performer.image_count,
+            onClick: performer.image_count > 0 ? () => navigate(`/images?performerIds=${performer.id}`) : undefined,
+          },
+          {
+            type: "GALLERIES",
+            count: performer.gallery_count,
+            onClick: performer.gallery_count > 0 ? () => navigate(`/galleries?performerIds=${performer.id}`) : undefined,
+          },
+          {
+            type: "TAGS",
+            count: performer.tags?.length || 0,
+            onClick: performer.tags?.length > 0 ? () => navigate(`/tags?performerIds=${performer.id}`) : undefined,
+          },
         ]}
         linkTo={`/performer/${performer.id}`}
         ratingControlsProps={{

--- a/client/src/components/ui/SceneCard.jsx
+++ b/client/src/components/ui/SceneCard.jsx
@@ -113,6 +113,14 @@ const SceneCard = forwardRef(
       <TooltipEntityGrid entityType="tag" entities={allTags} title="Tags" />
     );
 
+    const galleriesTooltip = scene.galleries && scene.galleries.length > 0 && (
+      <TooltipEntityGrid
+        entityType="gallery"
+        entities={scene.galleries}
+        title="Galleries"
+      />
+    );
+
     const handleClick = (e) => {
       const target = e.target;
       const closestButton = target.closest("button");
@@ -396,16 +404,33 @@ const SceneCard = forwardRef(
               type: "PERFORMERS",
               count: scene.performers?.length,
               tooltipContent: performersTooltip,
+              onClick: scene.performers?.length > 0 ? () => {
+                navigate(`/performers?sceneId=${scene.id}`);
+              } : undefined,
             },
             {
               type: "GROUPS",
               count: scene.groups?.length,
               tooltipContent: groupsTooltip,
+              onClick: scene.groups?.length > 0 ? () => {
+                navigate(`/collections?sceneId=${scene.id}`);
+              } : undefined,
+            },
+            {
+              type: "GALLERIES",
+              count: scene.galleries?.length,
+              tooltipContent: galleriesTooltip,
+              onClick: scene.galleries?.length > 0 ? () => {
+                navigate(`/galleries?sceneId=${scene.id}`);
+              } : undefined,
             },
             {
               type: "TAGS",
               count: allTags?.length,
               tooltipContent: tagsTooltip,
+              onClick: allTags?.length > 0 ? () => {
+                navigate(`/tags?sceneId=${scene.id}`);
+              } : undefined,
             },
           ]}
         />

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -703,6 +703,33 @@ export const PERFORMER_FILTER_OPTIONS = [
     defaultValue: "",
     placeholder: "Search details...",
   },
+
+  // Entity Filters
+  {
+    type: "section-header",
+    label: "Entity Filters",
+    key: "section-entities",
+    collapsible: true,
+    defaultOpen: false,
+  },
+  {
+    key: "sceneId",
+    label: "Scene",
+    type: "searchable-select",
+    entityType: "scenes",
+    multi: false,
+    defaultValue: "",
+    placeholder: "Select scene...",
+  },
+  {
+    key: "groupIds",
+    label: "Collections",
+    type: "searchable-select",
+    entityType: "groups",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select collections...",
+  },
 ];
 
 export const STUDIO_FILTER_OPTIONS = [
@@ -865,6 +892,51 @@ export const TAG_FILTER_OPTIONS = [
     placeholder: "Favorites Only",
   },
 
+  // Entity Filters
+  {
+    type: "section-header",
+    label: "Entity Filters",
+    key: "section-entities",
+    collapsible: true,
+    defaultOpen: false,
+  },
+  {
+    key: "performerIds",
+    label: "Performers",
+    type: "searchable-select",
+    entityType: "performers",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select performers...",
+  },
+  {
+    key: "studioId",
+    label: "Studio",
+    type: "searchable-select",
+    entityType: "studios",
+    multi: false,
+    defaultValue: "",
+    placeholder: "Select studio...",
+  },
+  {
+    key: "sceneId",
+    label: "Scene",
+    type: "searchable-select",
+    entityType: "scenes",
+    multi: false,
+    defaultValue: "",
+    placeholder: "Select scene...",
+  },
+  {
+    key: "groupIds",
+    label: "Collections",
+    type: "searchable-select",
+    entityType: "groups",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select collections...",
+  },
+
   // Date Ranges
   {
     type: "section-header",
@@ -1007,6 +1079,24 @@ export const GROUP_FILTER_OPTIONS = [
     label: "Updated Date",
     type: "date-range",
     defaultValue: {},
+  },
+
+  // Entity Filters
+  {
+    type: "section-header",
+    label: "Entity Filters",
+    key: "section-entities",
+    collapsible: true,
+    defaultOpen: false,
+  },
+  {
+    key: "sceneId",
+    label: "Scene",
+    type: "searchable-select",
+    entityType: "scenes",
+    multi: false,
+    defaultValue: "",
+    placeholder: "Select scene...",
   },
 ];
 
@@ -1727,6 +1817,24 @@ export const buildPerformerFilter = (filters) => {
     };
   }
 
+  // Entity filters
+  if (filters.sceneId) {
+    performerFilter.scene_filter = {
+      id: {
+        value: [filters.sceneId],
+        modifier: "INCLUDES",
+      },
+    };
+  }
+
+  if (filters.groupIds && filters.groupIds.length > 0) {
+    performerFilter.scene_filter = performerFilter.scene_filter || {};
+    performerFilter.scene_filter.groups = {
+      value: filters.groupIds,
+      modifier: "INCLUDES",
+    };
+  }
+
   return performerFilter;
 };
 
@@ -2015,6 +2123,38 @@ export const buildTagFilter = (filters) => {
     };
   }
 
+  // Entity filters
+  if (filters.performerIds && filters.performerIds.length > 0) {
+    tagFilter.performers = {
+      value: filters.performerIds,
+      modifier: "INCLUDES",
+    };
+  }
+
+  if (filters.studioId) {
+    tagFilter.studios = {
+      value: [filters.studioId],
+      modifier: "INCLUDES",
+    };
+  }
+
+  if (filters.sceneId) {
+    tagFilter.scenes_filter = {
+      id: {
+        value: [filters.sceneId],
+        modifier: "INCLUDES",
+      },
+    };
+  }
+
+  if (filters.groupIds && filters.groupIds.length > 0) {
+    tagFilter.scenes_filter = tagFilter.scenes_filter || {};
+    tagFilter.scenes_filter.groups = {
+      value: filters.groupIds,
+      modifier: "INCLUDES",
+    };
+  }
+
   return tagFilter;
 };
 
@@ -2167,6 +2307,16 @@ export const buildGroupFilter = (filters) => {
     groupFilter.director = {
       value: filters.director,
       modifier: "INCLUDES",
+    };
+  }
+
+  // Entity filters
+  if (filters.sceneId) {
+    groupFilter.scene_filter = {
+      id: {
+        value: [filters.sceneId],
+        modifier: "INCLUDES",
+      },
     };
   }
 

--- a/server/types/peekFilters.ts
+++ b/server/types/peekFilters.ts
@@ -56,6 +56,13 @@ export type PeekTagFilter = BaseTagFilterType & {
   rating100?: { value?: number; value2?: number; modifier?: string };
   o_counter?: { value?: number; value2?: number; modifier?: string };
   play_count?: { value?: number; value2?: number; modifier?: string };
+  // Custom entity filters (not in Stash API)
+  performers?: { value: string[]; modifier?: string };
+  studios?: { value: string[]; modifier?: string };
+  scenes_filter?: {
+    id?: { value: string[]; modifier?: string };
+    groups?: { value: string[]; modifier?: string };
+  };
 };
 
 /**


### PR DESCRIPTION
### Summary
Enhanced all card indicators across the application to support clickable navigation, enabling users to quickly explore relationships between entities. Clicking an indicator (e.g., "5 Tags" on a performer card) now navigates to a filtered view showing only those related entities.

### Changes

**Frontend Enhancements:**
- Made all card indicators clickable with hover feedback across Scene, Performer, Studio, Tag, and Collection cards
- Added missing indicators: Tags to performers/studios, Galleries to scenes, Studios/Performers/Galleries to tags
- Implemented proper event handling (`stopPropagation` + `preventDefault`) to prevent card navigation when clicking indicators
- Fixed URL parameter merging with user default filter presets for seamless navigation experience

**Backend Filtering:**
- Added custom cross-entity filtering support: tags by studio/performer/scene, performers by scene/group, studios by tag
- Implemented server-side filtering logic for relationships not natively supported by Stash GraphQL API
- Added new filter types to `PeekTagFilter`, `PeekPerformerFilter`, and `PeekGroupFilter` type definitions
- Fixed studio tag filtering to correctly look at tags directly on studio objects (not nested scene/performer tags)

**Filter Configuration:**
- Extended filter options for all entity types to support new cross-entity filters
- Updated filter builder functions (`buildTagFilter`, `buildPerformerFilter`, `buildGroupFilter`) to handle new parameters
- Ensured all navigation URLs use correct plural parameter names (e.g., `performerIds`, `tagIds`, `studioId`)

### Testing
- ✅ All unit tests passing (239 client + 258 server tests)
- ✅ Manual testing confirmed correct filtering behavior
- ✅ Verified URL parameter merging with default presets

### Impact
Significantly improves content discovery and navigation UX by allowing users to quickly explore entity relationships with a single click instead of manually setting up filters