### PR TITLE
feat: add View in Stash button to entity detail pages

### DIFF
--- a/client/public/assets/stash-logo.svg
+++ b/client/public/assets/stash-logo.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="256"
+   height="255.99998"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="stash.svg"
+   viewBox="0 0 256.00031 256.0003"
+   inkscape:export-filename="stash_icon.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter15"
+       x="-0.05306626"
+       y="-0.076049218"
+       width="1.1191703"
+       height="1.1707829">
+      <feFlood
+         result="flood"
+         in="SourceGraphic"
+         flood-opacity="0.498039"
+         flood-color="rgb(51,51,51)"
+         id="feFlood14" />
+      <feGaussianBlur
+         result="blur"
+         in="SourceGraphic"
+         stdDeviation="3.391827"
+         id="feGaussianBlur14" />
+      <feOffset
+         result="offset"
+         in="blur"
+         dx="2.000000"
+         dy="2.000000"
+         id="feOffset14" />
+      <feComposite
+         result="comp1"
+         operator="in"
+         in="flood"
+         in2="offset"
+         id="feComposite14" />
+      <feComposite
+         result="comp2"
+         operator="over"
+         in="SourceGraphic"
+         in2="comp1"
+         id="feComposite15" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.1621094"
+     inkscape:cx="272.2014"
+     inkscape:cy="-3.3966829"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:export-bgcolor="#24242400">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="256.00031"
+       height="256.00031"
+       id="page2"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2">
+    <rect
+       style="fill:#242424;fill-opacity:1;stroke-width:0.982009"
+       id="rect17"
+       width="256.0011"
+       height="256.07516"
+       x="1.3057871e-07"
+       y="-0.06748686"
+       ry="18.07061"
+       rx="10.756315" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-180.90625,-335.34375)">
+    <path
+       style="fill:#a08069;fill-opacity:1;stroke:none;stroke-width:0.775662;filter:url(#filter15)"
+       d="m 308.68104,408.60174 -64.43628,19.31216 -12.3475,16.08936 56.07724,20.1486 16.26431,-20.32082 4.27506,1.86972 4.27504,-1.86972 16.93304,20.83745 55.5757,-20.32081 -12.99234,-17.44244 z m 0,5.26472 45.06719,13.70301 -45.06719,13.03879 -45.54484,-13.55541 z m 3.53469,40.2972 -0.16718,61.30689 59.85074,-25.24112 0.16719,-34.36826 -44.87612,15.22831 -13.15954,-16.92582 z m -8.62176,0.17222 -13.15953,16.92581 -44.87611,-15.2283 0.16717,34.36825 59.85075,25.24111 -0.16717,-61.30687 z"
+       id="path3824"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/client/src/components/pages/GalleryDetail.jsx
+++ b/client/src/components/pages/GalleryDetail.jsx
@@ -13,6 +13,7 @@ import {
   PageHeader,
   RatingSlider,
 } from "../ui/index.js";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 
 const GalleryDetail = () => {
   const { galleryId } = useParams();
@@ -163,6 +164,7 @@ const GalleryDetail = () => {
                   onChange={handleFavoriteChange}
                   size="large"
                 />
+                <ViewInStashButton stashUrl={gallery?.stashUrl} size={24} />
               </div>
             }
             subtitle={

--- a/client/src/components/pages/GroupDetail.jsx
+++ b/client/src/components/pages/GroupDetail.jsx
@@ -13,6 +13,7 @@ import {
   PageHeader,
   RatingSlider,
 } from "../ui/index.js";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 
 const GroupDetail = () => {
   const { groupId } = useParams();
@@ -111,6 +112,7 @@ const GroupDetail = () => {
                   onChange={handleFavoriteChange}
                   size="large"
                 />
+                <ViewInStashButton stashUrl={group?.stashUrl} size={24} />
               </div>
             }
             subtitle={

--- a/client/src/components/pages/PerformerDetail.jsx
+++ b/client/src/components/pages/PerformerDetail.jsx
@@ -28,6 +28,7 @@ import {
   RatingSlider,
   TabNavigation,
 } from "../ui/index.js";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 
 // Helper to detect and map URLs to known sites with colors
 const getSiteInfo = (url) => {
@@ -189,6 +190,7 @@ const PerformerDetail = () => {
                   onChange={handleFavoriteChange}
                   size="large"
                 />
+                <ViewInStashButton stashUrl={performer?.stashUrl} size={24} />
               </div>
             }
             subtitle={

--- a/client/src/components/pages/Scene.jsx
+++ b/client/src/components/pages/Scene.jsx
@@ -17,6 +17,7 @@ import {
 } from "../ui/index.js";
 import PlaybackControls from "../video-player/PlaybackControls.jsx";
 import VideoPlayer from "../video-player/VideoPlayer.jsx";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 import SceneDetails from "./SceneDetails.jsx";
 
 // Inner component that reads from context
@@ -113,22 +114,25 @@ const SceneContent = ({ location }) => {
       {/* Video Player Header */}
       <header className="w-full py-8 px-4 lg:px-6 xl:px-8">
         <div className="flex flex-col md:flex-row md:items-center gap-4">
-          <Button
-            onClick={() => {
-              // If we have a referrer URL with filters, navigate to it
-              // Otherwise use browser back
-              if (location.state?.referrerUrl) {
-                navigate(location.state.referrerUrl);
-              } else {
-                navigate(-1);
-              }
-            }}
-            variant="secondary"
-            className="inline-flex items-center gap-2 flex-shrink-0 self-start"
-          >
-            <span>←</span>
-            <span className="whitespace-nowrap">Back to Scenes</span>
-          </Button>
+          <div className="flex items-center gap-2 flex-shrink-0 self-start">
+            <Button
+              onClick={() => {
+                // If we have a referrer URL with filters, navigate to it
+                // Otherwise use browser back
+                if (location.state?.referrerUrl) {
+                  navigate(location.state.referrerUrl);
+                } else {
+                  navigate(-1);
+                }
+              }}
+              variant="secondary"
+              className="inline-flex items-center gap-2"
+            >
+              <span>←</span>
+              <span className="whitespace-nowrap">Back to Scenes</span>
+            </Button>
+            <ViewInStashButton stashUrl={scene?.stashUrl} size={20} />
+          </div>
           <h1
             className="text-2xl font-bold line-clamp-2"
             style={{ color: "var(--text-primary)" }}

--- a/client/src/components/pages/StudioDetail.jsx
+++ b/client/src/components/pages/StudioDetail.jsx
@@ -22,6 +22,7 @@ import {
   RatingSlider,
   TabNavigation,
 } from "../ui/index.js";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 
 const StudioDetail = () => {
   const { studioId } = useParams();
@@ -122,6 +123,7 @@ const StudioDetail = () => {
                   onChange={handleFavoriteChange}
                   size="large"
                 />
+                <ViewInStashButton stashUrl={studio?.stashUrl} size={24} />
               </div>
             }
             subtitle={

--- a/client/src/components/pages/TagDetail.jsx
+++ b/client/src/components/pages/TagDetail.jsx
@@ -16,6 +16,7 @@ import {
   RatingSlider,
   TabNavigation,
 } from "../ui/index.js";
+import ViewInStashButton from "../ui/ViewInStashButton.jsx";
 
 const TagDetail = () => {
   const { tagId } = useParams();
@@ -151,6 +152,7 @@ const TagDetail = () => {
                   onChange={handleFavoriteChange}
                   size="large"
                 />
+                <ViewInStashButton stashUrl={tag?.stashUrl} size={24} />
               </div>
             }
             subtitle={

--- a/client/src/components/ui/ViewInStashButton.jsx
+++ b/client/src/components/ui/ViewInStashButton.jsx
@@ -1,0 +1,43 @@
+import { useAuth } from "../../hooks/useAuth";
+
+/**
+ * Button that opens the entity in Stash in a new tab
+ * Only visible to admin users
+ *
+ * @param {Object} props
+ * @param {string} props.stashUrl - Full URL to entity in Stash
+ * @param {string} [props.className] - Additional CSS classes
+ * @param {string} [props.size] - Icon size (default: 20)
+ */
+export default function ViewInStashButton({ stashUrl, className = "", size = 20 }) {
+  const { user } = useAuth();
+
+  // Only show button to admin users
+  if (!user || user.role !== "ADMIN") {
+    return null;
+  }
+
+  // Don't render if no stashUrl provided
+  if (!stashUrl) {
+    return null;
+  }
+
+  return (
+    <a
+      href={stashUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center justify-center p-2 rounded-lg bg-zinc-800 hover:bg-zinc-700 transition-colors ${className}`}
+      title="View in Stash"
+      aria-label="View in Stash"
+    >
+      <img
+        src="/assets/stash-logo.svg"
+        alt="Stash"
+        width={size}
+        height={size}
+        className="opacity-80 hover:opacity-100 transition-opacity"
+      />
+    </a>
+  );
+}

--- a/server/controllers/library/galleries.ts
+++ b/server/controllers/library/galleries.ts
@@ -14,6 +14,7 @@ import {
   PeekGalleryFilter,
 } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 import { convertToProxyUrl } from "../../utils/pathMapping.js";
 import { mergePerformersWithUserData } from "./performers.js";
 import { mergeStudiosWithUserData } from "./studios.js";
@@ -328,10 +329,16 @@ export const findGalleries = async (
     const endIndex = startIndex + perPage;
     const paginatedGalleries = galleries.slice(startIndex, endIndex);
 
+    // Add stashUrl to each gallery
+    const galleriesWithStashUrl = paginatedGalleries.map((gallery) => ({
+      ...gallery,
+      stashUrl: buildStashEntityUrl("gallery", gallery.id),
+    }));
+
     res.json({
       findGalleries: {
         count: total,
-        galleries: paginatedGalleries,
+        galleries: galleriesWithStashUrl,
       },
     });
   } catch (error) {

--- a/server/controllers/library/groups.ts
+++ b/server/controllers/library/groups.ts
@@ -7,6 +7,7 @@ import { stashCacheManager } from "../../services/StashCacheManager.js";
 import { userRestrictionService } from "../../services/UserRestrictionService.js";
 import type { NormalizedGroup, PeekGroupFilter } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 
 /**
  * Merge user-specific data into groups
@@ -313,10 +314,16 @@ export const findGroups = async (req: AuthenticatedRequest, res: Response) => {
     const endIndex = startIndex + perPage;
     const paginatedGroups = groups.slice(startIndex, endIndex);
 
+    // Add stashUrl to each group
+    const groupsWithStashUrl = paginatedGroups.map(group => ({
+      ...group,
+      stashUrl: buildStashEntityUrl('group', group.id),
+    }));
+
     res.json({
       findGroups: {
         count: total,
-        groups: paginatedGroups,
+        groups: groupsWithStashUrl,
       },
     });
   } catch (error) {

--- a/server/controllers/library/performers.ts
+++ b/server/controllers/library/performers.ts
@@ -12,6 +12,7 @@ import type {
   PeekPerformerFilter,
 } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 import { calculateEntityImageCount } from "./images.js";
 
 /**
@@ -216,10 +217,16 @@ export const findPerformers = async (
       });
     }
 
+    // Add stashUrl to each performer
+    const performersWithStashUrl = paginatedPerformers.map(performer => ({
+      ...performer,
+      stashUrl: buildStashEntityUrl('performer', performer.id),
+    }));
+
     res.json({
       findPerformers: {
         count: total,
-        performers: paginatedPerformers,
+        performers: performersWithStashUrl,
       },
     });
   } catch (error) {

--- a/server/controllers/library/scenes.ts
+++ b/server/controllers/library/scenes.ts
@@ -7,6 +7,7 @@ import getStash from "../../stash.js";
 import type { NormalizedScene, PeekSceneFilter } from "../../types/index.js";
 import { isSceneStreamable } from "../../utils/codecDetection.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 
 /**
  * Seeded random number generator for consistent shuffling per user
@@ -153,11 +154,13 @@ export function addStreamabilityInfo(
 ): NormalizedScene[] {
   return scenes.map((scene) => {
     const streamabilityInfo = isSceneStreamable(scene);
+    const stashUrl = buildStashEntityUrl('scene', scene.id);
 
     return {
       ...scene,
       isStreamable: streamabilityInfo.isStreamable,
       streamabilityReasons: streamabilityInfo.reasons,
+      stashUrl,
     };
   });
 }

--- a/server/controllers/library/studios.ts
+++ b/server/controllers/library/studios.ts
@@ -9,6 +9,7 @@ import { userStatsService } from "../../services/UserStatsService.js";
 import getStash from "../../stash.js";
 import type { NormalizedStudio, PeekStudioFilter } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 import { calculateEntityImageCount } from "./images.js";
 
 /**
@@ -201,10 +202,16 @@ export const findStudios = async (req: AuthenticatedRequest, res: Response) => {
       });
     }
 
+    // Add stashUrl to each studio
+    const studiosWithStashUrl = paginatedStudios.map(studio => ({
+      ...studio,
+      stashUrl: buildStashEntityUrl('studio', studio.id),
+    }));
+
     res.json({
       findStudios: {
         count: total,
-        studios: paginatedStudios,
+        studios: studiosWithStashUrl,
       },
     });
   } catch (error) {

--- a/server/controllers/library/tags.ts
+++ b/server/controllers/library/tags.ts
@@ -9,6 +9,7 @@ import { userStatsService } from "../../services/UserStatsService.js";
 import getStash from "../../stash.js";
 import type { NormalizedTag, PeekTagFilter } from "../../types/index.js";
 import { logger } from "../../utils/logger.js";
+import { buildStashEntityUrl } from "../../utils/stashUrl.js";
 import { calculateEntityImageCount } from "./images.js";
 
 /**
@@ -293,10 +294,16 @@ export const findTags = async (req: AuthenticatedRequest, res: Response) => {
       });
     }
 
+    // Add stashUrl to each tag
+    const tagsWithStashUrl = paginatedTags.map(tag => ({
+      ...tag,
+      stashUrl: buildStashEntityUrl('tag', tag.id),
+    }));
+
     res.json({
       findTags: {
         count: total,
-        tags: paginatedTags,
+        tags: tagsWithStashUrl,
       },
     });
   } catch (error) {

--- a/server/utils/stashUrl.ts
+++ b/server/utils/stashUrl.ts
@@ -1,0 +1,52 @@
+/**
+ * Utility functions for working with Stash URLs
+ */
+
+/**
+ * Strips /graphql from the STASH_URL environment variable to get the base Stash URL
+ * @returns Base Stash URL (e.g., http://localhost:9999)
+ */
+export function getStashBaseUrl(): string | null {
+  const stashUrl = process.env.STASH_URL;
+
+  if (!stashUrl) {
+    return null;
+  }
+
+  // Remove /graphql suffix if present
+  return stashUrl.replace(/\/graphql\/?$/, '');
+}
+
+/**
+ * Builds a Stash entity URL
+ * @param entityType - Type of entity (scene, performer, studio, tag, group, gallery)
+ * @param entityId - ID of the entity
+ * @returns Full URL to the entity in Stash, or null if stashBaseUrl is not available
+ */
+export function buildStashEntityUrl(
+  entityType: 'scene' | 'performer' | 'studio' | 'tag' | 'group' | 'gallery',
+  entityId: string | number
+): string | null {
+  const baseUrl = getStashBaseUrl();
+
+  if (!baseUrl) {
+    return null;
+  }
+
+  // Map entity types to Stash URL paths
+  const pathMap: Record<string, string> = {
+    scene: 'scenes',
+    performer: 'performers',
+    studio: 'studios',
+    tag: 'tags',
+    group: 'groups',
+    gallery: 'galleries',
+  };
+
+  const path = pathMap[entityType];
+  if (!path) {
+    return null;
+  }
+
+  return `${baseUrl}/${path}/${entityId}`;
+}


### PR DESCRIPTION
### Summary
Adds admin-only "View in Stash" buttons to all entity detail pages that link directly to the corresponding entity in the Stash web interface, enabling quick navigation between Peek and Stash for content management workflows.

### Changes
- **Backend**: Created `stashUrl.ts` utility that strips `/graphql` from `STASH_URL` and constructs entity-specific URLs for scenes, performers, studios, tags, groups, and galleries
- **Backend**: Modified all 6 entity controllers to include `stashUrl` field in API responses
- **Frontend**: Added official Stash logo SVG asset for button icon
- **Frontend**: Created `ViewInStashButton` component with admin-only visibility check
- **Frontend**: Integrated button into all entity detail pages (Scene, Performer, Studio, Tag, Group, Gallery) with mobile-friendly, non-obtrusive placement

### Technical Details
- Button only visible to users with ADMIN role
- Icon-only design using Stash's official logo (20-24px size)
- Opens in new tab with `target="_blank"` and `rel="noopener noreferrer"`
- Gracefully handles missing `stashUrl` (no button shown if unavailable)
- Scene page: Button placed next to Back button for minimal header disruption
- Other pages: Button placed after FavoriteButton in PageHeader title area

### Testing
- ✅ All unit tests passing (client: 239 tests, server: 258 tests)
- ✅ TypeScript compilation successful
- ✅ Docker containers running without errors