### PR TITLE
fix: add missing gallery filter and sort options to SearchControls

### DIFF
--- a/client/src/components/ui/SearchControls.jsx
+++ b/client/src/components/ui/SearchControls.jsx
@@ -5,6 +5,8 @@ import { apiGet } from "../../services/api.js";
 import { useTVMode } from "../../hooks/useTVMode.js";
 import { useHorizontalNavigation } from "../../hooks/useHorizontalNavigation.js";
 import {
+  GALLERY_FILTER_OPTIONS,
+  GALLERY_SORT_OPTIONS,
   GROUP_FILTER_OPTIONS,
   GROUP_SORT_OPTIONS,
   PERFORMER_FILTER_OPTIONS,
@@ -15,6 +17,7 @@ import {
   STUDIO_SORT_OPTIONS,
   TAG_FILTER_OPTIONS,
   TAG_SORT_OPTIONS,
+  buildGalleryFilter,
   buildGroupFilter,
   buildPerformerFilter,
   buildSceneFilter,
@@ -43,6 +46,8 @@ const buildFilter = (artifactType, filters) => {
       return { tag_filter: buildTagFilter(filters) };
     case "group":
       return { group_filter: buildGroupFilter(filters) };
+    case "gallery":
+      return { gallery_filter: buildGalleryFilter(filters) };
     case "scene":
     default:
       return { scene_filter: buildSceneFilter(filters) };
@@ -59,6 +64,8 @@ const getSortOptions = (artifactType) => {
       return TAG_SORT_OPTIONS;
     case "group":
       return GROUP_SORT_OPTIONS;
+    case "gallery":
+      return GALLERY_SORT_OPTIONS;
     case "scene":
     default:
       return SCENE_SORT_OPTIONS;
@@ -152,6 +159,8 @@ const SearchControls = ({
         return [...TAG_FILTER_OPTIONS];
       case "group":
         return [...GROUP_FILTER_OPTIONS];
+      case "gallery":
+        return [...GALLERY_FILTER_OPTIONS];
       case "scene":
       default:
         return [...SCENE_FILTER_OPTIONS];

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -81,6 +81,18 @@ export const GROUP_SORT_OPTIONS = [
   { value: "updated_at", label: "Updated At" },
 ];
 
+// Gallery sorting options (alphabetically organized by label)
+export const GALLERY_SORT_OPTIONS = [
+  { value: "created_at", label: "Created At" },
+  { value: "date", label: "Date" },
+  { value: "image_count", label: "Image Count" },
+  { value: "path", label: "Path" },
+  { value: "random", label: "Random" },
+  { value: "rating", label: "Rating" },
+  { value: "title", label: "Title" },
+  { value: "updated_at", label: "Updated At" },
+];
+
 // Filter type options for different data types
 const RATING_OPTIONS = [
   { value: "1", label: "1 Star" },
@@ -1097,6 +1109,83 @@ export const GROUP_FILTER_OPTIONS = [
     multi: false,
     defaultValue: "",
     placeholder: "Select scene...",
+  },
+];
+
+export const GALLERY_FILTER_OPTIONS = [
+  // Common Filters
+  {
+    type: "section-header",
+    label: "Common Filters",
+    key: "section-common",
+    collapsible: true,
+    defaultOpen: true,
+  },
+  {
+    key: "title",
+    label: "Title Search",
+    type: "text",
+    defaultValue: "",
+    placeholder: "Search title...",
+  },
+  {
+    key: "performerIds",
+    label: "Performers",
+    type: "searchable-select",
+    entityType: "performers",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select performers...",
+    modifierOptions: MULTI_MODIFIER_OPTIONS,
+    modifierKey: "performerIdsModifier",
+    defaultModifier: "INCLUDES",
+  },
+  {
+    key: "studioIds",
+    label: "Studios",
+    type: "searchable-select",
+    entityType: "studios",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select studios...",
+    modifierOptions: MULTI_MODIFIER_OPTIONS,
+    modifierKey: "studioIdsModifier",
+    defaultModifier: "INCLUDES",
+  },
+  {
+    key: "tagIds",
+    label: "Tags",
+    type: "searchable-select",
+    entityType: "tags",
+    multi: true,
+    defaultValue: [],
+    placeholder: "Select tags...",
+    modifierOptions: MULTI_MODIFIER_OPTIONS,
+    modifierKey: "tagIdsModifier",
+    defaultModifier: "INCLUDES_ALL",
+  },
+  {
+    key: "rating",
+    label: "Rating (0-100)",
+    type: "range",
+    defaultValue: {},
+    min: 0,
+    max: 100,
+  },
+  {
+    key: "imageCount",
+    label: "Image Count",
+    type: "range",
+    defaultValue: {},
+    min: 0,
+    max: 1000,
+  },
+  {
+    key: "favorite",
+    label: "Favorite Galleries",
+    type: "checkbox",
+    defaultValue: false,
+    placeholder: "Favorites Only",
   },
 ];
 


### PR DESCRIPTION
Gallery filtering was broken because SearchControls was missing the gallery case in its switch statements, causing it to fall through to the default scene filter. Added GALLERY_FILTER_OPTIONS and GALLERY_SORT_OPTIONS exports to filterConfig.js, and integrated them into SearchControls component to properly handle gallery-specific filtering and sorting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)