### PR TITLE
fix: apply hidden entity filtering to all entity types in minimal endpoints

### DIFF
--- a/server/controllers/library/groups.ts
+++ b/server/controllers/library/groups.ts
@@ -379,6 +379,15 @@ export const findGroupsMinimal = async (
       logger.debug("Groups minimal cache miss", { userId, cacheVersion });
       filteredGroups = groups;
 
+      // Apply content restrictions and hidden entity filtering
+      // Hidden entities are ALWAYS filtered (for all users including admins)
+      // Content restrictions (INCLUDE/EXCLUDE) are only applied to non-admins
+      filteredGroups = await userRestrictionService.filterGroupsForUser(
+        filteredGroups,
+        userId,
+        requestingUser?.role === "ADMIN" // Skip content restrictions for admins
+      );
+
       // Filter empty groups (non-admins only)
       if (requestingUser && requestingUser.role !== "ADMIN") {
         filteredGroups =

--- a/server/controllers/library/performers.ts
+++ b/server/controllers/library/performers.ts
@@ -582,6 +582,16 @@ export const findPerformersMinimal = async (
       logger.debug("Performers minimal cache miss", { userId, cacheVersion });
       filteredPerformers = performers;
 
+      // Apply content restrictions and hidden entity filtering
+      // Hidden entities are ALWAYS filtered (for all users including admins)
+      // Content restrictions (INCLUDE/EXCLUDE) are only applied to non-admins
+      filteredPerformers =
+        await userRestrictionService.filterPerformersForUser(
+          filteredPerformers,
+          userId,
+          requestingUser?.role === "ADMIN" // Skip content restrictions for admins
+        );
+
       // Filter empty performers (non-admins only)
       if (requestingUser && requestingUser.role !== "ADMIN") {
         // CRITICAL FIX: Filter scenes first to get visibility baseline

--- a/server/controllers/library/studios.ts
+++ b/server/controllers/library/studios.ts
@@ -526,6 +526,15 @@ export const findStudiosMinimal = async (
       logger.debug("Studios minimal cache miss", { userId, cacheVersion });
       filteredStudios = studios;
 
+      // Apply content restrictions and hidden entity filtering
+      // Hidden entities are ALWAYS filtered (for all users including admins)
+      // Content restrictions (INCLUDE/EXCLUDE) are only applied to non-admins
+      filteredStudios = await userRestrictionService.filterStudiosForUser(
+        filteredStudios,
+        userId,
+        requestingUser?.role === "ADMIN" // Skip content restrictions for admins
+      );
+
       // Filter empty studios (non-admins only)
       if (requestingUser && requestingUser.role !== "ADMIN") {
         // CRITICAL FIX: Filter scenes first to get visibility baseline

--- a/server/controllers/library/tags.ts
+++ b/server/controllers/library/tags.ts
@@ -710,9 +710,17 @@ export const findTagsMinimal = async (
         ? await prisma.userContentRestriction.findMany({ where: { userId } })
         : [];
 
-    // Early return: If no restrictions, just return all tags (safe, nothing to leak)
+    // Apply hidden entity filtering (ALWAYS applied, even for admins and users without restrictions)
+    // This is separate from content restrictions
+    tags = await userRestrictionService.filterTagsForUser(
+      tags,
+      userId,
+      requestingUser?.role === "ADMIN" // Skip content restrictions for admins
+    );
+
+    // Early return: If no restrictions, skip expensive empty entity filtering
     if (userRestrictions.length === 0) {
-      // No restrictions - skip expensive filtering entirely (all tags visible)
+      // No restrictions - skip expensive empty entity filtering (but hidden filtering already applied above)
     } else {
       // User has restrictions - must do full filtering for security
       // Use cached filtering from Priority 2

--- a/server/services/UserHiddenEntityService.ts
+++ b/server/services/UserHiddenEntityService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { filteredEntityCacheService } from "./FilteredEntityCacheService.js";
 import { stashCacheManager } from "./StashCacheManager.js";
 
 const prisma = new PrismaClient();
@@ -55,8 +56,9 @@ class UserHiddenEntityService {
       },
     });
 
-    // Invalidate cache for this user
+    // Invalidate caches for this user
     this.hiddenIdsCache.delete(userId);
+    filteredEntityCacheService.invalidateUser(userId);
   }
 
   /**
@@ -75,8 +77,9 @@ class UserHiddenEntityService {
       },
     });
 
-    // Invalidate cache for this user
+    // Invalidate caches for this user
     this.hiddenIdsCache.delete(userId);
+    filteredEntityCacheService.invalidateUser(userId);
   }
 
   /**
@@ -91,8 +94,9 @@ class UserHiddenEntityService {
 
     const result = await prisma.userHiddenEntity.deleteMany({ where });
 
-    // Invalidate cache for this user
+    // Invalidate caches for this user
     this.hiddenIdsCache.delete(userId);
+    filteredEntityCacheService.invalidateUser(userId);
 
     return result.count;
   }


### PR DESCRIPTION

The hidden entities feature was only working for scenes because the *Minimal endpoints (used for grid views and dropdowns) weren't calling filterXXXForUser() methods from UserRestrictionService. Additionally, the FilteredEntityCacheService wasn't being invalidated when hiding/unhiding entities, causing stale cached results to be served even after entities were restored.

Changes:
- Added filterPerformersForUser() call to findPerformersMinimal
- Added filterStudiosForUser() call to findStudiosMinimal
- Added filterTagsForUser() call to findTagsMinimal
- Added filterGroupsForUser() call to findGroupsMinimal
- Added filterGalleriesForUser() call to findGalleriesMinimal
- Added filteredEntityCacheService.invalidateUser() to hideEntity(), unhideEntity(), and unhideAll() in UserHiddenEntityService

This ensures hidden entities are properly filtered across all entity types and cache invalidation happens immediately when entities are hidden/unhidden, allowing real-time UI updates without page refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)