### PR TITLE
feat: display studio code field on scene cards and details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Video: FFmpeg for HLS transcoding with quality presets (360p-1080p)
 - Deployment: Docker (dev: docker-compose, prod: single container with Nginx)
 
-**Dependency**: Consumes `stashapp-api` npm package (v0.3.16) for type-safe Stash GraphQL queries
+**Dependency**: Consumes `stashapp-api` npm package (v0.3.18) for type-safe Stash GraphQL queries
 
 ## Development Commands
 

--- a/client/src/components/pages/SceneDetails.jsx
+++ b/client/src/components/pages/SceneDetails.jsx
@@ -86,8 +86,8 @@ const SceneDetails = ({
             </Paper.Header>
             {showDetails && (
               <Paper.Body>
-                {/* Studio and Release Date Row */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                {/* Studio, Studio Code, and Release Date Row */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
                   {scene.studio && (
                     <div>
                       <h3
@@ -103,6 +103,23 @@ const SceneDetails = ({
                       >
                         {scene.studio.name}
                       </Link>
+                    </div>
+                  )}
+
+                  {scene.code && (
+                    <div>
+                      <h3
+                        className="text-sm font-medium mb-1"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
+                        Studio Code
+                      </h3>
+                      <p
+                        className="text-base"
+                        style={{ color: "var(--text-primary)" }}
+                      >
+                        {scene.code}
+                      </p>
                     </div>
                   )}
 

--- a/client/src/components/ui/SceneCard.jsx
+++ b/client/src/components/ui/SceneCard.jsx
@@ -59,16 +59,23 @@ const SceneCard = forwardRef(
         ? formatResolution(scene.files[0].width, scene.files[0].height)
         : null;
 
-    // Build subtitle with studio and date (like Groups)
+    // Build subtitle with studio, code, and date (like Groups)
     const subtitle = (() => {
-      if (scene.studio && date) {
-        return `${scene.studio.name} • ${date}`;
-      } else if (scene.studio) {
-        return scene.studio.name;
-      } else if (date) {
-        return date;
+      const parts = [];
+
+      if (scene.studio) {
+        parts.push(scene.studio.name);
       }
-      return null;
+
+      if (scene.code) {
+        parts.push(scene.code);
+      }
+
+      if (date) {
+        parts.push(date);
+      }
+
+      return parts.length > 0 ? parts.join(' • ') : null;
     })();
 
     // Merge and deduplicate tags

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "stashapp-api": "^0.3.17"
+        "stashapp-api": "^0.3.18"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^6.0.0",
@@ -6520,9 +6520,9 @@
       "license": "MIT"
     },
     "node_modules/stashapp-api": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.17.tgz",
-      "integrity": "sha512-f+JVr3o0Nv2e9eUQ9Bd5z2MXDiMn8Xh4p/4pBs/A7y+NDbN1RQexvocRvx9Ib1UCRkpFi7rhftKBWIhyGPpn6A==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.18.tgz",
+      "integrity": "sha512-uHft2vOMo4l/B7DjFnQioQX3AMHw3JvKML33X2oo+R8hi4ch3/ehy1XSHPj92sRTBIKe99Og9dVK6xI/xp43Pw==",
       "license": "MIT",
       "dependencies": {
         "graphql": "^16.11.0",

--- a/server/package.json
+++ b/server/package.json
@@ -54,6 +54,6 @@
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "stashapp-api": "^0.3.17"
+    "stashapp-api": "^0.3.18"
   }
 }


### PR DESCRIPTION
Add support for displaying the scene code field (from Stash) on both scene cards and scene details pages. The code appears between the studio name and date in the format "Studio • CODE • Date", with empty values intelligently omitted.

Changes:
- Updated stashapp-api dependency from v0.3.17 to v0.3.18 (adds code field)
- Modified SceneCard subtitle to include code in format: studio • code • date
- Added Studio Code field to SceneDetails accordion (responsive 3-column grid)
- Updated CLAUDE.md to reflect new stashapp-api version

🤖 Generated with [Claude Code](https://claude.com/claude-code)