### PR TITLE
fix: enable rating hotkeys on Scene page without conflicting with vid…

### DIFF
--- a/client/src/components/ui/HelpModal.jsx
+++ b/client/src/components/ui/HelpModal.jsx
@@ -117,6 +117,17 @@ const HelpModal = ({ onClose }) => {
     ],
     scene: [
       {
+        category: "Rating",
+        items: [
+          {
+            keys: ["r 1-5"],
+            description: "Set rating (20%, 40%, 60%, 80%, 100%)",
+          },
+          { keys: ["r 0"], description: "Clear rating" },
+          { keys: ["r f"], description: "Toggle Favorite" },
+        ],
+      },
+      {
         category: "Playback Control",
         items: [
           { keys: ["Space", "K"], description: "Play / Pause" },
@@ -155,6 +166,13 @@ const HelpModal = ({ onClose }) => {
       {
         category: "Display",
         items: [{ keys: ["F"], description: "Toggle fullscreen" }],
+      },
+      {
+        category: "Playlist Navigation",
+        items: [
+          { keys: ["Shift+N"], description: "Next scene in playlist" },
+          { keys: ["Shift+P"], description: "Previous scene in playlist" },
+        ],
       },
     ],
     global: [
@@ -454,7 +472,7 @@ const HelpModal = ({ onClose }) => {
                   </h2>
                   <p className="text-sm" style={{ color: "var(--text-muted)" }}>
                     {currentPage === "scene"
-                      ? "Control video playback and navigation with these keyboard shortcuts"
+                      ? "Control video playback with these shortcuts. Press R followed by 1-5 to set rating, R then 0 to clear, or R then F to toggle favorite."
                       : [
                             "performer",
                             "studio",

--- a/client/src/hooks/useKeyboardShortcuts.js
+++ b/client/src/hooks/useKeyboardShortcuts.js
@@ -61,13 +61,20 @@ export const useKeyboardShortcuts = (
       const handler = shortcutsRef.current[keyCombo];
 
       if (handler) {
-        // Prevent default browser behavior for this shortcut
-        event.preventDefault();
-        event.stopPropagation();
-
-        // Execute the handler
+        // Execute the handler first - it may return false to indicate it didn't handle
+        // (e.g., video player 'f' handler returns early when in rating mode)
         try {
-          handler(event);
+          const result = handler(event);
+
+          // If handler returns false, don't stop propagation - let other handlers try
+          // This allows rating hotkeys to handle 'f' when video player defers
+          if (result === false) {
+            return;
+          }
+
+          // Handler handled it - prevent default and stop propagation
+          event.preventDefault();
+          event.stopPropagation();
         } catch (error) {
           console.error(
             `[useKeyboardShortcuts:${context}] Error handling "${keyCombo}":`,

--- a/client/src/hooks/useMediaKeys.js
+++ b/client/src/hooks/useMediaKeys.js
@@ -1,9 +1,13 @@
 import { useEffect, useMemo } from "react";
 import { useVideoPlayerShortcuts } from "./useKeyboardShortcuts.js";
+import { isInRatingMode } from "./useRatingHotkeys.js";
 
 /**
  * Hook for video player keyboard shortcuts
  * Uses the new useKeyboardShortcuts hook with YouTube-standard shortcuts
+ *
+ * Note: Keys that conflict with rating hotkeys (f, 0-5) check isInRatingMode()
+ * and skip handling when in rating mode, allowing useRatingHotkeys to handle them.
  *
  * @param {Object} options Configuration options
  * @param {Object} options.playerRef Ref to Video.js player instance
@@ -129,12 +133,32 @@ export const usePlaylistMediaKeys = ({
       },
 
       // Number keys for percentage jumps (0-9)
-      "0": () => jumpToPercentage(playerRef, 0),
-      "1": () => jumpToPercentage(playerRef, 10),
-      "2": () => jumpToPercentage(playerRef, 20),
-      "3": () => jumpToPercentage(playerRef, 30),
-      "4": () => jumpToPercentage(playerRef, 40),
-      "5": () => jumpToPercentage(playerRef, 50),
+      // Note: 0-5 conflict with rating hotkeys (r + 0-5 = set rating)
+      // Return false when in rating mode to let event propagate to rating hotkeys
+      "0": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 0);
+      },
+      "1": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 10);
+      },
+      "2": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 20);
+      },
+      "3": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 30);
+      },
+      "4": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 40);
+      },
+      "5": () => {
+        if (isInRatingMode()) return false;
+        jumpToPercentage(playerRef, 50);
+      },
       "6": () => jumpToPercentage(playerRef, 60),
       "7": () => jumpToPercentage(playerRef, 70),
       "8": () => jumpToPercentage(playerRef, 80),
@@ -191,7 +215,10 @@ export const usePlaylistMediaKeys = ({
       // DISPLAY CONTROL
       // ============================================================================
 
+      // Note: 'f' conflicts with rating hotkey (r + f = toggle favorite)
+      // Return false when in rating mode to let event propagate to rating hotkeys
       f: () => {
+        if (isInRatingMode()) return false;
         const player = playerRef.current;
         if (player) {
           if (player.isFullscreen()) {


### PR DESCRIPTION
…eo controls

Rating hotkeys (r + 1-5, r + 0, r + f) were not working on the Scene page because video player shortcuts intercepted conflicting keys (f for fullscreen, 0-9 for seek) before the rating hotkeys could handle them. This fix introduces a shared global rating mode state that video player shortcuts check before handling, allowing them to defer to rating hotkeys when appropriate by returning false from their handlers.

Also documents rating and playlist navigation hotkeys in the help modal for the Scene page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)