### PR TITLE
fix: use correct URL param key for studio filter on Galleries page

### DIFF
--- a/client/src/components/pages/Studios.jsx
+++ b/client/src/components/pages/Studios.jsx
@@ -186,7 +186,7 @@ const StudioCard = forwardRef(
           {
             type: "GALLERIES",
             count: studio.gallery_count,
-            onClick: studio.gallery_count > 0 ? () => navigate(`/galleries?studioId=${studio.id}`) : undefined,
+            onClick: studio.gallery_count > 0 ? () => navigate(`/galleries?studioIds=${studio.id}`) : undefined,
           },
           {
             type: "PERFORMERS",


### PR DESCRIPTION
StudioCard was navigating to /galleries?studioId=... but the Gallery filter system expects studioIds (plural, multi-select). This caused the filter to be ignored and overwritten during SearchControls init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)