### PR TITLE
feat: add Performers and Tags indicators to gallery cards

### DIFF
--- a/client/src/components/pages/Galleries.jsx
+++ b/client/src/components/pages/Galleries.jsx
@@ -16,6 +16,7 @@ import {
   PageHeader,
   PageLayout,
   SearchControls,
+  TooltipEntityGrid,
 } from "../ui/index.js";
 
 const Galleries = () => {
@@ -155,6 +156,7 @@ const Galleries = () => {
 
 const GalleryCard = forwardRef(
   ({ gallery, tabIndex, isTVMode = false, referrerUrl, ...others }, ref) => {
+    const navigate = useNavigate();
     const coverImage = gallery.paths?.cover || null;
     const title = galleryTitle(gallery);
     const date = gallery.date
@@ -173,6 +175,27 @@ const GalleryCard = forwardRef(
       return null;
     })();
 
+    // Build rich tooltip content for performers and tags
+    const performersTooltip =
+      gallery.performers &&
+      gallery.performers.length > 0 && (
+        <TooltipEntityGrid
+          entityType="performer"
+          entities={gallery.performers}
+          title="Performers"
+        />
+      );
+
+    const tagsTooltip =
+      gallery.tags &&
+      gallery.tags.length > 0 && (
+        <TooltipEntityGrid
+          entityType="tag"
+          entities={gallery.tags}
+          title="Tags"
+        />
+      );
+
     return (
       <GridCard
         description={gallery.description}
@@ -186,6 +209,24 @@ const GalleryCard = forwardRef(
               gallery.image_count === 1
                 ? "1 Image"
                 : `${gallery.image_count} Images`,
+          },
+          {
+            type: "PERFORMERS",
+            count: gallery.performers?.length || 0,
+            tooltipContent: performersTooltip,
+            onClick:
+              gallery.performers?.length > 0
+                ? () => navigate(`/performers?galleryId=${gallery.id}`)
+                : undefined,
+          },
+          {
+            type: "TAGS",
+            count: gallery.tags?.length || 0,
+            tooltipContent: tagsTooltip,
+            onClick:
+              gallery.tags?.length > 0
+                ? () => navigate(`/tags?galleryId=${gallery.id}`)
+                : undefined,
           },
         ]}
         linkTo={`/gallery/${gallery.id}`}

--- a/client/src/components/ui/EntityGrid.jsx
+++ b/client/src/components/ui/EntityGrid.jsx
@@ -8,6 +8,7 @@ import { GridCard } from "./GridCard.jsx";
 import LoadingSpinner from "./LoadingSpinner.jsx";
 import Pagination from "./Pagination.jsx";
 import PerformerCard from "./PerformerCard.jsx";
+import { TooltipEntityGrid } from "./TooltipEntityGrid.jsx";
 
 /**
  * EntityGrid - Generic grid component for displaying entities (galleries, images, groups, etc.)
@@ -161,7 +162,7 @@ const EntityCard = forwardRef(({ entity, entityType, onHideSuccess, ...others },
   let imagePath, title, subtitle, indicators, linkTo, description;
 
   switch (entityType) {
-    case "gallery":
+    case "gallery": {
       imagePath = entity.paths?.cover || null;
       title = galleryTitle(entity);
       description = entity.description;
@@ -178,6 +179,25 @@ const EntityCard = forwardRef(({ entity, entityType, onHideSuccess, ...others },
         }
         return null;
       })();
+      // Build rich tooltip content for performers and tags
+      const performersTooltip =
+        entity.performers &&
+        entity.performers.length > 0 && (
+          <TooltipEntityGrid
+            entityType="performer"
+            entities={entity.performers}
+            title="Performers"
+          />
+        );
+      const tagsTooltip =
+        entity.tags &&
+        entity.tags.length > 0 && (
+          <TooltipEntityGrid
+            entityType="tag"
+            entities={entity.tags}
+            title="Tags"
+          />
+        );
       indicators = [
         {
           type: "IMAGES",
@@ -187,9 +207,28 @@ const EntityCard = forwardRef(({ entity, entityType, onHideSuccess, ...others },
               ? "1 Image"
               : `${entity.image_count} Images`,
         },
+        {
+          type: "PERFORMERS",
+          count: entity.performers?.length || 0,
+          tooltipContent: performersTooltip,
+          onClick:
+            entity.performers?.length > 0
+              ? () => navigate(`/performers?galleryId=${entity.id}`)
+              : undefined,
+        },
+        {
+          type: "TAGS",
+          count: entity.tags?.length || 0,
+          tooltipContent: tagsTooltip,
+          onClick:
+            entity.tags?.length > 0
+              ? () => navigate(`/tags?galleryId=${entity.id}`)
+              : undefined,
+        },
       ];
       linkTo = `/gallery/${entity.id}`;
       break;
+    }
 
     case "group":
       imagePath = entity.front_image_path || entity.back_image_path;
@@ -243,13 +282,6 @@ const EntityCard = forwardRef(({ entity, entityType, onHideSuccess, ...others },
       break;
 
     case "studio":
-      console.log('[EntityGrid] Studio entity:', {
-        id: entity.id,
-        name: entity.name,
-        tags: entity.tags,
-        tagsLength: entity.tags?.length,
-        tag_count: entity.tag_count,
-      });
       imagePath = entity.image_path;
       title = entity.name;
       description = entity.details;
@@ -271,7 +303,6 @@ const EntityCard = forwardRef(({ entity, entityType, onHideSuccess, ...others },
               : undefined,
         },
       ];
-      console.log('[EntityGrid] Studio indicators:', indicators);
       linkTo = `/studio/${entity.id}`;
       break;
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peek-server",
-  "version": "1.6.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peek-server",
-      "version": "1.6.1",
+      "version": "2.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.17.0",
@@ -16,7 +16,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "stashapp-api": "^0.3.20"
+        "stashapp-api": "^0.3.21"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^6.0.0",
@@ -6520,9 +6520,9 @@
       "license": "MIT"
     },
     "node_modules/stashapp-api": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.20.tgz",
-      "integrity": "sha512-sN8+4P0V7jOKFd4coXZ5YqAZyOzLpo0KYjtjcKsoK9Fm9ubxTQbH2jDqFhpTSRnxrG3P1Fn6ju/UqOrAlH99pg==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.3.21.tgz",
+      "integrity": "sha512-tEAvGcUZ5tpW1dsrm8QBAA9Hyh80eeMbEOfCrCEGb4YBbh9dvaUOp82TSPREMmJ57nd4pAcSIwiZTPl7Kj6gDg==",
       "license": "MIT",
       "dependencies": {
         "graphql": "^16.11.0",

--- a/server/package.json
+++ b/server/package.json
@@ -54,6 +54,6 @@
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "stashapp-api": "^0.3.20"
+    "stashapp-api": "^0.3.21"
   }
 }


### PR DESCRIPTION
Gallery cards now display clickable performer and tag count indicators with rich tooltip popups (matching scene card behavior). Clicking the indicators navigates to filtered performer/tag lists for that gallery.

Also updates stashapp-api to v0.3.21 which adds image_path to gallery performer queries for tooltip display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)