### PR TITLE
fix: show loading spinner immediately when opening lightbox

### DIFF
--- a/client/src/components/ui/Lightbox.jsx
+++ b/client/src/components/ui/Lightbox.jsx
@@ -402,21 +402,21 @@ const Lightbox = ({
         </button>
       )}
 
+      {/* Loading spinner - centered in viewport, not in image container */}
+      {!imageLoaded && (
+        <div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none"
+          style={{ color: "var(--text-primary)" }}
+        >
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-current" />
+        </div>
+      )}
+
       {/* Image container */}
       <div
         className="relative max-w-[90vw] max-h-[90vh] flex items-center justify-center"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Loading spinner */}
-        {!imageLoaded && (
-          <div
-            className="absolute inset-0 flex items-center justify-center"
-            style={{ color: "var(--text-primary)" }}
-          >
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-current" />
-          </div>
-        )}
-
         {/* Image */}
         <img
           src={imageSrc}


### PR DESCRIPTION
Move the loading spinner from inside the image container to be positioned relative to the viewport. The spinner was not visible on open because the image container had no dimensions until the image loaded, causing the absolute-positioned spinner to have no space to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)