### PR TITLE
fix: remove hover background effect from video player controls

### DIFF
--- a/client/src/components/video-player/VideoPlayer.css
+++ b/client/src/components/video-player/VideoPlayer.css
@@ -245,17 +245,6 @@ section.video-container {
 
 
 /* ============================================================================
-   HOVER EFFECTS - Subtle YouTube-style interactions
-   ============================================================================ */
-
-.video-js .vjs-control:not(:disabled):hover,
-.video-js .vjs-control:not(:disabled):focus {
-  background: rgba(255, 255, 255, 0.1) !important;
-  border-radius: 4px !important;
-  transition: background 0.1s ease !important;
-}
-
-/* ============================================================================
    BIG PLAY BUTTON (Stash pattern - no background, no border, large icon)
    ============================================================================ */
 


### PR DESCRIPTION
Remove the light gray background that appeared when hovering over the seek bar and other video controls. This aligns with Stash's styling which doesn't apply hover backgrounds to video controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)