### PR TITLE
feat: add hierarchical filtering for tags and studios

### DIFF
--- a/client/src/components/ui/FilterControls.jsx
+++ b/client/src/components/ui/FilterControls.jsx
@@ -61,6 +61,11 @@ export const FilterControl = ({
   modifierOptions, // for multi-criterion modifiers
   modifierValue, // current modifier value
   onModifierChange, // modifier change handler
+  // Hierarchy support for tags/studios
+  supportsHierarchy = false,
+  hierarchyLabel = "Include children",
+  hierarchyValue, // current depth value (undefined/0 = off, -1 = all)
+  onHierarchyChange, // hierarchy change handler
 }) => {
   // Standardized styles for all inputs in the filter panel
   const baseInputStyle = {
@@ -154,6 +159,26 @@ export const FilterControl = ({
               multi={multi}
               placeholder={placeholder || `Select ${label}...`}
             />
+            {/* Hierarchy checkbox (for tags/studios) */}
+            {supportsHierarchy && onHierarchyChange && (
+              <label className="flex items-center cursor-pointer mt-1">
+                <input
+                  type="checkbox"
+                  checked={hierarchyValue === -1}
+                  onChange={(e) => onHierarchyChange(e.target.checked ? -1 : undefined)}
+                  className="w-4 h-4 rounded border cursor-pointer"
+                  style={{
+                    accentColor: "var(--accent-primary)",
+                  }}
+                />
+                <span
+                  className="ml-2 text-xs"
+                  style={{ color: "var(--text-secondary)" }}
+                >
+                  {hierarchyLabel}
+                </span>
+              </label>
+            )}
           </div>
         );
       case "number":

--- a/client/src/components/ui/SearchControls.jsx
+++ b/client/src/components/ui/SearchControls.jsx
@@ -862,6 +862,9 @@ const SearchControls = ({
             modifierOptions,
             modifierKey,
             defaultModifier,
+            supportsHierarchy,
+            hierarchyKey,
+            hierarchyLabel,
             ...filterProps
           } = rest;
 
@@ -875,6 +878,14 @@ const SearchControls = ({
               modifierValue={filters[modifierKey] || defaultModifier}
               onModifierChange={(value) =>
                 modifierKey && handleFilterChange(modifierKey, value)
+              }
+              supportsHierarchy={supportsHierarchy}
+              hierarchyLabel={hierarchyLabel}
+              hierarchyValue={hierarchyKey ? filters[hierarchyKey] : undefined}
+              onHierarchyChange={
+                hierarchyKey
+                  ? (value) => handleFilterChange(hierarchyKey, value)
+                  : undefined
               }
               {...filterProps}
             />

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -235,6 +235,9 @@ export const SCENE_FILTER_OPTIONS = [
     multi: false,
     defaultValue: "",
     placeholder: "Select studio...",
+    supportsHierarchy: true,
+    hierarchyKey: "studioIdDepth",
+    hierarchyLabel: "Include sub-studios",
   },
   {
     key: "tagIds",
@@ -247,6 +250,9 @@ export const SCENE_FILTER_OPTIONS = [
     modifierOptions: MULTI_MODIFIER_OPTIONS,
     modifierKey: "tagIdsModifier",
     defaultModifier: "INCLUDES_ALL",
+    supportsHierarchy: true,
+    hierarchyKey: "tagIdsDepth",
+    hierarchyLabel: "Include sub-tags",
   },
   {
     key: "groupIds",
@@ -500,6 +506,9 @@ export const PERFORMER_FILTER_OPTIONS = [
     modifierOptions: MULTI_MODIFIER_OPTIONS,
     modifierKey: "tagIdsModifier",
     defaultModifier: "INCLUDES_ALL",
+    supportsHierarchy: true,
+    hierarchyKey: "tagIdsDepth",
+    hierarchyLabel: "Include sub-tags",
   },
   {
     key: "gender",
@@ -1151,6 +1160,9 @@ export const GALLERY_FILTER_OPTIONS = [
     modifierOptions: MULTI_MODIFIER_OPTIONS,
     modifierKey: "studioIdsModifier",
     defaultModifier: "INCLUDES",
+    supportsHierarchy: true,
+    hierarchyKey: "studioIdsDepth",
+    hierarchyLabel: "Include sub-studios",
   },
   {
     key: "tagIds",
@@ -1163,6 +1175,9 @@ export const GALLERY_FILTER_OPTIONS = [
     modifierOptions: MULTI_MODIFIER_OPTIONS,
     modifierKey: "tagIdsModifier",
     defaultModifier: "INCLUDES_ALL",
+    supportsHierarchy: true,
+    hierarchyKey: "tagIdsDepth",
+    hierarchyLabel: "Include sub-tags",
   },
   {
     key: "rating",
@@ -1216,6 +1231,7 @@ export const buildSceneFilter = (filters) => {
   }
 
   // Studios: Merge permanent + UI filters
+  // Supports hierarchical filtering via depth parameter
   const studioIds = [];
   if (filters.studios?.value) {
     studioIds.push(...filters.studios.value);
@@ -1228,9 +1244,17 @@ export const buildSceneFilter = (filters) => {
       value: [...new Set(studioIds)], // Remove duplicates
       modifier: "INCLUDES",
     };
+    // Pass through depth for hierarchical filtering
+    // Priority: permanent filters > UI filters
+    if (filters.studios?.depth !== undefined) {
+      sceneFilter.studios.depth = filters.studios.depth;
+    } else if (filters.studioIdDepth !== undefined) {
+      sceneFilter.studios.depth = filters.studioIdDepth;
+    }
   }
 
   // Tags: Merge permanent + UI filters
+  // Supports hierarchical filtering via depth parameter
   const tagIds = [];
   if (filters.tags?.value) {
     tagIds.push(...filters.tags.value);
@@ -1244,6 +1268,13 @@ export const buildSceneFilter = (filters) => {
       modifier:
         filters.tagIdsModifier || filters.tags?.modifier || "INCLUDES_ALL",
     };
+    // Pass through depth for hierarchical filtering
+    // Priority: permanent filters > UI filters
+    if (filters.tags?.depth !== undefined) {
+      sceneFilter.tags.depth = filters.tags.depth;
+    } else if (filters.tagIdsDepth !== undefined) {
+      sceneFilter.tags.depth = filters.tagIdsDepth;
+    }
   }
 
   // Collections/Groups: Merge permanent + UI filters
@@ -1619,11 +1650,16 @@ export const buildPerformerFilter = (filters) => {
   }
 
   // Tags filter
+  // Supports hierarchical filtering via depth parameter
   if (filters.tagIds && filters.tagIds.length > 0) {
     performerFilter.tags = {
       value: filters.tagIds.map(String),
       modifier: filters.tagIdsModifier || "INCLUDES_ALL",
     };
+    // Pass through depth for hierarchical filtering
+    if (filters.tagIdsDepth !== undefined) {
+      performerFilter.tags.depth = filters.tagIdsDepth;
+    }
   }
 
   // Select filters with EQUALS modifier
@@ -2474,11 +2510,16 @@ export const buildGalleryFilter = (filters) => {
   }
 
   // Studio filter
+  // Supports hierarchical filtering via depth parameter
   if (filters.studioIds && filters.studioIds.length > 0) {
     galleryFilter.studios = {
       value: filters.studioIds.map(String),
       modifier: filters.studioIdsModifier || "INCLUDES",
     };
+    // Pass through depth for hierarchical filtering
+    if (filters.studioIdsDepth !== undefined) {
+      galleryFilter.studios.depth = filters.studioIdsDepth;
+    }
   }
 
   // Performers filter
@@ -2490,11 +2531,16 @@ export const buildGalleryFilter = (filters) => {
   }
 
   // Tags filter
+  // Supports hierarchical filtering via depth parameter
   if (filters.tagIds && filters.tagIds.length > 0) {
     galleryFilter.tags = {
       value: filters.tagIds.map(String),
       modifier: filters.tagIdsModifier || "INCLUDES",
     };
+    // Pass through depth for hierarchical filtering
+    if (filters.tagIdsDepth !== undefined) {
+      galleryFilter.tags.depth = filters.tagIdsDepth;
+    }
   }
 
   return galleryFilter;

--- a/server/controllers/library/images.ts
+++ b/server/controllers/library/images.ts
@@ -3,6 +3,7 @@ import { AuthenticatedRequest } from "../../middleware/auth.js";
 import { stashCacheManager } from "../../services/StashCacheManager.js";
 import { stashInstanceManager } from "../../services/StashInstanceManager.js";
 import { CriterionModifier } from "../../types/index.js";
+import { expandStudioIds, expandTagIds } from "../../utils/hierarchyUtils.js";
 import { logger } from "../../utils/logger.js";
 import { transformImage } from "../../utils/pathMapping.js";
 
@@ -109,16 +110,28 @@ export const findImages = async (req: AuthenticatedRequest, res: Response) => {
     }
 
     if (image_filter?.tags) {
-      const tagIds = new Set(image_filter.tags.value.map(String));
+      // Expand tag IDs to include descendants if depth is specified
+      const expandedTagIds = new Set(
+        expandTagIds(
+          image_filter.tags.value.map(String),
+          image_filter.tags.depth ?? 0
+        )
+      );
       matchingGalleries = matchingGalleries.filter((g) =>
-        g.tags?.some((t) => tagIds.has(String(t.id)))
+        g.tags?.some((t) => expandedTagIds.has(String(t.id)))
       );
     }
 
     if (image_filter?.studios) {
-      const studioIds = new Set(image_filter.studios.value.map(String));
+      // Expand studio IDs to include descendants if depth is specified
+      const expandedStudioIds = new Set(
+        expandStudioIds(
+          image_filter.studios.value.map(String),
+          image_filter.studios.depth ?? 0
+        )
+      );
       matchingGalleries = matchingGalleries.filter(
-        (g) => g.studio && studioIds.has(String(g.studio.id))
+        (g) => g.studio && expandedStudioIds.has(String(g.studio.id))
       );
     }
 

--- a/server/utils/hierarchyUtils.ts
+++ b/server/utils/hierarchyUtils.ts
@@ -1,0 +1,174 @@
+/**
+ * Hierarchy Utilities
+ *
+ * Functions for working with hierarchical entities (tags and studios).
+ * Used to expand filter selections to include child entities when
+ * "Include sub-tags" or "Include sub-studios" options are enabled.
+ *
+ * Depth parameter:
+ *   0 or undefined: No hierarchy (exact match only)
+ *   -1: All descendants (infinite depth)
+ *   1, 2, 3...: Specific depth levels
+ */
+
+import { stashCacheManager } from "../services/StashCacheManager.js";
+
+/**
+ * Get all descendant tag IDs for a given tag ID
+ *
+ * @param tagId - The parent tag ID to start from
+ * @param depth - How deep to traverse (-1 for infinite, 0 for none, N for N levels)
+ * @returns Set of tag IDs including the original and all descendants up to depth
+ */
+export function getDescendantTagIds(
+  tagId: string,
+  depth: number
+): Set<string> {
+  const result = new Set<string>();
+  result.add(tagId);
+
+  // depth 0 or undefined means no hierarchy
+  if (depth === 0) {
+    return result;
+  }
+
+  const allTags = stashCacheManager.getAllTags();
+
+  // Build a map of tag ID to its children for O(1) lookups
+  const childrenMap = new Map<string, string[]>();
+  for (const tag of allTags) {
+    if (tag.children && Array.isArray(tag.children)) {
+      childrenMap.set(
+        String(tag.id),
+        tag.children.map((c) => String(c.id))
+      );
+    }
+  }
+
+  // BFS to collect descendants up to depth
+  const queue: { id: string; currentDepth: number }[] = [
+    { id: tagId, currentDepth: 0 },
+  ];
+
+  while (queue.length > 0) {
+    const { id, currentDepth } = queue.shift()!;
+
+    // Check if we've reached the depth limit (depth -1 means infinite)
+    if (depth !== -1 && currentDepth >= depth) {
+      continue;
+    }
+
+    const children = childrenMap.get(id) || [];
+    for (const childId of children) {
+      if (!result.has(childId)) {
+        result.add(childId);
+        queue.push({ id: childId, currentDepth: currentDepth + 1 });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all descendant studio IDs for a given studio ID
+ *
+ * @param studioId - The parent studio ID to start from
+ * @param depth - How deep to traverse (-1 for infinite, 0 for none, N for N levels)
+ * @returns Set of studio IDs including the original and all descendants up to depth
+ */
+export function getDescendantStudioIds(
+  studioId: string,
+  depth: number
+): Set<string> {
+  const result = new Set<string>();
+  result.add(studioId);
+
+  // depth 0 or undefined means no hierarchy
+  if (depth === 0) {
+    return result;
+  }
+
+  const allStudios = stashCacheManager.getAllStudios();
+
+  // Build a map of studio ID to its children for O(1) lookups
+  const childrenMap = new Map<string, string[]>();
+  for (const studio of allStudios) {
+    if (studio.child_studios && Array.isArray(studio.child_studios)) {
+      childrenMap.set(
+        String(studio.id),
+        studio.child_studios.map((c) => String(c.id))
+      );
+    }
+  }
+
+  // BFS to collect descendants up to depth
+  const queue: { id: string; currentDepth: number }[] = [
+    { id: studioId, currentDepth: 0 },
+  ];
+
+  while (queue.length > 0) {
+    const { id, currentDepth } = queue.shift()!;
+
+    // Check if we've reached the depth limit (depth -1 means infinite)
+    if (depth !== -1 && currentDepth >= depth) {
+      continue;
+    }
+
+    const children = childrenMap.get(id) || [];
+    for (const childId of children) {
+      if (!result.has(childId)) {
+        result.add(childId);
+        queue.push({ id: childId, currentDepth: currentDepth + 1 });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Expand tag IDs to include descendants based on depth
+ *
+ * @param tagIds - Array of tag IDs to expand
+ * @param depth - How deep to traverse (-1 for infinite, 0 for none, N for N levels)
+ * @returns Array of expanded tag IDs (original + descendants)
+ */
+export function expandTagIds(tagIds: string[], depth: number): string[] {
+  if (depth === 0 || !tagIds || tagIds.length === 0) {
+    return tagIds;
+  }
+
+  const expandedSet = new Set<string>();
+  for (const tagId of tagIds) {
+    const descendants = getDescendantTagIds(String(tagId), depth);
+    for (const id of descendants) {
+      expandedSet.add(id);
+    }
+  }
+
+  return Array.from(expandedSet);
+}
+
+/**
+ * Expand studio IDs to include descendants based on depth
+ *
+ * @param studioIds - Array of studio IDs to expand
+ * @param depth - How deep to traverse (-1 for infinite, 0 for none, N for N levels)
+ * @returns Array of expanded studio IDs (original + descendants)
+ */
+export function expandStudioIds(studioIds: string[], depth: number): string[] {
+  if (depth === 0 || !studioIds || studioIds.length === 0) {
+    return studioIds;
+  }
+
+  const expandedSet = new Set<string>();
+  for (const studioId of studioIds) {
+    const descendants = getDescendantStudioIds(String(studioId), depth);
+    for (const id of descendants) {
+      expandedSet.add(id);
+    }
+  }
+
+  return Array.from(expandedSet);
+}


### PR DESCRIPTION
Add "Include sub-tags" and "Include sub-studios" toggles that expand filters to include all descendant entities. This addresses a common use case where users have organized tags/studios into hierarchies and want to filter by a parent while including all children.

Backend:
- Add hierarchyUtils.ts with recursive BFS traversal for collecting child tag/studio IDs from the cache
- Update scenes, galleries, and images controllers to expand tag/studio IDs when depth parameter is provided (-1 = all descendants)

Frontend:
- Add hierarchy checkbox support to FilterControl component
- Update SearchControls to pass hierarchy props for tag/studio filters
- Add toggles to TagDetail and StudioDetail pages with URL persistence
- Toggles only appear when the entity has children

Closes #109, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)