### PR TITLE
fix: close delete confirmation dialog after playlist deletion

### DIFF
--- a/client/src/components/pages/Playlists.jsx
+++ b/client/src/components/pages/Playlists.jsx
@@ -82,6 +82,7 @@ const Playlists = () => {
     } catch {
       showError("Failed to delete playlist");
     } finally {
+      setDeleteConfirmOpen(false);
       setPlaylistToDelete(null);
     }
   };


### PR DESCRIPTION
The confirmDelete function was setting playlistToDelete to null but not closing the dialog, causing the modal to re-render with undefined name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)