### PR TITLE
feat: User-defined custom carousels with visual query builde

### DIFF
--- a/CUSTOM_CAROUSELS_IMPLEMENTATION.md
+++ b/CUSTOM_CAROUSELS_IMPLEMENTATION.md
@@ -8,62 +8,70 @@ Allow users to create custom homepage carousels using a visual query builder. Us
 
 **Visual Query Builder** - Inspired by Plex Smart Collections and Jellyfin Smart Playlists, use a visual rule-based interface instead of JSON/code editing.
 
-**DRY Architecture** - Share filter schema between Scene Search and Carousel Builder so new scene filters automatically work in both systems.
+**DRY Architecture** - Extend existing `filterConfig.js` with metadata needed for carousel builder. Scene Search and Carousel Builder share the same filter definitions, so new filters automatically work in both systems.
 
-**Mobile-Friendly** - Full-page editor (not modal) for better mobile UX.
+**Scene Search Parity** - The carousel builder should support ALL filter capabilities from Scene Search. Users should be able to reproduce any Scene Search query as a carousel.
+
+**Mobile-Friendly** - Full-page editor (not modal) for better mobile UX. Up/down buttons for reordering (not drag-and-drop).
 
 ## UI/UX Design
 
-### Carousel Settings Page (`/settings/carousels`)
+### Carousel Settings Page (existing `/settings` page, Carousels section)
 
 **Layout:**
 - List of all carousels (hardcoded + custom)
-- Hardcoded carousels: Toggle visibility, reorder, cannot edit/delete
+- Hardcoded carousels: Toggle visibility, reorder (up/down buttons), cannot edit/delete
 - Custom carousels: Toggle visibility, reorder, edit, delete
 - "Create Custom Carousel" button (disabled if at 15 custom limit)
-- Drag-and-drop reordering for all carousels
+- Shows count: "X/15 custom carousels"
 
 **Custom Carousel Cards:**
 ```
-┌─────────────────────────────────────────┐
-│ 🎬 My Favorite Action Scenes       [≡]  │
-│ 3 rules • Sort: Random • 12 scenes      │
-│ [Edit] [Preview] [Delete] [Toggle ●]    │
-└─────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────┐
+│ [↑][↓] 🎬 My Favorite Action Scenes            [👁] │
+│        3 rules • Sort: Random                       │
+│        [Edit] [Delete]                              │
+│        ⚠️ Query failed - click Edit to fix (if broken)
+└─────────────────────────────────────────────────────┘
 ```
 
 ### Carousel Builder Page (`/settings/carousels/new` or `/settings/carousels/:id/edit`)
 
 **Header:**
+- Back button
 - Title input field
 - Icon selector (curated Lucide icon picker)
-- Back button
 
 **Query Builder:**
 ```
-Match [Any ▾] of the following rules:
-┌─────────────────────────────────────────┐
-│ [Performers ▾] [includes ▾] [Select...] [×] │
-│ [Rating ▾] [greater than ▾] [80____]   [×] │
-│ [Tags ▾] [excludes ▾] [Select...]      [×] │
-└─────────────────────────────────────────┘
+Filter Rules (ALL must match):
+┌─────────────────────────────────────────────────────┐
+│ [Performers ▾] [includes ▾] [Select...]         [×] │
+│ [Rating ▾] [greater than ▾] [80____]            [×] │
+│ [Tags ▾] [excludes ▾] [Select...]               [×] │
+└─────────────────────────────────────────────────────┘
 [+ Add Rule]
 
 Sort by: [Random ▾] [Descending ▾]
-Limit: 12 scenes (fixed)
+Limit: 12 scenes (fixed, not editable)
 
 [Preview Results] [Save Carousel] [Cancel]
 ```
 
+**Validation:**
+- Preview must succeed before Save is enabled
+- At least one rule required
+- Title required (non-empty)
+
 **Icon Selector:**
 - Grid of ~50 curated Lucide icons relevant to media browsing
-- Categories: Film, TV, Music, Gaming, Genres, Moods, etc.
-- Selected icons: Film, Heart, Star, Flame, Zap, Trophy, Calendar, Clock, Eye, Play, etc.
+- Search/filter by name
+- Selected icon highlighted
 
 **Preview Results:**
-- Opens preview modal/section showing matching scenes
-- Uses same SceneGrid component as Scene Search
-- Shows count: "Found 847 scenes matching rules (showing 12)"
+- Inline section (not modal) showing matching scenes
+- Uses same SceneCard component as Scene Search
+- Shows: "Showing 12 scenes" (no total count query)
 
 ## Architecture
 
@@ -72,15 +80,12 @@ Limit: 12 scenes (fixed)
 ```prisma
 model UserCarousel {
   id        String   @id @default(uuid())
-  userId    String
+  userId    Int
   title     String
-  icon      String   // Lucide icon name (e.g., "Film", "Heart")
-  enabled   Boolean  @default(true)
-  order     Int      // Sort position among ALL carousels
+  icon      String   @default("Film")  // Lucide icon name
 
-  // Query definition
-  matchMode String   @default("ANY") // "ANY" or "ALL"
-  rules     Json     // Array of filter rules
+  // Query definition (matches Scene Search filter format)
+  rules     Json     // Scene filter object (same format as buildSceneFilter output)
   sort      String   @default("random")
   direction String   @default("DESC")
 
@@ -90,95 +95,86 @@ model UserCarousel {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
-  @@index([userId, order])
 }
 ```
 
 **Rules JSON Structure:**
+Stored in the same format as `buildSceneFilter()` output, making it directly usable:
 ```json
-[
-  {
-    "field": "performers",
-    "modifier": "INCLUDES",
-    "value": ["performer-id-1", "performer-id-2"]
+{
+  "tags": {
+    "value": ["tag-id-1", "tag-id-2"],
+    "modifier": "INCLUDES"
   },
-  {
-    "field": "rating100",
-    "modifier": "GREATER_THAN",
-    "value": 80
+  "rating100": {
+    "value": 79,
+    "modifier": "GREATER_THAN"
   },
-  {
-    "field": "tags",
-    "modifier": "EXCLUDES",
-    "value": ["tag-id-1"]
+  "performers": {
+    "value": ["performer-id-1"],
+    "modifier": "INCLUDES"
   }
-]
+}
 ```
+
+This is the same format used by Scene Search, so no conversion needed.
+
+### ID Strategy
+
+- **Hardcoded carousels**: Use `fetchKey` strings (e.g., `"continueWatching"`, `"highRatedScenes"`)
+- **Custom carousels**: Use UUID prefixed with `"custom-"` (e.g., `"custom-a1b2c3d4-e5f6-..."`)
+- **`User.carouselPreferences`**: Single source of truth for order/visibility of ALL carousels
+  ```json
+  [
+    { "id": "continueWatching", "enabled": true, "order": 0 },
+    { "id": "custom-uuid-123", "enabled": true, "order": 1 },
+    { "id": "highRatedScenes", "enabled": false, "order": 2 }
+  ]
+  ```
 
 ### API Endpoints
 
-**Carousel Management:**
+**Carousel CRUD:**
 - `GET /api/carousels` - List user's custom carousels
-- `POST /api/carousels` - Create new carousel (max 15)
+- `POST /api/carousels` - Create new carousel (max 15 enforced)
 - `GET /api/carousels/:id` - Get single carousel
 - `PUT /api/carousels/:id` - Update carousel
 - `DELETE /api/carousels/:id` - Delete carousel
-- `PUT /api/carousels/reorder` - Bulk update order (all carousels)
 
 **Preview:**
 - `POST /api/carousels/preview` - Preview results without saving
-  - Body: `{ rules, matchMode, sort, direction }`
-  - Returns: `{ count, scenes }` (paginated to 12)
+  - Body: `{ rules, sort, direction }`
+  - Returns: `{ scenes: [...] }` (12 scenes)
 
-### Shared Filter Schema
+### Extending filterConfig.js (DRY Approach)
 
-**Location:** `client/src/utils/filterSchema.js`
+Instead of creating a new `filterSchema.js`, extend existing `SCENE_FILTER_OPTIONS` with metadata for the carousel builder:
 
-**Structure:**
 ```javascript
-export const SCENE_FILTERS = [
-  {
-    key: "performers",
-    label: "Performers",
-    type: "entity-multi",
-    modifiers: ["INCLUDES", "INCLUDES_ALL", "EXCLUDES"],
-    entityType: "performer",
-    valueComponent: "PerformerPicker"
-  },
-  {
-    key: "rating100",
-    label: "Rating",
-    type: "number",
-    modifiers: ["GREATER_THAN", "LESS_THAN", "EQUALS", "NOT_EQUALS", "BETWEEN"],
-    min: 0,
-    max: 100,
-    valueComponent: "NumberInput"
-  },
-  {
-    key: "tags",
-    label: "Tags",
-    type: "entity-multi",
-    modifiers: ["INCLUDES", "INCLUDES_ALL", "EXCLUDES"],
-    entityType: "tag",
-    valueComponent: "TagPicker"
-  },
-  // ... all other scene filters
-];
+// Add to each filter option in SCENE_FILTER_OPTIONS:
+{
+  key: "performerIds",
+  label: "Performers",
+  type: "searchable-select",
+  entityType: "performers",
+  multi: true,
+  defaultValue: [],
+  placeholder: "Select performers...",
+  modifierOptions: MULTI_MODIFIER_OPTIONS,
+  modifierKey: "performerIdsModifier",
+  defaultModifier: "INCLUDES",
 
-export const SCENE_SORT_OPTIONS = [
-  { value: "random", label: "Random" },
-  { value: "created_at", label: "Created At" },
-  { value: "rating100", label: "Rating" },
-  { value: "date", label: "Date" },
-  { value: "o_counter", label: "O Counter" },
-  // ... all other sort options from filterConfig.js
-];
+  // NEW: Carousel builder metadata
+  carouselSupported: true,  // Include in carousel builder
+  carouselLabel: "Performers",  // Display name in rule dropdown
+}
 ```
 
-**Migration from `filterConfig.js`:**
-1. Extract filter definitions into structured schema
-2. Add metadata for carousel builder (type, modifiers, value component)
-3. Update Scene Search to consume shared schema (ensure no regressions)
+**Helper function to get carousel-compatible filters:**
+```javascript
+export const getCarouselFilters = () =>
+  SCENE_FILTER_OPTIONS.filter(f => f.carouselSupported !== false && f.type !== 'section-header');
+```
 
 ### Frontend Components
 
@@ -186,539 +182,273 @@ export const SCENE_SORT_OPTIONS = [
 ```
 client/src/components/
   carousel-builder/
-    CarouselBuilder.jsx       - Main editor page
-    CarouselList.jsx          - Settings list view
-    FilterBuilder.jsx         - Rule builder container
-    FilterRule.jsx            - Single rule editor
-    FilterValueSelector.jsx   - Value input (switches based on filter type)
+    CarouselBuilder.jsx       - Main editor page (full-page)
+    CarouselPreview.jsx       - Preview results section
     IconPicker.jsx            - Lucide icon grid selector
-    PreviewModal.jsx          - Preview results modal
+    RuleBuilder.jsx           - Container for filter rules
+    RuleRow.jsx               - Single rule editor row
 
-  filter-components/          - Shared with Scene Search
-    PerformerPicker.jsx
-    TagPicker.jsx
-    StudioPicker.jsx
-    NumberInput.jsx
-    DatePicker.jsx
+  settings/
+    CarouselSettings.jsx      - Update existing to handle custom carousels
 ```
 
-**FilterBuilder Component:**
-```jsx
-<FilterBuilder
-  rules={rules}
-  matchMode={matchMode}
-  onRulesChange={setRules}
-  onMatchModeChange={setMatchMode}
-/>
-```
-
-**FilterRule Component:**
-```jsx
-<FilterRule
-  rule={rule}
-  onChange={handleRuleChange}
-  onRemove={handleRuleRemove}
-  filterSchema={SCENE_FILTERS}
-/>
-```
-
-**Icon Picker Component:**
-- Grid of 50-60 curated Lucide icons
-- Search/filter by name
-- Selected icon highlighted
-- Preview shows icon + carousel title
-
-**Curated Icon List:**
-```javascript
-export const CAROUSEL_ICONS = [
-  // Film & Video
-  "Film", "Video", "Play", "PlayCircle", "Clapperboard",
-
-  // Favorites & Collections
-  "Heart", "Star", "Bookmark", "Award", "Trophy",
-
-  // Time & Recency
-  "Clock", "Calendar", "TrendingUp", "Zap", "Flame",
-
-  // Moods & Genres
-  "Smile", "Frown", "Angry", "Meh", "PartyPopper",
-
-  // Discovery
-  "Eye", "Sparkles", "Target", "Compass", "Search",
-
-  // Quality & Rating
-  "ThumbsUp", "Crown", "Shield", "Diamond", "Gem",
-
-  // Media Types
-  "Users", "User", "Building", "Tag", "Folder",
-
-  // Additional
-  "Camera", "Tv", "Monitor", "Smartphone", "Headphones"
-];
-```
+**Reuse existing filter components:**
+- `SearchableSelect` - For entity pickers (performers, tags, studios, groups)
+- Range inputs, date pickers, etc. from Scene Search
 
 ### Homepage Integration
 
-**Updated Flow:**
+**Updated Home.jsx flow:**
 
-1. **Fetch All Carousels:**
+1. Fetch user settings (includes `carouselPreferences`)
+2. Fetch custom carousels from `/api/carousels`
+3. Merge hardcoded + custom carousel definitions
+4. Sort by user preferences
+5. Filter to enabled only
+6. Render each carousel, handling errors gracefully
+
 ```javascript
-// Fetch hardcoded definitions
-const hardcodedCarousels = CAROUSEL_DEFINITIONS;
-
-// Fetch user's custom carousels
-const customCarousels = await fetch('/api/carousels');
-
-// Merge and sort by user preferences
-const allCarousels = [...hardcodedCarousels, ...customCarousels]
-  .map(def => ({
-    ...def,
-    preference: userCarouselPrefs[def.id] || { enabled: true, order: 999 }
-  }))
-  .filter(def => def.preference.enabled)
-  .sort((a, b) => a.preference.order - b.preference.order);
-```
-
-2. **Dynamic Query Building:**
-```javascript
-// For custom carousels, build query from rules
-carouselQueries[customCarousel.id] = async () => {
-  const filter = buildFilterFromRules({
-    rules: customCarousel.rules,
-    matchMode: customCarousel.matchMode,
-    sort: customCarousel.sort,
-    direction: customCarousel.direction,
-    page: 1,
-    per_page: 12
-  });
-
-  const response = await libraryApi.findScenes(filter);
-  return response?.findScenes?.scenes || [];
-};
-```
-
-3. **buildFilterFromRules Function:**
-```javascript
-function buildFilterFromRules({ rules, matchMode, sort, direction, page, per_page }) {
-  const scene_filter = {};
-
-  // Convert rules array to scene_filter object
-  rules.forEach(rule => {
-    scene_filter[rule.field] = {
-      modifier: rule.modifier,
-      value: rule.value,
-      ...(rule.value2 && { value2: rule.value2 }) // For BETWEEN modifier
-    };
-  });
-
-  // Add match mode (ANY/ALL) to filter
-  // Backend interprets this for multi-rule combinations
-  scene_filter._matchMode = matchMode;
-
-  return {
-    filter: {
-      page,
-      per_page,
-      sort,
-      direction
-    },
-    scene_filter
-  };
-}
-```
-
-### Backend Implementation
-
-**Carousel Controller** (`server/controllers/carousel.ts`):
-
-```typescript
-// List user's carousels
-export const listCarousels = async (req: AuthenticatedRequest, res: Response) => {
-  const carousels = await prisma.userCarousel.findMany({
-    where: { userId: req.user!.id },
-    orderBy: { order: 'asc' }
-  });
-  res.json(carousels);
-};
-
-// Create carousel
-export const createCarousel = async (req: AuthenticatedRequest, res: Response) => {
-  const { title, icon, rules, matchMode, sort, direction } = req.body;
-
-  // Check max limit (15)
-  const count = await prisma.userCarousel.count({
-    where: { userId: req.user!.id }
-  });
-
-  if (count >= 15) {
-    return res.status(400).json({ error: 'Maximum 15 custom carousels allowed' });
+// For custom carousels, query function is built dynamically:
+const buildCustomCarouselQuery = (carousel) => async () => {
+  try {
+    const response = await libraryApi.findScenes({
+      filter: {
+        page: 1,
+        per_page: 12,
+        sort: carousel.sort,
+        direction: carousel.direction,
+      },
+      scene_filter: carousel.rules,
+    });
+    return { scenes: response?.findScenes?.scenes || [], error: null };
+  } catch (error) {
+    return { scenes: [], error: error.message };
   }
-
-  // Get next order position
-  const maxOrder = await prisma.userCarousel.findFirst({
-    where: { userId: req.user!.id },
-    orderBy: { order: 'desc' },
-    select: { order: true }
-  });
-
-  const carousel = await prisma.userCarousel.create({
-    data: {
-      userId: req.user!.id,
-      title,
-      icon: icon || 'Film',
-      rules,
-      matchMode: matchMode || 'ANY',
-      sort: sort || 'random',
-      direction: direction || 'DESC',
-      order: (maxOrder?.order ?? -1) + 1
-    }
-  });
-
-  res.json(carousel);
-};
-
-// Preview carousel results
-export const previewCarousel = async (req: AuthenticatedRequest, res: Response) => {
-  const { rules, matchMode, sort, direction } = req.body;
-
-  // Build filter from rules (same as homepage would)
-  const filter = buildFilterFromRules({
-    rules,
-    matchMode,
-    sort,
-    direction,
-    page: 1,
-    per_page: 12
-  });
-
-  // Execute scene query (reuse existing findScenes controller)
-  const result = await findScenesWithFilter(req.user!.id, filter);
-
-  res.json({
-    count: result.count,
-    scenes: result.scenes
-  });
 };
 ```
 
-**Scene Filter Updates** (`server/controllers/library/scenes.ts`):
+**Error handling on homepage:**
+- If a custom carousel query fails, show friendly error card:
+  ```
+  ┌─────────────────────────────────────────────────────┐
+  │ ⚠️ "My Action Scenes" couldn't load                 │
+  │ The query may need to be updated.                   │
+  │ [Edit Carousel]                                     │
+  └─────────────────────────────────────────────────────┘
+  ```
 
-Add support for `_matchMode` in `scene_filter`:
+### Preference Migration
 
-```typescript
-// Current: ALL filters are AND-ed together
-// Enhancement: Support ANY (OR) logic
-
-if (scene_filter._matchMode === 'ANY') {
-  // Match if ANY filter passes
-  filteredScenes = allScenes.filter(scene => {
-    return Object.entries(scene_filter)
-      .filter(([key]) => key !== '_matchMode')
-      .some(([filterKey, filterValue]) => {
-        return applyFilter(scene, filterKey, filterValue);
-      });
-  });
-} else {
-  // Default: Match if ALL filters pass (existing logic)
-  filteredScenes = applyAllFilters(allScenes, scene_filter);
-}
-```
-
-### User Preference Storage
-
-**Merged Carousel Preferences:**
-
-Update `User.carouselPreferences` JSON structure:
-
-```json
-{
-  "hardcoded-carousel-id": {
-    "enabled": true,
-    "order": 0
-  },
-  "custom-carousel-uuid-1": {
-    "enabled": true,
-    "order": 1
-  },
-  "custom-carousel-uuid-2": {
-    "enabled": false,
-    "order": 2
-  }
-}
-```
-
-**Reordering:**
-- Single endpoint updates ALL carousel orders (hardcoded + custom)
-- `PUT /api/user/settings/carousel-order`
-- Body: `{ order: ["id1", "id2", "id3", ...] }`
+Update `migrateCarouselPreferences()` in `carousels.js`:
+- Keep existing logic for hardcoded carousels
+- Preserve custom carousel preferences (don't remove unknown IDs that start with "custom-")
+- Clean up preferences for deleted custom carousels (carousel no longer exists in DB)
 
 ## Implementation Phases
 
-### Phase 1: Foundation (Database & API)
+### Phase 1: Database & API Foundation
 
 **Tasks:**
-1. Create `UserCarousel` Prisma model
-2. Generate migration
-3. Create carousel CRUD endpoints
-4. Create preview endpoint
-5. Add max carousel limit (15) validation
+1. Add `UserCarousel` model to Prisma schema
+2. Add `userCarousels` relation to User model
+3. Generate and run migration
+4. Create `server/controllers/carousel.ts` with CRUD operations
+5. Create `server/routes/carousel.ts` and wire up routes
+6. Add preview endpoint
+7. Add max 15 carousel limit validation
+8. Add unit tests for carousel controller
 
 **Files:**
 - `server/prisma/schema.prisma`
-- `server/controllers/carousel.ts`
-- `server/routes/carousel.ts`
+- `server/controllers/carousel.ts` (new)
+- `server/routes/carousel.ts` (new)
+- `server/api.ts` (add routes)
 
-### Phase 2: Shared Filter Schema (DRY)
+### Phase 2: Filter Schema Extension (DRY)
 
 **Tasks:**
-6. Extract filter definitions from `filterConfig.js`
-7. Create `filterSchema.js` with structured metadata
-8. Update Scene Search to consume shared schema
-9. Test Scene Search for regressions
-10. Add unit tests for filter schema
+9. Add `carouselSupported` flag to all `SCENE_FILTER_OPTIONS` entries
+10. Add `getCarouselFilters()` helper function
+11. Clean up dead carousel metadata in `CarouselSettings.jsx` (longScenes, highBitrateScenes, barelyLegalScenes)
+12. Add unit tests for filter schema helpers
+13. Verify Scene Search still works (regression test)
 
 **Files:**
-- `client/src/utils/filterSchema.js`
-- `client/src/components/scene-search/SceneSearch.jsx` (update)
+- `client/src/utils/filterConfig.js` (extend)
+- `client/src/components/settings/CarouselSettings.jsx` (cleanup)
 
 ### Phase 3: Carousel Builder UI
 
 **Tasks:**
-11. Create `IconPicker` component with curated Lucide icons
-12. Create `FilterBuilder` component (rule container)
-13. Create `FilterRule` component (single rule editor)
-14. Create `FilterValueSelector` (switches on filter type)
-15. Create `CarouselBuilder` page (main editor)
-16. Add form validation and error handling
-17. Wire up save/cancel/preview actions
+14. Create `IconPicker.jsx` with curated Lucide icon list
+15. Create `RuleRow.jsx` - single filter rule editor
+16. Create `RuleBuilder.jsx` - container managing multiple rules
+17. Create `CarouselPreview.jsx` - preview results display
+18. Create `CarouselBuilder.jsx` - main full-page editor
+19. Add route `/settings/carousels/new` and `/settings/carousels/:id/edit`
+20. Wire up Preview button (must succeed to enable Save)
+21. Wire up Save/Cancel actions
+22. Add form validation (title required, at least one rule)
 
 **Files:**
-- `client/src/components/carousel-builder/IconPicker.jsx`
-- `client/src/components/carousel-builder/FilterBuilder.jsx`
-- `client/src/components/carousel-builder/FilterRule.jsx`
-- `client/src/components/carousel-builder/FilterValueSelector.jsx`
-- `client/src/components/carousel-builder/CarouselBuilder.jsx`
+- `client/src/components/carousel-builder/IconPicker.jsx` (new)
+- `client/src/components/carousel-builder/RuleRow.jsx` (new)
+- `client/src/components/carousel-builder/RuleBuilder.jsx` (new)
+- `client/src/components/carousel-builder/CarouselPreview.jsx` (new)
+- `client/src/components/carousel-builder/CarouselBuilder.jsx` (new)
+- `client/src/App.jsx` (add routes)
 
 ### Phase 4: Carousel Management UI
 
 **Tasks:**
-18. Create `CarouselList` component (settings page)
-19. Add drag-and-drop reordering (react-beautiful-dnd or @dnd-kit)
-20. Add edit/delete/toggle actions
-21. Add "Create Custom Carousel" button
-22. Display carousel count (X/15)
-23. Add confirmation modals for delete
+23. Update `CarouselSettings.jsx` to fetch and display custom carousels
+24. Add Edit/Delete buttons for custom carousels
+25. Add "Create Custom Carousel" button with count (X/15)
+26. Add delete confirmation modal
+27. Add broken carousel indicator (warning icon + "Edit to fix")
+28. Integrate custom carousel IDs into reorder/toggle logic
+29. Update preference save to include custom carousel IDs
 
 **Files:**
-- `client/src/components/carousel-builder/CarouselList.jsx`
-- `client/src/components/pages/Settings.jsx` (add route)
+- `client/src/components/settings/CarouselSettings.jsx` (major update)
 
 ### Phase 5: Homepage Integration
 
 **Tasks:**
-24. Update `CAROUSEL_DEFINITIONS` to include dynamic fetch
-25. Fetch custom carousels from API
-26. Merge hardcoded + custom carousels
-27. Update `useHomeCarouselQueries` for dynamic query building
-28. Add `buildFilterFromRules` utility function
-29. Handle carousel loading/error states
-30. Update carousel preference migration logic
+30. Fetch custom carousels in `Home.jsx`
+31. Merge hardcoded + custom carousels
+32. Build dynamic query functions for custom carousels
+33. Add error state rendering for failed carousels
+34. Update `migrateCarouselPreferences()` to handle custom carousel IDs
+35. Add "Edit Carousel" link from error state
+36. Test carousel rendering with various rule combinations
 
 **Files:**
-- `client/src/constants/carousels.js` (update)
-- `client/src/hooks/useHomeCarouselQueries.js` (update)
 - `client/src/components/pages/Home.jsx` (update)
-- `client/src/utils/carouselHelpers.js` (new)
+- `client/src/constants/carousels.js` (update migration)
+- `client/src/hooks/useHomeCarouselQueries.js` (may need updates)
 
-### Phase 6: Backend Filter Enhancement
-
-**Tasks:**
-31. Add `_matchMode` support to scene filtering pipeline
-32. Implement ANY (OR) logic for rules
-33. Test with various rule combinations
-34. Verify user restrictions still apply correctly
-35. Test performance with expensive filters
-
-**Files:**
-- `server/controllers/library/scenes.ts` (update)
-
-### Phase 7: Testing & Polish
+### Phase 6: Testing & Polish
 
 **Tasks:**
-36. Test carousel creation with all filter types
-37. Test carousel editing and deletion
-38. Test reordering (drag-and-drop)
-39. Test preview functionality
-40. Test max carousel limit enforcement
-41. Test with user restrictions and hidden entities
-42. Mobile responsiveness testing
-43. Add loading states and error handling
-44. Add empty states ("No custom carousels yet")
+37. Test carousel creation with all filter types
+38. Test carousel editing and deletion
+39. Test reordering (up/down buttons)
+40. Test preview functionality
+41. Test max 15 carousel limit enforcement
+42. Test with user content restrictions
+43. Test with hidden entities
+44. Test broken carousel handling (delete referenced entity)
+45. Mobile responsiveness testing
+46. Add loading states
+47. Add empty states ("No custom carousels yet")
+48. Final regression test on Scene Search
 
-## Data Flow Examples
+## Error Handling Strategy
 
-### Example 1: Creating "Best Action Scenes" Carousel
+### Builder Errors
+- **Preview fails**: Show error message, keep Save disabled
+- **Save fails**: Show error toast, don't navigate away
+- **Invalid rules**: Validation prevents save
 
-**User Actions:**
-1. Goes to Settings → Carousels
-2. Clicks "Create Custom Carousel"
-3. Enters title: "Best Action Scenes"
-4. Selects icon: "Zap"
-5. Adds rules:
-   - Tags includes "Action"
-   - Rating greater than 80
-6. Sets sort: "Rating" DESC
-7. Clicks "Preview Results" → sees 847 matching scenes
-8. Clicks "Save Carousel"
+### Homepage Errors
+- **Query fails**: Show friendly error card with "Edit Carousel" link
+- **Carousel deleted but in preferences**: Clean up on next preference save
 
-**Backend:**
-```sql
-INSERT INTO UserCarousel (
-  id, userId, title, icon, rules, matchMode, sort, direction, order
-) VALUES (
-  'uuid-123',
-  'user-456',
-  'Best Action Scenes',
-  'Zap',
-  '[{"field":"tags","modifier":"INCLUDES","value":["tag-action"]},{"field":"rating100","modifier":"GREATER_THAN","value":80}]',
-  'ALL',
-  'rating100',
-  'DESC',
-  5
-);
-```
+### Settings Errors
+- **Broken carousel**: Show warning icon, "Query failed - Edit to fix"
+- **Load fails**: Show error message, retry button
 
-**Homepage Rendering:**
+## Curated Icon List
+
 ```javascript
-const customCarousel = {
-  id: 'uuid-123',
-  title: 'Best Action Scenes',
-  icon: 'Zap',
-  fetchKey: 'custom-uuid-123' // Generated
-};
+export const CAROUSEL_ICONS = [
+  // Film & Video
+  "Film", "Video", "Play", "PlayCircle", "Clapperboard", "Tv", "Monitor",
 
-carouselQueries['custom-uuid-123'] = async () => {
-  const filter = {
-    filter: { page: 1, per_page: 12, sort: 'rating100', direction: 'DESC' },
-    scene_filter: {
-      tags: { modifier: 'INCLUDES', value: ['tag-action'] },
-      rating100: { modifier: 'GREATER_THAN', value: 80 },
-      _matchMode: 'ALL'
-    }
-  };
+  // Favorites & Collections
+  "Heart", "Star", "Bookmark", "Award", "Trophy", "Crown", "Gem",
 
-  const response = await libraryApi.findScenes(filter);
-  return response?.findScenes?.scenes || [];
-};
+  // Time & Recency
+  "Clock", "Calendar", "TrendingUp", "Zap", "Flame", "Hourglass",
+
+  // Discovery & Search
+  "Eye", "Sparkles", "Target", "Compass", "Search", "Filter",
+
+  // Quality & Rating
+  "ThumbsUp", "ThumbsDown", "Shield", "Diamond", "Medal",
+
+  // People & Groups
+  "Users", "User", "UserCheck", "UsersRound",
+
+  // Organization
+  "Building", "Tag", "Folder", "FolderHeart", "Library", "Layers",
+
+  // Misc Media
+  "Camera", "Headphones", "Music", "Mic", "Radio",
+
+  // Actions & States
+  "Check", "X", "AlertCircle", "Info", "HelpCircle",
+
+  // Fun & Mood
+  "Smile", "PartyPopper", "Gift", "Cake", "Sun", "Moon"
+];
 ```
-
-### Example 2: Editing Existing Carousel
-
-**User Actions:**
-1. Goes to Settings → Carousels
-2. Clicks "Edit" on "Best Action Scenes"
-3. Changes icon to "Flame"
-4. Adds rule: O Counter greater than 0
-5. Changes sort to "Random"
-6. Clicks "Save"
-
-**API Call:**
-```
-PUT /api/carousels/uuid-123
-Body: {
-  title: "Best Action Scenes",
-  icon: "Flame",
-  rules: [
-    { field: "tags", modifier: "INCLUDES", value: ["tag-action"] },
-    { field: "rating100", modifier: "GREATER_THAN", value: 80 },
-    { field: "o_counter", modifier: "GREATER_THAN", value: 0 }
-  ],
-  matchMode: "ALL",
-  sort: "random",
-  direction: "DESC"
-}
-```
-
-## Key Design Decisions
-
-### 1. Separate Hardcoded vs Custom Carousels
-- Hardcoded carousels cannot be edited/deleted (only toggle visibility)
-- Custom carousels fully editable
-- Both share same order/visibility preference system
-
-### 2. Fixed 12-Scene Limit
-- Keeps homepage consistent and performant
-- Matches existing carousel behavior
-- Users can click carousel to see full search results
-
-### 3. Random Sort Default
-- Provides discovery and variety
-- Different scenes shown each page load
-- Users can override with any sort option
-
-### 4. Full-Page Builder (Not Modal)
-- Better mobile UX with more space
-- Easier to manage complex rule sets
-- Follows settings pattern (full-page editors)
-
-### 5. Curated Icon Set
-- ~50-60 relevant Lucide icons
-- Prevents overwhelming choice
-- Ensures icons make sense for media context
-
-### 6. Manual Preview (Not Auto)
-- Reduces API calls during editing
-- User controls when to test query
-- Shows full count + sample results
-
-### 7. 15 Carousel Maximum
-- Prevents homepage from becoming overwhelming
-- Encourages thoughtful curation
-- Can be increased if needed
-
-## Future Enhancements
-
-**Phase 2 Features (Not in Initial Release):**
-- Carousel templates (pre-built popular queries)
-- Duplicate carousel
-- Export/import carousel JSON
-- Carousel analytics (views, clicks)
-- Scheduled carousels (time-based visibility)
-- Shared carousels between users (admin-created)
 
 ## Testing Checklist
 
+### Carousel Builder
 - [ ] Create carousel with single rule
-- [ ] Create carousel with multiple rules (ANY mode)
-- [ ] Create carousel with multiple rules (ALL mode)
-- [ ] Test all filter types (entity, number, date, boolean)
-- [ ] Test all modifiers (INCLUDES, EXCLUDES, GREATER_THAN, etc.)
-- [ ] Edit existing carousel
-- [ ] Delete carousel
-- [ ] Reorder carousels (drag-and-drop)
-- [ ] Toggle carousel visibility
-- [ ] Test max 15 carousel limit
-- [ ] Preview carousel results
-- [ ] Test random sort
-- [ ] Test with user restrictions
-- [ ] Test with hidden entities
-- [ ] Test mobile responsiveness
-- [ ] Test carousel on homepage
-- [ ] Test empty states
-- [ ] Test error handling
-- [ ] Test icon picker
-- [ ] Verify Scene Search still works (no regressions)
+- [ ] Create carousel with multiple rules (all filter types)
+- [ ] Test each filter type works correctly
+- [ ] Test each modifier works correctly
+- [ ] Preview shows correct results
+- [ ] Save disabled until preview succeeds
+- [ ] Edit existing carousel loads correctly
+- [ ] Cancel returns without saving
+- [ ] Icon picker works
+- [ ] Title validation (required)
+- [ ] Sort/direction options work
 
-## Success Metrics
+### Carousel Management
+- [ ] List shows hardcoded + custom carousels
+- [ ] Reorder with up/down buttons works
+- [ ] Toggle visibility works
+- [ ] Edit button navigates to builder
+- [ ] Delete button shows confirmation
+- [ ] Delete removes carousel
+- [ ] Max 15 limit enforced
+- [ ] Broken carousel shows warning
 
-- Users can create custom carousels without coding
-- Filter changes in Scene Search automatically work in carousel builder
-- Homepage loads efficiently with custom carousels
-- Mobile-friendly carousel builder
-- User restrictions and hidden entities respected in custom carousels
+### Homepage
+- [ ] Custom carousels render correctly
+- [ ] Random sort shows different scenes on refresh
+- [ ] Error state shows for broken carousels
+- [ ] "Edit Carousel" link works from error state
+- [ ] Disabled carousels don't show
+- [ ] Order matches user preferences
+
+### Regression Tests
+- [ ] Scene Search still works with all filters
+- [ ] Hardcoded carousels still work
+- [ ] Existing carousel preferences preserved
+- [ ] Content restrictions apply to custom carousels
+- [ ] Hidden entities excluded from custom carousels
+
+### Mobile
+- [ ] Builder UI responsive
+- [ ] Icon picker usable on mobile
+- [ ] Rule rows don't overflow
+- [ ] Preview scrollable
 
 ---
 
 **Document Created:** 2025-01-21
-**Implementation Status:** Planning Phase
-**Estimated Effort:** Large (2-3 weeks full-time)
+**Document Updated:** 2025-01-26
+**Implementation Status:** Planning Phase - Refined
+**Key Decisions:**
+- ALL mode only (matches Scene Search behavior)
+- Expose all Scene Search filters
+- Up/down buttons for reordering (not drag-and-drop)
+- Preview must succeed before save enabled
+- Graceful error handling on homepage

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -42,6 +42,9 @@ const WatchHistory = lazy(() => import("./components/pages/WatchHistory.jsx"));
 const HiddenItemsPage = lazy(
   () => import("./components/pages/HiddenItemsPage.jsx")
 );
+const CarouselBuilder = lazy(
+  () => import("./components/carousel-builder/CarouselBuilder.jsx")
+);
 
 // Loading fallback component
 const PageLoader = () => (
@@ -257,6 +260,22 @@ const AppContent = () => {
             element={
               <GlobalLayout>
                 <Scene />
+              </GlobalLayout>
+            }
+          />
+          <Route
+            path="/my-settings/carousels/new"
+            element={
+              <GlobalLayout>
+                <CarouselBuilder />
+              </GlobalLayout>
+            }
+          />
+          <Route
+            path="/my-settings/carousels/:id/edit"
+            element={
+              <GlobalLayout>
+                <CarouselBuilder />
               </GlobalLayout>
             }
           />

--- a/client/src/components/carousel-builder/CarouselBuilder.jsx
+++ b/client/src/components/carousel-builder/CarouselBuilder.jsx
@@ -1,0 +1,605 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import * as LucideIcons from "lucide-react";
+import {
+  ArrowLeft,
+  Save,
+  Eye,
+  Plus,
+  Trash2,
+  AlertCircle,
+  Loader2,
+} from "lucide-react";
+import { Button } from "../ui/index.js";
+import IconPickerButton from "./IconPickerButton.jsx";
+import RuleEditor from "./RuleEditor.jsx";
+import CarouselPreview from "./CarouselPreview.jsx";
+import { libraryApi } from "../../services/api.js";
+import {
+  SCENE_SORT_OPTIONS,
+  CAROUSEL_FILTER_DEFINITIONS,
+  buildSceneFilter,
+  carouselRulesToFilterState,
+} from "../../utils/filterConfig.js";
+
+/**
+ * CarouselBuilder Component
+ * Full-page editor for creating and editing custom carousels.
+ * Supports adding filter rules, previewing results, and saving.
+ */
+const CarouselBuilder = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditing = Boolean(id);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [icon, setIcon] = useState("Film");
+  const [rules, setRules] = useState([]); // Array of rule objects
+  const [sort, setSort] = useState("random");
+  const [direction, setDirection] = useState("DESC");
+
+  // UI state
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewScenes, setPreviewScenes] = useState(null);
+  const [previewError, setPreviewError] = useState(null);
+  const [error, setError] = useState(null);
+  const [previewValid, setPreviewValid] = useState(false);
+
+  // Load existing carousel if editing
+  useEffect(() => {
+    if (!isEditing || !id) return;
+
+    const loadCarousel = async () => {
+      setLoading(true);
+      try {
+        const { carousel } = await libraryApi.getCarousel(id);
+        setTitle(carousel.title);
+        setIcon(carousel.icon);
+        setSort(carousel.sort);
+        setDirection(carousel.direction);
+
+        // Convert stored rules back to editable format
+        const filterState = carouselRulesToFilterState(carousel.rules);
+        const ruleList = convertFilterStateToRules(filterState);
+        setRules(ruleList);
+      } catch (err) {
+        setError(err.message || "Failed to load carousel");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadCarousel();
+  }, [id, isEditing]);
+
+  /**
+   * Convert filter state (flat object) to rule array for the editor
+   */
+  const convertFilterStateToRules = (filterState) => {
+    const ruleList = [];
+
+    // Entity selection rules
+    if (filterState.performerIds?.length > 0) {
+      ruleList.push({
+        id: crypto.randomUUID(),
+        filterKey: "performerIds",
+        value: filterState.performerIds,
+        modifier: filterState.performerIdsModifier || "INCLUDES",
+      });
+    }
+
+    if (filterState.studioId) {
+      ruleList.push({
+        id: crypto.randomUUID(),
+        filterKey: "studioId",
+        value: filterState.studioId,
+        depth: filterState.studioIdDepth,
+      });
+    }
+
+    if (filterState.tagIds?.length > 0) {
+      ruleList.push({
+        id: crypto.randomUUID(),
+        filterKey: "tagIds",
+        value: filterState.tagIds,
+        modifier: filterState.tagIdsModifier || "INCLUDES_ALL",
+        depth: filterState.tagIdsDepth,
+      });
+    }
+
+    if (filterState.groupIds?.length > 0) {
+      ruleList.push({
+        id: crypto.randomUUID(),
+        filterKey: "groupIds",
+        value: filterState.groupIds,
+        modifier: filterState.groupIdsModifier || "INCLUDES",
+      });
+    }
+
+    // Range rules
+    ["rating", "oCount", "duration", "playCount", "playDuration", "performerCount", "performerAge", "bitrate"].forEach(
+      (key) => {
+        if (filterState[key]?.min !== undefined || filterState[key]?.max !== undefined) {
+          ruleList.push({
+            id: crypto.randomUUID(),
+            filterKey: key,
+            value: filterState[key],
+          });
+        }
+      }
+    );
+
+    // Boolean rules
+    ["favorite", "performerFavorite", "studioFavorite", "tagFavorite"].forEach((key) => {
+      if (filterState[key] === true) {
+        ruleList.push({
+          id: crypto.randomUUID(),
+          filterKey: key,
+          value: true,
+        });
+      }
+    });
+
+    // Resolution
+    if (filterState.resolution) {
+      ruleList.push({
+        id: crypto.randomUUID(),
+        filterKey: "resolution",
+        value: filterState.resolution,
+        modifier: filterState.resolutionModifier || "EQUALS",
+      });
+    }
+
+    // Text rules
+    ["title", "details"].forEach((key) => {
+      if (filterState[key]) {
+        ruleList.push({
+          id: crypto.randomUUID(),
+          filterKey: key,
+          value: filterState[key],
+        });
+      }
+    });
+
+    // Date range rules
+    ["date", "createdAt", "lastPlayedAt"].forEach((key) => {
+      if (filterState[key]?.min || filterState[key]?.max) {
+        ruleList.push({
+          id: crypto.randomUUID(),
+          filterKey: key,
+          value: filterState[key],
+        });
+      }
+    });
+
+    return ruleList;
+  };
+
+  /**
+   * Convert rule array back to filter state for buildSceneFilter
+   */
+  const convertRulesToFilterState = useCallback(() => {
+    const filterState = {};
+
+    rules.forEach((rule) => {
+      const def = CAROUSEL_FILTER_DEFINITIONS.find((d) => d.key === rule.filterKey);
+      if (!def) return;
+
+      switch (def.type) {
+        case "searchable-select":
+          if (def.multi) {
+            filterState[rule.filterKey] = rule.value || [];
+            if (def.modifierOptions && rule.modifier) {
+              filterState[`${rule.filterKey}Modifier`] = rule.modifier;
+            }
+          } else {
+            filterState[rule.filterKey] = rule.value || "";
+          }
+          if (def.supportsHierarchy && rule.depth !== undefined) {
+            filterState[`${rule.filterKey}Depth`] = rule.depth;
+          }
+          break;
+
+        case "range":
+          filterState[rule.filterKey] = rule.value || {};
+          break;
+
+        case "checkbox":
+          filterState[rule.filterKey] = rule.value === true;
+          break;
+
+        case "select":
+          filterState[rule.filterKey] = rule.value || "";
+          if (def.modifierOptions && rule.modifier) {
+            filterState[`${rule.filterKey}Modifier`] = rule.modifier;
+          }
+          break;
+
+        case "text":
+          filterState[rule.filterKey] = rule.value || "";
+          break;
+
+        case "date-range":
+          filterState[rule.filterKey] = rule.value || {};
+          break;
+      }
+    });
+
+    return filterState;
+  }, [rules]);
+
+  /**
+   * Add a new rule
+   */
+  const addRule = () => {
+    const usedKeys = new Set(rules.map((r) => r.filterKey));
+    const availableFilter = CAROUSEL_FILTER_DEFINITIONS.find((f) => !usedKeys.has(f.key));
+
+    if (!availableFilter) {
+      return; // All filters already used
+    }
+
+    const newRule = {
+      id: crypto.randomUUID(),
+      filterKey: availableFilter.key,
+      value: availableFilter.type === "checkbox" ? true : availableFilter.multi ? [] : "",
+      modifier: availableFilter.defaultModifier,
+    };
+
+    setRules([...rules, newRule]);
+    setPreviewValid(false);
+    setPreviewScenes(null);
+  };
+
+  /**
+   * Update a rule
+   */
+  const updateRule = (ruleId, updates) => {
+    setRules(rules.map((r) => (r.id === ruleId ? { ...r, ...updates } : r)));
+    setPreviewValid(false);
+    setPreviewScenes(null);
+  };
+
+  /**
+   * Remove a rule
+   */
+  const removeRule = (ruleId) => {
+    setRules(rules.filter((r) => r.id !== ruleId));
+    setPreviewValid(false);
+    setPreviewScenes(null);
+  };
+
+  /**
+   * Preview the carousel results
+   */
+  const handlePreview = async () => {
+    if (rules.length === 0) {
+      setPreviewError("Add at least one rule to preview");
+      return;
+    }
+
+    setPreviewing(true);
+    setPreviewError(null);
+
+    try {
+      const filterState = convertRulesToFilterState();
+      const apiRules = buildSceneFilter(filterState);
+
+      const { scenes } = await libraryApi.previewCarousel({
+        rules: apiRules,
+        sort,
+        direction,
+      });
+
+      setPreviewScenes(scenes);
+      setPreviewValid(true);
+      setPreviewError(null);
+    } catch (err) {
+      setPreviewError(err.message || "Failed to preview carousel");
+      setPreviewValid(false);
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  /**
+   * Save the carousel
+   */
+  const handleSave = async () => {
+    if (!title.trim()) {
+      setError("Title is required");
+      return;
+    }
+
+    if (rules.length === 0) {
+      setError("Add at least one rule");
+      return;
+    }
+
+    if (!previewValid) {
+      setError("Preview must succeed before saving");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const filterState = convertRulesToFilterState();
+      const apiRules = buildSceneFilter(filterState);
+
+      const carouselData = {
+        title: title.trim(),
+        icon,
+        rules: apiRules,
+        sort,
+        direction,
+      };
+
+      if (isEditing) {
+        await libraryApi.updateCarousel(id, carouselData);
+      } else {
+        await libraryApi.createCarousel(carouselData);
+      }
+
+      navigate("/my-settings");
+    } catch (err) {
+      setError(err.message || "Failed to save carousel");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const IconComponent = LucideIcons[icon] || LucideIcons.Film;
+  const canSave = title.trim() && rules.length > 0 && previewValid;
+  const usedFilterKeys = new Set(rules.map((r) => r.filterKey));
+  const hasMoreFilters = CAROUSEL_FILTER_DEFINITIONS.some((f) => !usedFilterKeys.has(f.key));
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="w-8 h-8 animate-spin" style={{ color: "var(--accent-primary)" }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "var(--bg-primary)" }}>
+      {/* Header */}
+      <div
+        className="sticky top-0 z-10 border-b px-4 py-3"
+        style={{
+          backgroundColor: "var(--bg-secondary)",
+          borderColor: "var(--border-color)",
+        }}
+      >
+        <div className="max-w-4xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Button variant="secondary" onClick={() => navigate("/my-settings")} icon={<ArrowLeft className="w-4 h-4" />}>
+              Back
+            </Button>
+            <h1 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+              {isEditing ? "Edit Carousel" : "Create Carousel"}
+            </h1>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={handlePreview}
+              disabled={previewing || rules.length === 0}
+              icon={previewing ? <Loader2 className="w-4 h-4 animate-spin" /> : <Eye className="w-4 h-4" />}
+            >
+              Preview
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleSave}
+              disabled={!canSave || saving}
+              icon={saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+            >
+              {isEditing ? "Update" : "Save"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-4xl mx-auto p-4 space-y-6">
+        {/* Error Banner */}
+        {error && (
+          <div
+            className="flex items-center gap-2 p-3 rounded-lg border"
+            style={{
+              backgroundColor: "var(--status-error-bg)",
+              borderColor: "var(--status-error)",
+              color: "var(--status-error)",
+            }}
+          >
+            <AlertCircle className="w-5 h-5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Title & Icon */}
+        <div
+          className="rounded-lg border p-4 space-y-4"
+          style={{
+            backgroundColor: "var(--bg-card)",
+            borderColor: "var(--border-color)",
+          }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: "var(--text-secondary)" }}>
+            Carousel Details
+          </h2>
+
+          <div className="flex items-start gap-4">
+            {/* Icon */}
+            <div
+              className="flex-shrink-0 w-14 h-14 rounded-lg flex items-center justify-center"
+              style={{ backgroundColor: "var(--bg-secondary)" }}
+            >
+              <IconComponent className="w-7 h-7" style={{ color: "var(--accent-primary)" }} />
+            </div>
+
+            {/* Title Input */}
+            <div className="flex-1 space-y-2">
+              <label className="block text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+                Title
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="My Custom Carousel"
+                className="w-full px-3 py-2 rounded-lg border text-base"
+                style={{
+                  backgroundColor: "var(--bg-primary)",
+                  borderColor: "var(--border-color)",
+                  color: "var(--text-primary)",
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Icon Picker */}
+          <IconPickerButton icon={icon} onChange={setIcon} />
+        </div>
+
+        {/* Filter Rules */}
+        <div
+          className="rounded-lg border p-4 space-y-4"
+          style={{
+            backgroundColor: "var(--bg-card)",
+            borderColor: "var(--border-color)",
+          }}
+        >
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold" style={{ color: "var(--text-secondary)" }}>
+              Filter Rules (ALL must match)
+            </h2>
+            <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+              {rules.length} rule{rules.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+
+          {/* Rule List */}
+          <div className="space-y-3">
+            {rules.map((rule) => (
+              <RuleEditor
+                key={rule.id}
+                rule={rule}
+                usedFilterKeys={usedFilterKeys}
+                onChange={(updates) => updateRule(rule.id, updates)}
+                onRemove={() => removeRule(rule.id)}
+              />
+            ))}
+
+            {rules.length === 0 && (
+              <div
+                className="text-center py-8 text-sm"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                No rules added yet. Click &quot;Add Rule&quot; to get started.
+              </div>
+            )}
+          </div>
+
+          {/* Add Rule Button */}
+          <Button
+            variant="secondary"
+            onClick={addRule}
+            disabled={!hasMoreFilters}
+            icon={<Plus className="w-4 h-4" />}
+          >
+            Add Rule
+          </Button>
+        </div>
+
+        {/* Sort Options */}
+        <div
+          className="rounded-lg border p-4 space-y-4"
+          style={{
+            backgroundColor: "var(--bg-card)",
+            borderColor: "var(--border-color)",
+          }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: "var(--text-secondary)" }}>
+            Sort Order
+          </h2>
+
+          <div className="flex flex-wrap gap-4">
+            <div className="space-y-1">
+              <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+                Sort By
+              </label>
+              <select
+                value={sort}
+                onChange={(e) => {
+                  setSort(e.target.value);
+                  setPreviewValid(false);
+                  setPreviewScenes(null);
+                }}
+                className="px-3 py-2 rounded-lg border text-sm min-w-[150px]"
+                style={{
+                  backgroundColor: "var(--bg-primary)",
+                  borderColor: "var(--border-color)",
+                  color: "var(--text-primary)",
+                }}
+              >
+                {SCENE_SORT_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1">
+              <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+                Direction
+              </label>
+              <select
+                value={direction}
+                onChange={(e) => {
+                  setDirection(e.target.value);
+                  setPreviewValid(false);
+                  setPreviewScenes(null);
+                }}
+                className="px-3 py-2 rounded-lg border text-sm"
+                style={{
+                  backgroundColor: "var(--bg-primary)",
+                  borderColor: "var(--border-color)",
+                  color: "var(--text-primary)",
+                }}
+              >
+                <option value="DESC">Descending</option>
+                <option value="ASC">Ascending</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Preview Section */}
+        <CarouselPreview
+          scenes={previewScenes}
+          error={previewError}
+          loading={previewing}
+          onPreview={handlePreview}
+        />
+
+        {/* Save Hint */}
+        {!previewValid && rules.length > 0 && (
+          <p className="text-center text-sm" style={{ color: "var(--text-muted)" }}>
+            Preview your carousel to enable saving
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CarouselBuilder;

--- a/client/src/components/carousel-builder/CarouselPreview.jsx
+++ b/client/src/components/carousel-builder/CarouselPreview.jsx
@@ -1,0 +1,170 @@
+import { AlertCircle, Eye, Loader2, ImageOff } from "lucide-react";
+import { getSceneTitle } from "../../utils/format.js";
+
+/**
+ * CarouselPreview Component
+ * Shows a preview of the carousel results after running the query.
+ *
+ * @param {Array} scenes - Preview scenes to display
+ * @param {string} error - Error message if preview failed
+ * @param {boolean} loading - Whether preview is loading
+ */
+const CarouselPreview = ({ scenes, error, loading }) => {
+  return (
+    <div
+      className="rounded-lg border p-4 space-y-4"
+      style={{
+        backgroundColor: "var(--bg-card)",
+        borderColor: "var(--border-color)",
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold" style={{ color: "var(--text-secondary)" }}>
+          Preview
+        </h2>
+        {scenes && (
+          <span className="text-sm" style={{ color: "var(--text-muted)" }}>
+            Showing {scenes.length} scene{scenes.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div
+          className="flex items-center justify-center py-12"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          <Loader2 className="w-6 h-6 animate-spin mr-2" />
+          <span>Loading preview...</span>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && !loading && (
+        <div
+          className="flex items-center gap-2 p-3 rounded-lg"
+          style={{
+            backgroundColor: "var(--status-error-bg)",
+            color: "var(--status-error)",
+          }}
+        >
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!loading && !error && scenes === null && (
+        <div className="text-center py-12">
+          <Eye
+            className="w-12 h-12 mx-auto mb-3"
+            style={{ color: "var(--text-muted)" }}
+          />
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            Click &quot;Preview&quot; to see matching scenes
+          </p>
+        </div>
+      )}
+
+      {/* No Results */}
+      {!loading && !error && scenes && scenes.length === 0 && (
+        <div className="text-center py-12">
+          <AlertCircle
+            className="w-12 h-12 mx-auto mb-3"
+            style={{ color: "var(--text-muted)" }}
+          />
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            No scenes match your filter rules
+          </p>
+          <p className="text-xs mt-1" style={{ color: "var(--text-muted)" }}>
+            Try adjusting your rules to be less restrictive
+          </p>
+        </div>
+      )}
+
+      {/* Results Grid */}
+      {!loading && !error && scenes && scenes.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+          {scenes.map((scene) => (
+            <PreviewCard key={scene.id} scene={scene} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * PreviewCard Component
+ * Simple scene card for the preview grid.
+ */
+const PreviewCard = ({ scene }) => {
+  const thumbnailUrl = scene.paths?.screenshot;
+
+  return (
+    <div
+      className="rounded-lg overflow-hidden border"
+      style={{
+        backgroundColor: "var(--bg-secondary)",
+        borderColor: "var(--border-color)",
+      }}
+    >
+      {/* Thumbnail */}
+      <div className="aspect-video relative bg-black/50">
+        {thumbnailUrl ? (
+          <img
+            src={thumbnailUrl}
+            alt={scene.title || "Scene thumbnail"}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <ImageOff className="w-8 h-8" style={{ color: "var(--text-muted)" }} />
+          </div>
+        )}
+
+        {/* Duration badge */}
+        {scene.files?.[0]?.duration && (
+          <div
+            className="absolute bottom-1 right-1 px-1.5 py-0.5 rounded text-xs font-medium"
+            style={{
+              backgroundColor: "rgba(0,0,0,0.7)",
+              color: "white",
+            }}
+          >
+            {formatDuration(scene.files[0].duration)}
+          </div>
+        )}
+      </div>
+
+      {/* Title */}
+      <div className="p-2">
+        <p
+          className="text-xs line-clamp-2"
+          style={{ color: "var(--text-primary)" }}
+          title={getSceneTitle(scene)}
+        >
+          {getSceneTitle(scene)}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Format duration from seconds to HH:MM:SS or MM:SS
+ */
+const formatDuration = (seconds) => {
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+};
+
+export default CarouselPreview;

--- a/client/src/components/carousel-builder/IconPicker.jsx
+++ b/client/src/components/carousel-builder/IconPicker.jsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import * as LucideIcons from "lucide-react";
+import { Search, X } from "lucide-react";
+import { CAROUSEL_ICONS } from "./carouselIcons.js";
+
+/**
+ * IconPicker Component
+ * Grid-based icon selector with search functionality for choosing carousel icons.
+ *
+ * @param {string} selectedIcon - Currently selected icon name
+ * @param {function} onSelect - Callback when an icon is selected
+ * @param {function} onClose - Callback when picker is closed
+ */
+const IconPicker = ({ selectedIcon, onSelect, onClose }) => {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredIcons = CAROUSEL_ICONS.filter((iconName) =>
+    iconName.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleSelect = (iconName) => {
+    onSelect(iconName);
+    onClose();
+  };
+
+  return (
+    <div
+      className="rounded-lg border shadow-lg p-4"
+      style={{
+        backgroundColor: "var(--bg-card)",
+        borderColor: "var(--border-color)",
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3
+          className="text-sm font-semibold"
+          style={{ color: "var(--text-primary)" }}
+        >
+          Choose Icon
+        </h3>
+        <button
+          onClick={onClose}
+          className="p-1 rounded hover:bg-gray-500/20 transition-colors"
+        >
+          <X className="w-4 h-4" style={{ color: "var(--text-secondary)" }} />
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="relative mb-4">
+        <Search
+          className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4"
+          style={{ color: "var(--text-secondary)" }}
+        />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search icons..."
+          className="w-full pl-10 pr-4 py-2 rounded-lg border text-sm"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            borderColor: "var(--border-color)",
+            color: "var(--text-primary)",
+          }}
+        />
+      </div>
+
+      {/* Icon Grid */}
+      <div
+        className="grid grid-cols-6 gap-2 max-h-64 overflow-y-auto"
+        style={{ scrollbarWidth: "thin" }}
+      >
+        {filteredIcons.map((iconName) => {
+          const IconComponent = LucideIcons[iconName];
+          if (!IconComponent) return null;
+
+          const isSelected = selectedIcon === iconName;
+
+          return (
+            <button
+              key={iconName}
+              onClick={() => handleSelect(iconName)}
+              className={`
+                p-2.5 rounded-lg transition-all duration-200
+                hover:scale-110 flex items-center justify-center
+                ${isSelected ? "ring-2 ring-offset-2" : ""}
+              `}
+              style={{
+                backgroundColor: isSelected
+                  ? "var(--accent-primary)"
+                  : "var(--bg-secondary)",
+                color: isSelected
+                  ? "var(--text-on-accent)"
+                  : "var(--text-primary)",
+                ringColor: "var(--accent-primary)",
+                ringOffsetColor: "var(--bg-card)",
+              }}
+              title={iconName}
+            >
+              <IconComponent className="w-5 h-5" />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Empty state */}
+      {filteredIcons.length === 0 && (
+        <div
+          className="text-center py-8 text-sm"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          No icons match &quot;{searchQuery}&quot;
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IconPicker;

--- a/client/src/components/carousel-builder/IconPickerButton.jsx
+++ b/client/src/components/carousel-builder/IconPickerButton.jsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import * as LucideIcons from "lucide-react";
+import IconPicker from "./IconPicker.jsx";
+
+/**
+ * IconPickerButton Component
+ * Compact button that shows current icon and opens picker on click.
+ *
+ * @param {string} icon - Current icon name
+ * @param {function} onChange - Callback when icon changes
+ */
+const IconPickerButton = ({ icon, onChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const IconComponent = LucideIcons[icon] || LucideIcons.Film;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-3 py-2 rounded-lg border transition-colors hover:border-gray-500"
+        style={{
+          backgroundColor: "var(--bg-secondary)",
+          borderColor: "var(--border-color)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <IconComponent className="w-5 h-5" />
+        <span className="text-sm">Change Icon</span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-50 top-full mt-2 left-0">
+          <IconPicker
+            selectedIcon={icon}
+            onSelect={onChange}
+            onClose={() => setIsOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IconPickerButton;

--- a/client/src/components/carousel-builder/RuleEditor.jsx
+++ b/client/src/components/carousel-builder/RuleEditor.jsx
@@ -1,0 +1,313 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "../ui/index.js";
+import { CAROUSEL_FILTER_DEFINITIONS } from "../../utils/filterConfig.js";
+import SearchableSelect from "../ui/SearchableSelect.jsx";
+
+/**
+ * RuleEditor Component
+ * Edits a single filter rule for the carousel builder.
+ * Renders appropriate input based on filter type.
+ *
+ * @param {Object} rule - The rule being edited
+ * @param {Set} usedFilterKeys - Keys already used by other rules
+ * @param {function} onChange - Callback when rule changes
+ * @param {function} onRemove - Callback to remove this rule
+ */
+const RuleEditor = ({ rule, usedFilterKeys, onChange, onRemove }) => {
+  const filterDef = CAROUSEL_FILTER_DEFINITIONS.find((f) => f.key === rule.filterKey);
+
+  // Get available filters (current + unused)
+  const availableFilters = CAROUSEL_FILTER_DEFINITIONS.filter(
+    (f) => f.key === rule.filterKey || !usedFilterKeys.has(f.key)
+  );
+
+  const handleFilterChange = (newFilterKey) => {
+    const newDef = CAROUSEL_FILTER_DEFINITIONS.find((f) => f.key === newFilterKey);
+    if (!newDef) return;
+
+    // Reset value when changing filter type
+    onChange({
+      filterKey: newFilterKey,
+      value: newDef.type === "checkbox" ? true : newDef.multi ? [] : "",
+      modifier: newDef.defaultModifier,
+    });
+  };
+
+  return (
+    <div
+      className="flex flex-wrap items-start gap-3 p-3 rounded-lg border"
+      style={{
+        backgroundColor: "var(--bg-secondary)",
+        borderColor: "var(--border-color)",
+      }}
+    >
+      {/* Filter Selector */}
+      <div className="space-y-1 min-w-[150px]">
+        <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+          Filter
+        </label>
+        <select
+          value={rule.filterKey}
+          onChange={(e) => handleFilterChange(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg border text-sm"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            borderColor: "var(--border-color)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {availableFilters.map((f) => (
+            <option key={f.key} value={f.key}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Modifier (if applicable) */}
+      {filterDef?.modifierOptions && (
+        <div className="space-y-1 min-w-[120px]">
+          <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+            Condition
+          </label>
+          <select
+            value={rule.modifier || filterDef.defaultModifier}
+            onChange={(e) => onChange({ modifier: e.target.value })}
+            className="w-full px-3 py-2 rounded-lg border text-sm"
+            style={{
+              backgroundColor: "var(--bg-primary)",
+              borderColor: "var(--border-color)",
+              color: "var(--text-primary)",
+            }}
+          >
+            {filterDef.modifierOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Value Input */}
+      <div className="flex-1 min-w-[200px] space-y-1">
+        <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+          Value
+        </label>
+        <RuleValueInput filterDef={filterDef} rule={rule} onChange={onChange} />
+      </div>
+
+      {/* Hierarchy Toggle */}
+      {filterDef?.supportsHierarchy && (
+        <div className="space-y-1">
+          <label className="block text-xs" style={{ color: "var(--text-muted)" }}>
+            Sub-items
+          </label>
+          <label className="flex items-center gap-2 py-2">
+            <input
+              type="checkbox"
+              checked={rule.depth === -1}
+              onChange={(e) => onChange({ depth: e.target.checked ? -1 : undefined })}
+              className="rounded border"
+              style={{ accentColor: "var(--accent-primary)" }}
+            />
+            <span className="text-sm" style={{ color: "var(--text-primary)" }}>
+              Include all
+            </span>
+          </label>
+        </div>
+      )}
+
+      {/* Remove Button */}
+      <div className="space-y-1">
+        <label className="block text-xs invisible">Action</label>
+        <Button
+          variant="secondary"
+          onClick={onRemove}
+          className="p-2"
+          icon={<Trash2 className="w-4 h-4" />}
+          title="Remove rule"
+        />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * RuleValueInput Component
+ * Renders the appropriate input for the filter type.
+ */
+const RuleValueInput = ({ filterDef, rule, onChange }) => {
+  if (!filterDef) {
+    return <span style={{ color: "var(--text-secondary)" }}>Unknown filter</span>;
+  }
+
+  switch (filterDef.type) {
+    case "searchable-select":
+      return (
+        <SearchableSelect
+          entityType={filterDef.entityType}
+          value={rule.value}
+          onChange={(val) => onChange({ value: val })}
+          multi={filterDef.multi}
+          placeholder={`Select ${filterDef.label.toLowerCase()}...`}
+        />
+      );
+
+    case "range":
+      return <RangeInput filterDef={filterDef} value={rule.value} onChange={(val) => onChange({ value: val })} />;
+
+    case "checkbox":
+      return (
+        <div className="py-2">
+          <span className="text-sm" style={{ color: "var(--text-primary)" }}>
+            Enabled
+          </span>
+        </div>
+      );
+
+    case "select":
+      return (
+        <select
+          value={rule.value || ""}
+          onChange={(e) => onChange({ value: e.target.value })}
+          className="w-full px-3 py-2 rounded-lg border text-sm"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            borderColor: "var(--border-color)",
+            color: "var(--text-primary)",
+          }}
+        >
+          <option value="">Select...</option>
+          {filterDef.options?.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      );
+
+    case "text":
+      return (
+        <input
+          type="text"
+          value={rule.value || ""}
+          onChange={(e) => onChange({ value: e.target.value })}
+          placeholder={filterDef.placeholder || "Enter value..."}
+          className="w-full px-3 py-2 rounded-lg border text-sm"
+          style={{
+            backgroundColor: "var(--bg-primary)",
+            borderColor: "var(--border-color)",
+            color: "var(--text-primary)",
+          }}
+        />
+      );
+
+    case "date-range":
+      return <DateRangeInput value={rule.value} onChange={(val) => onChange({ value: val })} />;
+
+    default:
+      return <span style={{ color: "var(--text-secondary)" }}>Unsupported type: {filterDef.type}</span>;
+  }
+};
+
+/**
+ * RangeInput Component
+ * Min/max input for numeric range filters.
+ */
+const RangeInput = ({ filterDef, value, onChange }) => {
+  const handleMinChange = (e) => {
+    const min = e.target.value === "" ? undefined : parseInt(e.target.value);
+    onChange({ ...value, min });
+  };
+
+  const handleMaxChange = (e) => {
+    const max = e.target.value === "" ? undefined : parseInt(e.target.value);
+    onChange({ ...value, max });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="number"
+        value={value?.min ?? ""}
+        onChange={handleMinChange}
+        placeholder="Min"
+        min={filterDef.min}
+        max={filterDef.max}
+        className="w-24 px-3 py-2 rounded-lg border text-sm"
+        style={{
+          backgroundColor: "var(--bg-primary)",
+          borderColor: "var(--border-color)",
+          color: "var(--text-primary)",
+        }}
+      />
+      <span style={{ color: "var(--text-secondary)" }}>to</span>
+      <input
+        type="number"
+        value={value?.max ?? ""}
+        onChange={handleMaxChange}
+        placeholder="Max"
+        min={filterDef.min}
+        max={filterDef.max}
+        className="w-24 px-3 py-2 rounded-lg border text-sm"
+        style={{
+          backgroundColor: "var(--bg-primary)",
+          borderColor: "var(--border-color)",
+          color: "var(--text-primary)",
+        }}
+      />
+      {filterDef.valueUnit && (
+        <span className="text-sm" style={{ color: "var(--text-muted)" }}>
+          {filterDef.valueUnit}
+        </span>
+      )}
+    </div>
+  );
+};
+
+/**
+ * DateRangeInput Component
+ * Date pickers for date range filters.
+ */
+const DateRangeInput = ({ value, onChange }) => {
+  const handleFromChange = (e) => {
+    const min = e.target.value || undefined;
+    onChange({ ...value, min });
+  };
+
+  const handleToChange = (e) => {
+    const max = e.target.value || undefined;
+    onChange({ ...value, max });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="date"
+        value={value?.min || ""}
+        onChange={handleFromChange}
+        className="px-3 py-2 rounded-lg border text-sm"
+        style={{
+          backgroundColor: "var(--bg-primary)",
+          borderColor: "var(--border-color)",
+          color: "var(--text-primary)",
+        }}
+      />
+      <span style={{ color: "var(--text-secondary)" }}>to</span>
+      <input
+        type="date"
+        value={value?.max || ""}
+        onChange={handleToChange}
+        className="px-3 py-2 rounded-lg border text-sm"
+        style={{
+          backgroundColor: "var(--bg-primary)",
+          borderColor: "var(--border-color)",
+          color: "var(--text-primary)",
+        }}
+      />
+    </div>
+  );
+};
+
+export default RuleEditor;

--- a/client/src/components/carousel-builder/carouselIcons.js
+++ b/client/src/components/carousel-builder/carouselIcons.js
@@ -1,0 +1,96 @@
+/**
+ * Curated list of Lucide icons for carousel customization.
+ * Organized by category for easy browsing.
+ */
+export const CAROUSEL_ICONS = [
+  // Film & Video
+  "Film",
+  "Video",
+  "Play",
+  "PlayCircle",
+  "Clapperboard",
+  "Tv",
+  "Monitor",
+  "MonitorPlay",
+
+  // Favorites & Collections
+  "Heart",
+  "Star",
+  "Bookmark",
+  "Award",
+  "Trophy",
+  "Crown",
+  "Gem",
+  "Diamond",
+
+  // Time & Recency
+  "Clock",
+  "Calendar",
+  "CalendarDays",
+  "TrendingUp",
+  "Zap",
+  "Flame",
+  "Hourglass",
+  "Timer",
+
+  // Discovery & Search
+  "Eye",
+  "Sparkles",
+  "Target",
+  "Compass",
+  "Search",
+  "Filter",
+  "Telescope",
+
+  // Quality & Rating
+  "ThumbsUp",
+  "ThumbsDown",
+  "Shield",
+  "Medal",
+  "BadgeCheck",
+  "CheckCircle",
+
+  // People & Groups
+  "Users",
+  "User",
+  "UserCheck",
+  "UsersRound",
+  "UserPlus",
+
+  // Organization
+  "Building",
+  "Tag",
+  "Tags",
+  "Folder",
+  "FolderHeart",
+  "Library",
+  "Layers",
+  "Grid",
+  "List",
+
+  // Misc Media
+  "Camera",
+  "Headphones",
+  "Music",
+  "Mic",
+  "Radio",
+  "Image",
+  "Images",
+
+  // Actions & States
+  "Check",
+  "AlertCircle",
+  "Info",
+  "HelpCircle",
+  "RefreshCw",
+
+  // Fun & Mood
+  "Smile",
+  "PartyPopper",
+  "Gift",
+  "Cake",
+  "Sun",
+  "Moon",
+  "Rainbow",
+  "Palette",
+];

--- a/client/src/components/carousel-builder/index.js
+++ b/client/src/components/carousel-builder/index.js
@@ -1,0 +1,6 @@
+export { default as CarouselBuilder } from "./CarouselBuilder.jsx";
+export { default as CarouselPreview } from "./CarouselPreview.jsx";
+export { default as RuleEditor } from "./RuleEditor.jsx";
+export { default as IconPicker } from "./IconPicker.jsx";
+export { default as IconPickerButton } from "./IconPickerButton.jsx";
+export { CAROUSEL_ICONS } from "./carouselIcons.js";

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -336,6 +336,67 @@ export const libraryApi = {
 
     return method(entityId, { favorite });
   },
+
+  // ============================================================================
+  // CUSTOM CAROUSELS
+  // ============================================================================
+
+  /**
+   * Get all custom carousels for the current user
+   * @returns {Promise<{carousels: Array}>}
+   */
+  getCarousels: () => apiGet("/carousels"),
+
+  /**
+   * Get a single carousel by ID
+   * @param {string} id - Carousel ID
+   * @returns {Promise<{carousel: Object}>}
+   */
+  getCarousel: (id) => apiGet(`/carousels/${id}`),
+
+  /**
+   * Create a new custom carousel
+   * @param {Object} data - Carousel data
+   * @param {string} data.title - Carousel title
+   * @param {string} data.icon - Lucide icon name
+   * @param {Object} data.rules - Filter rules (buildSceneFilter output format)
+   * @param {string} data.sort - Sort field
+   * @param {string} data.direction - Sort direction (ASC/DESC)
+   * @returns {Promise<{carousel: Object}>}
+   */
+  createCarousel: (data) => apiPost("/carousels", data),
+
+  /**
+   * Update an existing carousel
+   * @param {string} id - Carousel ID
+   * @param {Object} data - Updated carousel data
+   * @returns {Promise<{carousel: Object}>}
+   */
+  updateCarousel: (id, data) => apiPut(`/carousels/${id}`, data),
+
+  /**
+   * Delete a carousel
+   * @param {string} id - Carousel ID
+   * @returns {Promise<{success: boolean, message: string}>}
+   */
+  deleteCarousel: (id) => apiDelete(`/carousels/${id}`),
+
+  /**
+   * Preview carousel results without saving
+   * @param {Object} data - Query parameters
+   * @param {Object} data.rules - Filter rules
+   * @param {string} data.sort - Sort field
+   * @param {string} data.direction - Sort direction
+   * @returns {Promise<{scenes: Array}>}
+   */
+  previewCarousel: (data) => apiPost("/carousels/preview", data),
+
+  /**
+   * Execute a carousel by ID and get its scenes
+   * @param {string} id - Carousel ID
+   * @returns {Promise<{carousel: Object, scenes: Array}>}
+   */
+  executeCarousel: (id) => apiGet(`/carousels/${id}/execute`),
 };
 
 // Helper functions for common filtering patterns

--- a/docs/development/regression-testing.md
+++ b/docs/development/regression-testing.md
@@ -416,14 +416,28 @@ Before beginning regression testing:
 
 #### 8.2 Carousel Preferences
 
-**Location**: Settings page → Carousel Settings section
+**Location**: Settings page → Homepage Carousels section
 
-- [ ] Can toggle carousels on/off (Recently Watched, Top Rated, etc.)
-- [ ] Can reorder carousels (drag-and-drop or up/down buttons)
-- [ ] Can configure number of items per carousel
-- [ ] Changes reflect immediately on home page
+- [ ] Can toggle hardcoded carousels on/off (Continue Watching, High Rated, etc.)
+- [ ] Can reorder carousels with up/down buttons
+- [ ] Changes reflect on home page after save
 
-#### 8.3 Navigation Preferences
+#### 8.3 Custom Carousels
+
+**Location**: Settings page → Homepage Carousels → Create Carousel
+
+- [ ] Can create custom carousel with title and icon
+- [ ] Can add filter rules (performers, tags, rating, etc.)
+- [ ] Preview shows matching scenes before save
+- [ ] Save is disabled until preview succeeds
+- [ ] Can edit existing custom carousel
+- [ ] Can delete custom carousel
+- [ ] Custom carousel appears on homepage
+- [ ] Maximum 15 custom carousels enforced
+- [ ] Filter options are sorted alphabetically
+- [ ] Scene titles use basename fallback when no title
+
+#### 8.4 Navigation Preferences
 
 **Location**: Settings page → Navigation Settings section
 
@@ -431,7 +445,7 @@ Before beginning regression testing:
 - [ ] Can toggle top bar elements (show/hide search, user menu, etc.)
 - [ ] Can configure keyboard shortcuts (if customizable)
 
-#### 8.4 Filter Presets
+#### 8.5 Filter Presets
 
 **Location**: Settings page → Filter Presets section
 
@@ -441,7 +455,7 @@ Before beginning regression testing:
 - [ ] Can set default filter preset (auto-loads on scenes page)
 - [ ] Can export/import filter presets (JSON file)
 
-#### 8.5 Hidden Items (User Feature)
+#### 8.6 Hidden Items (User Feature)
 
 **Location**: Settings page → link to Hidden Items page
 

--- a/docs/user-guide/custom-carousels.md
+++ b/docs/user-guide/custom-carousels.md
@@ -1,0 +1,101 @@
+# Custom Carousels
+
+Create personalized homepage carousels using a visual query builder. Custom carousels let you define filter rules to automatically curate collections of scenes based on performers, tags, ratings, and more.
+
+## Creating a Custom Carousel
+
+1. Navigate to **Settings** → **Homepage Carousels**
+2. Click **Create Carousel**
+3. Configure your carousel:
+   - **Title**: Give your carousel a descriptive name
+   - **Icon**: Choose from a selection of icons
+   - **Filter Rules**: Add one or more rules to define which scenes appear
+   - **Sort**: Choose how scenes are ordered (Random, Recently Added, etc.)
+
+4. Click **Preview** to see matching scenes
+5. Click **Save** once you're satisfied with the preview
+
+## Filter Rules
+
+Each rule consists of a filter type, comparison operator, and value. All rules must match (AND logic) for a scene to appear in the carousel.
+
+### Available Filters
+
+| Filter | Description |
+|--------|-------------|
+| Performers | Scenes featuring specific performers |
+| Tags | Scenes with specific tags |
+| Studio | Scenes from a specific studio |
+| Collections | Scenes in specific groups/collections |
+| Rating | Scenes within a rating range (0-100) |
+| Duration | Scene length in minutes |
+| Resolution | Video quality (480p, 720p, 1080p, etc.) |
+| Play Count | Number of times you've watched |
+| O Count | Your O count for the scene |
+| Favorite Scenes | Only your favorited scenes |
+| Favorite Performers | Scenes with your favorite performers |
+| Favorite Studios | Scenes from your favorite studios |
+| Favorite Tags | Scenes with your favorite tags |
+| Created Date | When the scene was added |
+| Scene Date | The scene's release date |
+| Last Played Date | When you last watched |
+| Performer Age | Performer age at time of scene |
+| Performer Count | Number of performers in scene |
+| Bitrate | Video bitrate in Mbps |
+| Title Contains | Text search in scene title |
+| Details Contains | Text search in scene description |
+
+### Comparison Operators
+
+Different filter types support different operators:
+
+- **Entity filters** (Performers, Tags, etc.): includes any of, includes all of, excludes
+- **Numeric filters** (Rating, Duration, etc.): between, greater than, less than
+- **Boolean filters** (Favorites): is true / is false
+- **Text filters**: contains
+
+## Managing Carousels
+
+### Reordering
+
+Use the up/down arrow buttons next to each carousel to change the display order on your homepage.
+
+### Visibility
+
+Click the eye icon to show/hide individual carousels. Hidden carousels remain saved but won't appear on the homepage.
+
+### Editing
+
+Click the pencil icon on any custom carousel to modify its rules, title, or icon.
+
+### Deleting
+
+Click the trash icon to delete a custom carousel. This action cannot be undone.
+
+## Limits
+
+- Maximum of **15 custom carousels** per user
+- Each carousel displays up to **12 scenes**
+- All filter rules use AND logic (scenes must match all rules)
+
+## Tips
+
+- **Start simple**: Begin with one or two rules and add more as needed
+- **Use Preview**: Always preview before saving to ensure your rules work as expected
+- **Random sort**: Great for variety - shows different scenes each time you visit
+- **Combine with favorites**: Create carousels for "Highly rated scenes with favorite performers"
+- **Content restrictions**: Custom carousels respect your hidden items and content restrictions
+
+## Troubleshooting
+
+### Carousel shows "No scenes found"
+
+- Your filter rules may be too restrictive
+- Try relaxing some rules or using different operators
+- Check that you have scenes matching your criteria
+
+### Carousel not appearing on homepage
+
+- Make sure the carousel is enabled (eye icon should be visible, not crossed out)
+- Try refreshing the page
+- Check Settings → Homepage Carousels to verify it's toggled on

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - Configuration: getting-started/configuration.md
       - Quick Start: getting-started/quick-start.md
   - User Guide:
+      - Custom Carousels: user-guide/custom-carousels.md
       - Watch History: user-guide/watch-history.md
       - Keyboard Navigation: user-guide/keyboard-navigation.md
       - Playlists: user-guide/playlists.md

--- a/server/controllers/carousel.ts
+++ b/server/controllers/carousel.ts
@@ -1,0 +1,370 @@
+import type { Response } from "express";
+import type { Prisma } from "@prisma/client";
+import type { AuthenticatedRequest } from "../middleware/auth.js";
+import prisma from "../prisma/singleton.js";
+import { stashCacheManager } from "../services/StashCacheManager.js";
+import { userRestrictionService } from "../services/UserRestrictionService.js";
+import type { NormalizedScene, PeekSceneFilter } from "../types/index.js";
+import {
+  mergeScenesWithUserData,
+  applyQuickSceneFilters,
+  applyExpensiveSceneFilters,
+  sortScenes,
+  addStreamabilityInfo,
+} from "./library/scenes.js";
+
+// Maximum number of custom carousels per user
+const MAX_CAROUSELS_PER_USER = 15;
+
+// Number of scenes to return for carousel preview/display
+const CAROUSEL_SCENE_LIMIT = 12;
+
+/**
+ * Get all custom carousels for the current user
+ */
+export const getUserCarousels = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const carousels = await prisma.userCarousel.findMany({
+      where: { userId },
+      orderBy: { createdAt: "asc" },
+    });
+
+    res.json({ carousels });
+  } catch (error) {
+    console.error("Error getting user carousels:", error);
+    res.status(500).json({ error: "Failed to get carousels" });
+  }
+};
+
+/**
+ * Get a single carousel by ID
+ */
+export const getCarousel = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    const carouselId = req.params.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const carousel = await prisma.userCarousel.findFirst({
+      where: {
+        id: carouselId,
+        userId,
+      },
+    });
+
+    if (!carousel) {
+      return res.status(404).json({ error: "Carousel not found" });
+    }
+
+    res.json({ carousel });
+  } catch (error) {
+    console.error("Error getting carousel:", error);
+    res.status(500).json({ error: "Failed to get carousel" });
+  }
+};
+
+interface CarouselPreference {
+  id: string;
+  enabled: boolean;
+  order: number;
+}
+
+/**
+ * Create a new custom carousel
+ */
+export const createCarousel = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const { title, icon, rules, sort, direction } = req.body;
+
+    // Validate required fields
+    if (!title || title.trim() === "") {
+      return res.status(400).json({ error: "Title is required" });
+    }
+
+    if (!rules || typeof rules !== "object") {
+      return res.status(400).json({ error: "Rules are required" });
+    }
+
+    // Check carousel limit
+    const count = await prisma.userCarousel.count({
+      where: { userId },
+    });
+
+    if (count >= MAX_CAROUSELS_PER_USER) {
+      return res.status(400).json({
+        error: `Maximum ${MAX_CAROUSELS_PER_USER} custom carousels allowed`,
+      });
+    }
+
+    const carousel = await prisma.userCarousel.create({
+      data: {
+        userId,
+        title: title.trim(),
+        icon: icon || "Film",
+        rules,
+        sort: sort || "random",
+        direction: direction || "DESC",
+      },
+    });
+
+    // Add the new carousel to the user's carouselPreferences so it shows on homepage immediately
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { carouselPreferences: true },
+    });
+
+    const existingPrefs = (user?.carouselPreferences as CarouselPreference[] | null) || [];
+    const customCarouselId = `custom-${carousel.id}`;
+
+    // Only add if not already present
+    if (!existingPrefs.find((p) => p.id === customCarouselId)) {
+      const maxOrder = existingPrefs.reduce((max, p) => Math.max(max, p.order), -1);
+      const newPrefs = [
+        ...existingPrefs,
+        { id: customCarouselId, enabled: true, order: maxOrder + 1 },
+      ];
+
+      await prisma.user.update({
+        where: { id: userId },
+        data: { carouselPreferences: newPrefs as unknown as Prisma.InputJsonValue },
+      });
+    }
+
+    res.status(201).json({ carousel });
+  } catch (error) {
+    console.error("Error creating carousel:", error);
+    res.status(500).json({ error: "Failed to create carousel" });
+  }
+};
+
+/**
+ * Update an existing carousel
+ */
+export const updateCarousel = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+    const carouselId = req.params.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const { title, icon, rules, sort, direction } = req.body;
+
+    // Check ownership
+    const existing = await prisma.userCarousel.findFirst({
+      where: {
+        id: carouselId,
+        userId,
+      },
+    });
+
+    if (!existing) {
+      return res.status(404).json({ error: "Carousel not found" });
+    }
+
+    // Validate title if provided
+    if (title !== undefined && title.trim() === "") {
+      return res.status(400).json({ error: "Title cannot be empty" });
+    }
+
+    const carousel = await prisma.userCarousel.update({
+      where: { id: carouselId },
+      data: {
+        ...(title !== undefined && { title: title.trim() }),
+        ...(icon !== undefined && { icon }),
+        ...(rules !== undefined && { rules }),
+        ...(sort !== undefined && { sort }),
+        ...(direction !== undefined && { direction }),
+      },
+    });
+
+    res.json({ carousel });
+  } catch (error) {
+    console.error("Error updating carousel:", error);
+    res.status(500).json({ error: "Failed to update carousel" });
+  }
+};
+
+/**
+ * Delete a carousel
+ */
+export const deleteCarousel = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+    const carouselId = req.params.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    // Check ownership
+    const existing = await prisma.userCarousel.findFirst({
+      where: {
+        id: carouselId,
+        userId,
+      },
+    });
+
+    if (!existing) {
+      return res.status(404).json({ error: "Carousel not found" });
+    }
+
+    await prisma.userCarousel.delete({
+      where: { id: carouselId },
+    });
+
+    res.json({ success: true, message: "Carousel deleted" });
+  } catch (error) {
+    console.error("Error deleting carousel:", error);
+    res.status(500).json({ error: "Failed to delete carousel" });
+  }
+};
+
+/**
+ * Preview carousel results without saving
+ * Executes the carousel query and returns matching scenes
+ */
+export const previewCarousel = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const { rules, sort, direction } = req.body;
+
+    if (!rules || typeof rules !== "object") {
+      return res.status(400).json({ error: "Rules are required" });
+    }
+
+    // Execute the carousel query
+    const scenes = await executeCarouselQuery(
+      userId,
+      rules as PeekSceneFilter,
+      sort || "random",
+      direction || "DESC"
+    );
+
+    res.json({ scenes });
+  } catch (error) {
+    console.error("Error previewing carousel:", error);
+    res.status(500).json({ error: "Failed to preview carousel" });
+  }
+};
+
+/**
+ * Execute a carousel's scene query
+ * This is also exported for use by the homepage to render carousel scenes
+ */
+export async function executeCarouselQuery(
+  userId: number,
+  rules: PeekSceneFilter,
+  sort: string,
+  direction: string
+): Promise<NormalizedScene[]> {
+  // Get all scenes from cache
+  let scenes = stashCacheManager.getAllScenes();
+
+  // Apply user content restrictions (hidden entities, exclusions)
+  scenes = await userRestrictionService.filterScenesForUser(scenes, userId);
+
+  // Apply the carousel's filter rules (quick filters that don't need user data)
+  scenes = applyQuickSceneFilters(scenes, rules);
+
+  // Merge with user-specific data (ratings, watch history, favorites)
+  scenes = await mergeScenesWithUserData(scenes, userId);
+
+  // Apply filters that require user data (favorite, rating, play_count, etc.)
+  scenes = applyExpensiveSceneFilters(scenes, rules);
+
+  // Add streamability info
+  scenes = addStreamabilityInfo(scenes);
+
+  // Sort the results
+  scenes = sortScenes(scenes, sort, direction);
+
+  // Limit to carousel size
+  return scenes.slice(0, CAROUSEL_SCENE_LIMIT);
+}
+
+/**
+ * Execute a carousel by ID and return its scenes
+ * Used by the homepage to render a specific carousel
+ */
+export const executeCarouselById = async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+  try {
+    const userId = req.user?.id;
+    const carouselId = req.params.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    // Get the carousel
+    const carousel = await prisma.userCarousel.findFirst({
+      where: {
+        id: carouselId,
+        userId,
+      },
+    });
+
+    if (!carousel) {
+      return res.status(404).json({ error: "Carousel not found" });
+    }
+
+    // Execute the query
+    const scenes = await executeCarouselQuery(
+      userId,
+      carousel.rules as PeekSceneFilter,
+      carousel.sort,
+      carousel.direction
+    );
+
+    res.json({
+      carousel: {
+        id: carousel.id,
+        title: carousel.title,
+        icon: carousel.icon,
+      },
+      scenes,
+    });
+  } catch (error) {
+    console.error("Error executing carousel:", error);
+    res.status(500).json({ error: "Failed to execute carousel query" });
+  }
+};

--- a/server/controllers/library/scenes.ts
+++ b/server/controllers/library/scenes.ts
@@ -742,7 +742,7 @@ export function applyExpensiveSceneFilters(
 /**
  * Sort scenes
  */
-function sortScenes(
+export function sortScenes(
   scenes: NormalizedScene[],
   sortField: string,
   direction: string,

--- a/server/initializers/api.ts
+++ b/server/initializers/api.ts
@@ -12,6 +12,7 @@ import {
 import * as statsController from "../controllers/stats.js";
 import { authenticateToken, requireAdmin } from "../middleware/auth.js";
 import authRoutes from "../routes/auth.js";
+import carouselRoutes from "../routes/carousel.js";
 import customThemeRoutes from "../routes/customTheme.js";
 import libraryGalleriesRoutes from "../routes/library/galleries.js";
 import libraryGroupsRoutes from "../routes/library/groups.js";
@@ -110,6 +111,9 @@ export const setupAPI = () => {
 
   // Playlist routes (protected)
   app.use("/api/playlists", playlistRoutes);
+
+  // Custom carousel routes (protected)
+  app.use("/api/carousels", carouselRoutes);
 
   // Watch history routes (protected)
   app.use("/api/watch-history", watchHistoryRoutes);

--- a/server/prisma/migrations/20251126202944_add_user_carousel/migration.sql
+++ b/server/prisma/migrations/20251126202944_add_user_carousel/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "UserCarousel" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "icon" TEXT NOT NULL DEFAULT 'Film',
+    "rules" JSONB NOT NULL,
+    "sort" TEXT NOT NULL DEFAULT 'random',
+    "direction" TEXT NOT NULL DEFAULT 'DESC',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UserCarousel_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "UserCarousel_userId_idx" ON "UserCarousel"("userId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -50,6 +50,9 @@ model User {
     // Hidden entities (user-level hiding)
     hiddenEntities UserHiddenEntity[]
     hideConfirmationDisabled Boolean @default(false) // Don't show hide confirmation dialog
+
+    // Custom carousels
+    customCarousels UserCarousel[]
 }
 
 model WatchHistory {
@@ -362,4 +365,25 @@ model StashInstance {
     priority  Int      @default(0)          // For ordering (lower = higher priority)
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
+}
+
+// User-defined custom carousels for homepage
+// Each carousel is a saved scene query with display settings
+model UserCarousel {
+    id        String   @id @default(uuid())
+    userId    Int
+    title     String
+    icon      String   @default("Film")     // Lucide icon name (e.g., "Film", "Heart", "Star")
+
+    // Query definition (same format as buildSceneFilter output)
+    rules     Json                          // Scene filter object for findScenes API
+    sort      String   @default("random")   // Sort field (random, created_at, rating, etc.)
+    direction String   @default("DESC")     // Sort direction (ASC or DESC)
+
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+    @@index([userId])
 }

--- a/server/routes/carousel.ts
+++ b/server/routes/carousel.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import {
+  getUserCarousels,
+  getCarousel,
+  createCarousel,
+  updateCarousel,
+  deleteCarousel,
+  previewCarousel,
+  executeCarouselById,
+} from "../controllers/carousel.js";
+import { authenticateToken } from "../middleware/auth.js";
+import { authenticated } from "../utils/routeHelpers.js";
+
+const router = express.Router();
+
+// All carousel routes require authentication
+router.use(authenticateToken);
+
+// Get all user's custom carousels
+router.get("/", authenticated(getUserCarousels));
+
+// Preview carousel results without saving
+router.post("/preview", authenticated(previewCarousel));
+
+// Get single carousel by ID
+router.get("/:id", authenticated(getCarousel));
+
+// Execute carousel query and get scenes
+router.get("/:id/execute", authenticated(executeCarouselById));
+
+// Create new carousel
+router.post("/", authenticated(createCarousel));
+
+// Update carousel
+router.put("/:id", authenticated(updateCarousel));
+
+// Delete carousel
+router.delete("/:id", authenticated(deleteCarousel));
+
+export default router;


### PR DESCRIPTION
## Summary
- Add ability for users to create personalized homepage carousels using a visual filter builder
- Custom carousels support all 21 Scene Search filter types with alphabetically sorted options
- Carousels can be reordered alongside existing hardcoded carousels and toggled on/off

## Test plan
- [x] Create a custom carousel with title, icon, and filter rules
- [x] Verify preview shows matching scenes before save is enabled
- [x] Verify carousel appears on homepage immediately after creation
- [x] Edit existing carousel and verify changes persist
- [x] Delete carousel and verify it's removed from homepage
- [x] Reorder carousels using up/down buttons in Settings
- [x] Toggle carousel visibility and verify homepage reflects changes
- [x] Test with maximum 15 custom carousels limit
- [x] Verify scene titles use basename fallback when no title exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)