### PR TITLE
fix: tags not showing for non-admin users

### DIFF
--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -151,6 +151,40 @@ class StashEntityService {
   }
 
   /**
+   * Get all scenes with tags relation included
+   * Used for empty entity filtering which needs to know which tags appear on visible scenes
+   */
+  async getAllScenesWithTags(): Promise<NormalizedScene[]> {
+    const startTotal = Date.now();
+
+    const queryStart = Date.now();
+    const cached = await prisma.stashScene.findMany({
+      where: { deletedAt: null },
+      select: {
+        ...this.BROWSE_SELECT,
+        // Include tags relation for filtering
+        tags: {
+          select: { tagId: true },
+        },
+      },
+    });
+    const queryTime = Date.now() - queryStart;
+
+    const transformStart = Date.now();
+    const result = cached.map((c) => {
+      const scene = this.transformSceneForBrowse(c);
+      // Override tags with the junction table data (cast to satisfy type checker - only id is needed for filtering)
+      scene.tags = (c.tags?.map((t: { tagId: string }) => ({ id: t.tagId })) || []) as typeof scene.tags;
+      return scene;
+    });
+    const transformTime = Date.now() - transformStart;
+
+    logger.info(`getAllScenesWithTags: query=${queryTime}ms, transform=${transformTime}ms, total=${Date.now() - startTotal}ms, count=${cached.length}`);
+
+    return result;
+  }
+
+  /**
    * Get scene by ID (includes related entities)
    */
   async getScene(id: string): Promise<NormalizedScene | null> {


### PR DESCRIPTION
## Summary

Fixes a bug where non-admin users saw an empty Tags page despite 196 tags being synced successfully.

## Root Cause

`getAllScenes()` used `BROWSE_SELECT` which excluded the `tags` relation. When `filterEmptyTags()` received scenes without tags populated, it filtered out ALL tags since no tags appeared to be attached to any visible scenes.

Admin users were unaffected because they skip the empty entity filtering entirely.

## Changes

### StashEntityService.ts
- Added `getAllScenesWithTags()` method that includes tags from junction table
- Minimal overhead: only fetches `tagId` from `SceneTag` junction table

### tags.ts controller
- Updated `findTags` endpoint to use `getAllScenesWithTags()` when filtering for non-admin users
- Updated `findTagsMinimal` endpoint with the same fix for consistency (filter dropdowns)
- Passes `visibleScenes` to `filterEmptyTags()` for accurate visibility determination

## Test Plan

- [x] Build passes
- [x] All 378 tests pass
- [x] Code review completed
- [ ] Manual verification: non-admin user can see Tags page
- [ ] Manual verification: tag filter dropdowns work for non-admin users