### PR TITLE
fix: aggregate O counters for performers, studios, and tags

### DIFF
--- a/client/src/components/cards/StudioCard.jsx
+++ b/client/src/components/cards/StudioCard.jsx
@@ -69,6 +69,7 @@ const StudioCard = forwardRef(
           entityId: studio.id,
           initialRating: studio.rating100,
           initialFavorite: studio.favorite || false,
+          initialOCounter: studio.o_counter,
           onHideSuccess,
         }}
         {...rest}

--- a/client/src/components/cards/TagCard.jsx
+++ b/client/src/components/cards/TagCard.jsx
@@ -86,6 +86,7 @@ const TagCard = forwardRef(
                 entityId: tag.id,
                 initialRating: tag.rating100,
                 initialFavorite: tag.favorite || false,
+                initialOCounter: tag.o_counter,
                 onHideSuccess,
               }
             : undefined

--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -286,6 +286,30 @@ class StashEntityService {
   }
 
   /**
+   * Get scenes by IDs with full relations (performers, tags, studio, groups, galleries)
+   * Use this when you need the related entities, not just scene data.
+   * This is more expensive than getScenesByIds due to the joins.
+   */
+  async getScenesByIdsWithRelations(ids: string[]): Promise<NormalizedScene[]> {
+    if (ids.length === 0) return [];
+
+    const cached = await prisma.stashScene.findMany({
+      where: {
+        id: { in: ids },
+        deletedAt: null,
+      },
+      include: {
+        performers: { include: { performer: true } },
+        tags: { include: { tag: true } },
+        groups: { include: { group: true } },
+        galleries: { include: { gallery: true } },
+      },
+    });
+
+    return cached.map((c) => this.transformSceneWithRelations(c));
+  }
+
+  /**
    * Get total scene count
    */
   async getSceneCount(): Promise<number> {

--- a/server/services/UserStatsService.ts
+++ b/server/services/UserStatsService.ts
@@ -355,9 +355,9 @@ class UserStatsService {
         }
       >();
 
-      // Batch load all scenes for the watch history
+      // Batch load all scenes for the watch history (with relations for performers/tags/studio)
       const sceneIds = watchHistory.map((wh) => wh.sceneId);
-      const scenes = await stashEntityService.getScenesByIds(sceneIds);
+      const scenes = await stashEntityService.getScenesByIdsWithRelations(sceneIds);
       const sceneMap = new Map(scenes.map((s) => [s.id, s]));
 
       for (const wh of watchHistory) {


### PR DESCRIPTION
## Summary
- Fix aggregate O counters showing 0 for Performers, Studios, and Tags
- Fix O counter not displaying on Studio and Tag cards

## Changes
- Add `getScenesByIdsWithRelations()` method to StashEntityService that includes performer/tag/group/gallery joins
- Update `rebuildAllStatsForUser()` to use the new method so stats aggregation has access to scene relationships
- Pass `initialOCounter` prop to StudioCard and TagCard components

## Root Cause
`getScenesByIds()` returned scenes with empty `performers[]` and `tags[]` arrays (using `transformScene()` instead of `transformSceneWithRelations()`). When `rebuildAllStatsForUser()` iterated through scenes to aggregate stats, the empty arrays meant no performer/tag stats were ever computed.

## Test plan
- [ ] Trigger a full sync from Stash
- [ ] Verify Performers show correct aggregate O counts
- [ ] Verify Studios show correct aggregate O counts  
- [ ] Verify Tags show correct aggregate O counts
- [ ] Verify sorting by O count works for all entity types
- [ ] Verify O counter badge displays on Studio cards
- [ ] Verify O counter badge displays on Tag cards