### PR TITLE
fix: performer filters for career length, eye color, ethnicity, breast type

### DIFF
--- a/client/src/utils/__tests__/performerFilterConfig.test.js
+++ b/client/src/utils/__tests__/performerFilterConfig.test.js
@@ -184,39 +184,39 @@ describe("buildPerformerFilter", () => {
   });
 
   describe("Select Filters (Ethnicity, Hair Color, Eye Color, Fake Tits)", () => {
-    it("should build ethnicity filter with INCLUDES modifier", () => {
+    it("should build ethnicity filter with EQUALS modifier", () => {
       const uiFilters = { ethnicity: "asian" };
       const result = buildPerformerFilter(uiFilters);
       expect(result.ethnicity).toEqual({
         value: "asian",
-        modifier: "INCLUDES",
+        modifier: "EQUALS",
       });
     });
 
-    it("should build hair_color filter with INCLUDES modifier", () => {
+    it("should build hair_color filter with EQUALS modifier", () => {
       const uiFilters = { hairColor: "blonde" };
       const result = buildPerformerFilter(uiFilters);
       expect(result.hair_color).toEqual({
         value: "blonde",
-        modifier: "INCLUDES",
+        modifier: "EQUALS",
       });
     });
 
-    it("should build eye_color filter with INCLUDES modifier", () => {
+    it("should build eye_color filter with EQUALS modifier", () => {
       const uiFilters = { eyeColor: "blue" };
       const result = buildPerformerFilter(uiFilters);
       expect(result.eye_color).toEqual({
         value: "blue",
-        modifier: "INCLUDES",
+        modifier: "EQUALS",
       });
     });
 
-    it("should build fake_tits filter with INCLUDES modifier", () => {
+    it("should build fake_tits filter with EQUALS modifier", () => {
       const uiFilters = { fakeTits: "Yes" };
       const result = buildPerformerFilter(uiFilters);
       expect(result.fake_tits).toEqual({
         value: "Yes",
-        modifier: "INCLUDES",
+        modifier: "EQUALS",
       });
     });
   });
@@ -714,8 +714,8 @@ describe("buildPerformerFilter", () => {
         modifier: "LESS_THAN",
         value: 101,
       });
-      expect(result.ethnicity).toEqual({ value: "caucasian", modifier: "INCLUDES" });
-      expect(result.hair_color).toEqual({ value: "brown", modifier: "INCLUDES" });
+      expect(result.ethnicity).toEqual({ value: "caucasian", modifier: "EQUALS" });
+      expect(result.hair_color).toEqual({ value: "brown", modifier: "EQUALS" });
       expect(result.name).toEqual({ value: "Jane", modifier: "INCLUDES" });
       expect(result.created_at).toEqual({
         value: "2023-01-01",

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -1738,28 +1738,28 @@ export const buildPerformerFilter = (filters, unitPreference = UNITS.METRIC) => 
   if (filters.ethnicity) {
     performerFilter.ethnicity = {
       value: filters.ethnicity,
-      modifier: "INCLUDES",
+      modifier: "EQUALS",
     };
   }
 
   if (filters.hairColor) {
     performerFilter.hair_color = {
       value: filters.hairColor,
-      modifier: "INCLUDES",
+      modifier: "EQUALS",
     };
   }
 
   if (filters.eyeColor) {
     performerFilter.eye_color = {
       value: filters.eyeColor,
-      modifier: "INCLUDES",
+      modifier: "EQUALS",
     };
   }
 
   if (filters.fakeTits) {
     performerFilter.fake_tits = {
       value: filters.fakeTits,
-      modifier: "INCLUDES",
+      modifier: "EQUALS",
     };
   }
 


### PR DESCRIPTION
## Summary

- Fix career length filter to properly parse Stash's free-text field and calculate duration
- Fix eye color, ethnicity, and breast type filters to use EQUALS modifier instead of INCLUDES

## Changes

**Backend (server/controllers/library/performers.ts):**
- Add `parseCareerLength()` function that parses various formats:
  - "2015-present" or "2015-" → calculates years from start to current year
  - "2010-2018" → calculates duration between years
  - "5 years" or "5" → extracts numeric duration
- Performers with null/empty/unparseable career_length are excluded from filter results

**Frontend (client/src/utils/filterConfig.js):**
- Change modifier from `INCLUDES` to `EQUALS` for select filters:
  - ethnicity
  - hair_color
  - eye_color
  - fake_tits (breast type)

## Test plan

- [x] Server tests pass (68 tests including 25 new tests)
- [x] Client tests pass (72 tests)
- [x] Lint passes
- [ ] Manual test: Filter performers by career length range
- [ ] Manual test: Filter performers by eye color, ethnicity, breast type