### PR TITLE
fix: case-insensitive performer filters and add fakeTits field

### DIFF
--- a/client/src/utils/__tests__/performerFilterConfig.test.js
+++ b/client/src/utils/__tests__/performerFilterConfig.test.js
@@ -212,10 +212,10 @@ describe("buildPerformerFilter", () => {
     });
 
     it("should build fake_tits filter with EQUALS modifier", () => {
-      const uiFilters = { fakeTits: "Yes" };
+      const uiFilters = { fakeTits: "Natural" };
       const result = buildPerformerFilter(uiFilters);
       expect(result.fake_tits).toEqual({
-        value: "Yes",
+        value: "Natural",
         modifier: "EQUALS",
       });
     });

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -162,8 +162,8 @@ const EYE_COLOR_OPTIONS = [
 ];
 
 const FAKE_TITS_OPTIONS = [
-  { value: "TRUE", label: "Fake" },
-  { value: "FALSE", label: "Natural" },
+  { value: "Fake", label: "Fake/Augmented" },
+  { value: "Natural", label: "Natural" },
 ];
 
 // Resolution options (matching Stash's ResolutionEnum)

--- a/server/controllers/library/performers.ts
+++ b/server/controllers/library/performers.ts
@@ -665,49 +665,57 @@ export async function applyPerformerFilters(
     }
   }
 
-  // Filter by eye_color (enum/string)
+  // Filter by eye_color (enum/string) - case-insensitive comparison
   if (filters.eye_color) {
     const { modifier, value } = filters.eye_color;
     if (value) {
+      const searchValue = value.toUpperCase();
       filtered = filtered.filter((p) => {
-        if (modifier === "EQUALS" || !modifier) return p.eye_color === value;
-        if (modifier === "NOT_EQUALS") return p.eye_color !== value;
+        const eyeColor = (p.eye_color || "").toUpperCase();
+        if (modifier === "EQUALS" || !modifier) return eyeColor === searchValue;
+        if (modifier === "NOT_EQUALS") return eyeColor !== searchValue;
         return true;
       });
     }
   }
 
-  // Filter by ethnicity (enum/string)
+  // Filter by ethnicity (enum/string) - case-insensitive comparison
   if (filters.ethnicity) {
     const { modifier, value } = filters.ethnicity;
     if (value) {
+      const searchValue = value.toUpperCase();
       filtered = filtered.filter((p) => {
-        if (modifier === "EQUALS" || !modifier) return p.ethnicity === value;
-        if (modifier === "NOT_EQUALS") return p.ethnicity !== value;
+        const ethnicity = (p.ethnicity || "").toUpperCase();
+        if (modifier === "EQUALS" || !modifier) return ethnicity === searchValue;
+        if (modifier === "NOT_EQUALS") return ethnicity !== searchValue;
         return true;
       });
     }
   }
 
-  // Filter by hair_color (enum/string)
+  // Filter by hair_color (enum/string) - case-insensitive comparison
   if (filters.hair_color) {
     const { modifier, value } = filters.hair_color;
     if (value) {
+      const searchValue = value.toUpperCase();
       filtered = filtered.filter((p) => {
-        if (modifier === "EQUALS" || !modifier) return p.hair_color === value;
-        if (modifier === "NOT_EQUALS") return p.hair_color !== value;
+        const hairColor = (p.hair_color || "").toUpperCase();
+        if (modifier === "EQUALS" || !modifier) return hairColor === searchValue;
+        if (modifier === "NOT_EQUALS") return hairColor !== searchValue;
         return true;
       });
     }
   }
 
-  // Filter by fake_tits/breast_type (enum/string)
+  // Filter by fake_tits/breast_type (enum/string) - case-insensitive comparison
   if (filters.fake_tits) {
     const { modifier, value } = filters.fake_tits;
     if (value) {
+      const searchValue = value.toUpperCase();
       filtered = filtered.filter((p) => {
-        if (modifier === "EQUALS" || !modifier) return p.fake_tits === value;
-        if (modifier === "NOT_EQUALS") return p.fake_tits !== value;
+        const fakeTits = (p.fake_tits || "").toUpperCase();
+        if (modifier === "EQUALS" || !modifier) return fakeTits === searchValue;
+        if (modifier === "NOT_EQUALS") return fakeTits !== searchValue;
         return true;
       });
     }

--- a/server/prisma/migrations/20251215000000_add_performer_fake_tits/migration.sql
+++ b/server/prisma/migrations/20251215000000_add_performer_fake_tits/migration.sql
@@ -1,0 +1,2 @@
+-- Add fakeTits column to StashPerformer for breast type filtering
+ALTER TABLE "StashPerformer" ADD COLUMN "fakeTits" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -494,6 +494,7 @@ model StashPerformer {
   heightCm     Int? // Height in cm
   weightKg     Int? // Weight in kg
   measurements String? // e.g., "34D-24-34"
+  fakeTits     String? // Breast type: "Natural", "Augmented", etc.
   tattoos      String?
   piercings    String?
   careerLength String?

--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -1339,6 +1339,7 @@ class StashEntityService {
       height_cm: performer.heightCm,
       weight: performer.weightKg,
       measurements: performer.measurements,
+      fake_tits: performer.fakeTits,
       tattoos: performer.tattoos,
       piercings: performer.piercings,
       career_length: performer.careerLength,

--- a/server/services/StashSyncService.ts
+++ b/server/services/StashSyncService.ts
@@ -947,6 +947,7 @@ class StashSyncService extends EventEmitter {
       ${performer.height_cm ?? "NULL"},
       ${performer.weight ?? "NULL"},
       ${this.escapeNullable(performer.measurements)},
+      ${this.escapeNullable(performer.fake_tits)},
       ${this.escapeNullable(performer.tattoos)},
       ${this.escapeNullable(performer.piercings)},
       ${this.escapeNullable(performer.career_length)},
@@ -969,7 +970,7 @@ class StashSyncService extends EventEmitter {
     INSERT INTO StashPerformer (
       id, stashInstanceId, name, disambiguation, gender, birthdate, favorite,
       rating100, details, aliasList,
-      country, ethnicity, hairColor, eyeColor, heightCm, weightKg, measurements,
+      country, ethnicity, hairColor, eyeColor, heightCm, weightKg, measurements, fakeTits,
       tattoos, piercings, careerLength, deathDate, url, imagePath,
       sceneCount, imageCount, galleryCount, groupCount,
       stashCreatedAt, stashUpdatedAt, syncedAt, deletedAt
@@ -990,6 +991,7 @@ class StashSyncService extends EventEmitter {
       heightCm = excluded.heightCm,
       weightKg = excluded.weightKg,
       measurements = excluded.measurements,
+      fakeTits = excluded.fakeTits,
       tattoos = excluded.tattoos,
       piercings = excluded.piercings,
       careerLength = excluded.careerLength,


### PR DESCRIPTION
## Summary

- Fix performer filters (eye_color, ethnicity, hair_color, fake_tits) that returned all performers instead of filtering correctly
- Add case-insensitive comparison for enum-like string filters
- Add missing `fakeTits` column to database schema with proper migration
- Update sync service to fetch `fake_tits` from Stash GraphQL
- Fix frontend dropdown options to use correct Stash values ("Fake"/"Natural" instead of "TRUE"/"FALSE")

## Test plan

- [x] Client tests pass (398 tests)
- [x] Server tests pass (253 tests)  
- [x] Linting passes
- [x] Manually verified breast type filter works with actual Stash data
- [ ] After merge, trigger full Stash sync to populate fakeTits for existing performers