### PR TITLE
fix: detail page tabs and O counter stale state

### DIFF
--- a/client/src/components/pages/GroupDetail.jsx
+++ b/client/src/components/pages/GroupDetail.jsx
@@ -205,6 +205,7 @@ const GroupDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No performers found in "${group?.name}"`}
             />
           )}

--- a/client/src/components/pages/PerformerDetail.jsx
+++ b/client/src/components/pages/PerformerDetail.jsx
@@ -273,6 +273,7 @@ const PerformerDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No galleries found for ${performer.name}`}
             />
           )}
@@ -292,6 +293,7 @@ const PerformerDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No collections found for ${performer.name}`}
             />
           )}

--- a/client/src/components/pages/StudioDetail.jsx
+++ b/client/src/components/pages/StudioDetail.jsx
@@ -275,6 +275,7 @@ const StudioDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No galleries found for ${studio?.name}`}
             />
           )}
@@ -298,6 +299,7 @@ const StudioDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No performers found for ${studio?.name}`}
             />
           )}
@@ -313,6 +315,7 @@ const StudioDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No collections found for ${studio?.name}`}
             />
           )}

--- a/client/src/components/pages/TagDetail.jsx
+++ b/client/src/components/pages/TagDetail.jsx
@@ -289,6 +289,7 @@ const TagDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No galleries found with tag "${tag?.name}"`}
             />
           )}
@@ -308,6 +309,7 @@ const TagDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No performers found with tag "${tag?.name}"`}
             />
           )}
@@ -323,6 +325,7 @@ const TagDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No studios found with tag "${tag?.name}"`}
             />
           )}
@@ -338,6 +341,7 @@ const TagDetail = () => {
                 },
               }}
               hideLockedFilters
+              syncToUrl={false}
               emptyMessage={`No collections found with tag "${tag?.name}"`}
             />
           )}

--- a/client/src/contexts/scenePlayerReducer.js
+++ b/client/src/contexts/scenePlayerReducer.js
@@ -254,6 +254,8 @@ export function scenePlayerReducer(state, action) {
         ready: false,
         // Reset quality to "direct" for new scene - will be auto-selected based on codec
         quality: "direct",
+        // Reset O counter immediately - will be set correctly when new scene loads
+        oCounter: 0,
       };
     }
 
@@ -286,6 +288,8 @@ export function scenePlayerReducer(state, action) {
             ready: false,
             // Reset quality to "direct" for new scene - will be auto-selected based on codec
             quality: "direct",
+            // Reset O counter immediately - will be set correctly when new scene loads
+            oCounter: 0,
           };
         } else {
           // No history - pick a random scene (excluding current)
@@ -319,6 +323,8 @@ export function scenePlayerReducer(state, action) {
         ready: false,
         // Reset quality to "direct" for new scene - will be auto-selected based on codec
         quality: "direct",
+        // Reset O counter immediately - will be set correctly when new scene loads
+        oCounter: 0,
       };
     }
 


### PR DESCRIPTION
## Summary

Fixes two HIGH/MEDIUM priority issues identified in v3.0.0-beta.9:

**Issue #1: Detail page tabs not loading (HIGH)**
- Clicking non-Scenes tabs (Galleries, Images, Groups, etc.) on detail pages would flicker and revert to Scenes
- Root cause: `SearchControls` was replacing entire URL params, obliterating the `?tab=` parameter
- Fix: Add `syncToUrl={false}` to nested grids in detail pages

**Issue #4: O counter shows stale value after playlist navigation (MEDIUM)**
- After incrementing O counter and navigating to next scene, old value persisted
- Root cause: Race condition - UI renders with stale state before async API call completes
- Fix: Reset `oCounter: 0` in `NEXT_SCENE` and `PREV_SCENE` reducer actions

## Files Changed
- `client/src/components/pages/PerformerDetail.jsx`
- `client/src/components/pages/StudioDetail.jsx`
- `client/src/components/pages/TagDetail.jsx`
- `client/src/components/pages/GroupDetail.jsx`
- `client/src/contexts/scenePlayerReducer.js`

## Test plan
- [ ] Navigate to Performer detail page, click Galleries tab - should load galleries
- [ ] Navigate to Studio detail page, click Performers tab - should load performers
- [ ] Navigate to Tag detail page, click Studios tab - should load studios
- [ ] Navigate to Group detail page, click Performers tab - should load performers
- [ ] In scene player with playlist, increment O counter, navigate to next scene - O counter should show 0 then correct value