### PR TITLE
fix: O counter prop mismatch and strip API keys from stream URLs

### DIFF
--- a/client/src/components/video-player/PlaybackControls.jsx
+++ b/client/src/components/video-player/PlaybackControls.jsx
@@ -104,7 +104,7 @@ const PlaybackControls = () => {
             <OCounterButton
               sceneId={scene?.id}
               initialCount={oCounter}
-              onIncrement={(newCount) =>
+              onChange={(newCount) =>
                 dispatch({ type: "SET_O_COUNTER", payload: newCount })
               }
               disabled={isLoading}
@@ -141,7 +141,7 @@ const PlaybackControls = () => {
               <OCounterButton
                 sceneId={scene?.id}
                 initialCount={oCounter}
-                onIncrement={(newCount) =>
+                onChange={(newCount) =>
                   dispatch({ type: "SET_O_COUNTER", payload: newCount })
                 }
                 disabled={isLoading}
@@ -170,7 +170,7 @@ const PlaybackControls = () => {
             <OCounterButton
               sceneId={scene?.id}
               initialCount={oCounter}
-              onIncrement={(newCount) =>
+              onChange={(newCount) =>
                 dispatch({ type: "SET_O_COUNTER", payload: newCount })
               }
               disabled={isLoading}

--- a/client/src/components/video-player/useVideoPlayer.js
+++ b/client/src/components/video-player/useVideoPlayer.js
@@ -511,7 +511,12 @@ export function useVideoPlayer({
           // e.g., "stream.m3u8" from "http://stash:9999/scene/123/stream.m3u8?resolution=STANDARD_HD"
           const pathParts = url.pathname.split(`/scene/${scene.id}/`);
           const streamPath = pathParts[1] || 'stream'; // "stream.m3u8" or "stream"
-          const queryString = url.search; // "?resolution=STANDARD_HD" or ""
+
+          // Strip apikey from query params (security: don't expose Stash API key to client)
+          url.searchParams.delete('apikey');
+          url.searchParams.delete('ApiKey');
+          url.searchParams.delete('APIKEY');
+          const queryString = url.search; // "?resolution=STANDARD_HD" or "" (without apikey)
 
           // Rewrite to Peek's proxy endpoint
           const proxiedUrl = `/api/scene/${scene.id}/proxy-stream/${streamPath}${queryString}`;

--- a/client/src/contexts/scenePlayerReducer.js
+++ b/client/src/contexts/scenePlayerReducer.js
@@ -352,6 +352,8 @@ export function scenePlayerReducer(state, action) {
         shouldAutoplay: shouldAutoplay,
         // Reset quality to "direct" for new scene - will be auto-selected based on codec
         quality: "direct",
+        // Reset O counter immediately - will be set correctly when new scene loads
+        oCounter: 0,
       };
     }
 

--- a/server/controllers/video.ts
+++ b/server/controllers/video.ts
@@ -7,6 +7,78 @@ import { logger } from "../utils/logger.js";
 // ============================================================================
 
 /**
+ * Rewrite URLs in HLS playlist to use Peek's proxy
+ * Stash includes apikey in segment URLs - we need to strip that and route through our proxy
+ *
+ * HLS playlists can contain various URL formats:
+ * - Absolute: http://stash:9999/scene/123/stream/segment_0.ts?apikey=xxx&resolution=FULL_HD
+ * - Absolute path: /scene/123/stream/segment_0.ts?apikey=xxx
+ * - Relative: stream/segment_0.ts?apikey=xxx
+ * - Just segment: segment_0.ts?apikey=xxx
+ *
+ * All should be rewritten to: /api/scene/{sceneId}/proxy-stream/{path}?{params without apikey}
+ */
+function rewriteHlsPlaylist(content: string, sceneId: string, _stashBaseUrl: string): string {
+  const lines = content.split('\n');
+
+  return lines.map(line => {
+    // Skip empty lines and HLS tags (start with #)
+    if (!line.trim() || line.startsWith('#')) {
+      return line;
+    }
+
+    try {
+      let urlPath: string;
+      let queryParams: URLSearchParams;
+
+      // Check if it's a full URL or a path
+      if (line.includes('://')) {
+        // Absolute URL: http://stash:9999/scene/123/stream/segment.ts?apikey=xxx
+        const url = new URL(line);
+        urlPath = url.pathname;
+        queryParams = url.searchParams;
+      } else if (line.startsWith('/')) {
+        // Absolute path: /scene/123/stream/segment.ts?apikey=xxx
+        const [path, query] = line.split('?');
+        urlPath = path;
+        queryParams = new URLSearchParams(query || '');
+      } else {
+        // Relative path: stream/segment.ts?apikey=xxx or segment.ts?apikey=xxx
+        const [path, query] = line.split('?');
+        urlPath = path;
+        queryParams = new URLSearchParams(query || '');
+      }
+
+      // Strip apikey from query params (case-insensitive)
+      queryParams.delete('apikey');
+      queryParams.delete('ApiKey');
+      queryParams.delete('APIKEY');
+
+      // Extract the stream path (everything after /scene/{id}/)
+      let streamPath: string;
+      const scenePathMatch = urlPath.match(/\/scene\/\d+\/(.+)/);
+      if (scenePathMatch) {
+        streamPath = scenePathMatch[1];
+      } else {
+        // If no scene path pattern, use the path as-is
+        streamPath = urlPath.startsWith('/') ? urlPath.slice(1) : urlPath;
+      }
+
+      // Build clean query string
+      const cleanQuery = queryParams.toString();
+      const queryString = cleanQuery ? `?${cleanQuery}` : '';
+
+      // Return proxied URL
+      return `/api/scene/${sceneId}/proxy-stream/${streamPath}${queryString}`;
+    } catch {
+      // If parsing fails, return original line (shouldn't happen for valid playlists)
+      logger.warn(`[PROXY] Failed to rewrite HLS line: ${line}`);
+      return line;
+    }
+  }).join('\n');
+}
+
+/**
  * Proxy all stream requests to Stash
  * Peek proxies ALL streams to Stash instead of managing its own transcoding.
  *
@@ -16,10 +88,15 @@ import { logger } from "../utils/logger.js";
  * GET /api/scene/:sceneId/proxy-stream/hls/:segment.ts?resolution=STANDARD -> Stash HLS segment
  *
  * This lets Stash handle all codec detection, transcoding, and quality selection.
+ *
+ * SECURITY: For HLS playlists (.m3u8), we rewrite internal URLs to strip the Stash API key
+ * and route segment requests through Peek's proxy.
  */
 export const proxyStashStream = async (req: Request, res: Response) => {
   try {
-    const { sceneId, streamPath } = req.params;
+    const { sceneId, streamPath, subPath } = req.params;
+    // Combine path segments if subPath exists (for HLS segments like stream/segment_0.ts)
+    const fullStreamPath = subPath ? `${streamPath}/${subPath}` : streamPath;
 
     // Parse query string from original request
     const queryString = req.url.split('?')[1] || '';
@@ -36,7 +113,7 @@ export const proxyStashStream = async (req: Request, res: Response) => {
       return res.status(500).send("Stash not configured");
     }
 
-    const stashUrl = `${stashBaseUrl}/scene/${sceneId}/${streamPath}${queryString ? '?' + queryString : ''}`;
+    const stashUrl = `${stashBaseUrl}/scene/${sceneId}/${fullStreamPath}${queryString ? '?' + queryString : ''}`;
 
     logger.info(`[PROXY] Proxying stream: ${req.url} -> ${stashUrl}`);
 
@@ -51,6 +128,27 @@ export const proxyStashStream = async (req: Request, res: Response) => {
     if (!response.ok) {
       logger.warn(`[PROXY] Stash returned ${response.status} for ${stashUrl}`);
       return res.status(response.status).send(`Stash stream error: ${response.statusText}`);
+    }
+
+    // Check if this is an HLS playlist that needs URL rewriting
+    const contentType = response.headers.get('content-type') || '';
+    const isHlsPlaylist = fullStreamPath.endsWith('.m3u8') ||
+                          contentType.includes('mpegurl') ||
+                          contentType.includes('x-mpegURL');
+
+    if (isHlsPlaylist) {
+      // For HLS playlists, read the entire response and rewrite URLs
+      const playlistContent = await response.text();
+      const rewrittenContent = rewriteHlsPlaylist(playlistContent, sceneId, stashBaseUrl);
+
+      // Set headers for the rewritten playlist
+      res.status(response.status);
+      res.setHeader('content-type', 'application/vnd.apple.mpegurl');
+      res.setHeader('cache-control', 'no-cache');
+      res.send(rewrittenContent);
+
+      logger.debug(`[PROXY] Rewrote HLS playlist: ${fullStreamPath}`);
+      return;
     }
 
     // Forward status code
@@ -100,7 +198,7 @@ export const proxyStashStream = async (req: Request, res: Response) => {
       res.end();
     }
 
-    logger.debug(`[PROXY] Stream proxied successfully: ${streamPath}`);
+    logger.debug(`[PROXY] Stream proxied successfully: ${fullStreamPath}`);
   } catch (error) {
     logger.error("[PROXY] Error proxying stream", {
       error: error instanceof Error ? error.message : String(error),

--- a/server/routes/video.ts
+++ b/server/routes/video.ts
@@ -7,7 +7,10 @@ import {
 const router = express.Router();
 
 // Stash stream proxy - forwards ALL stream requests to Stash
-// :streamPath matches the file being requested (stream, stream.m3u8, stream.mp4, etc.)
+// Two routes to handle both single-segment and multi-segment paths:
+//   /scene/123/proxy-stream/stream.m3u8 -> streamPath = "stream.m3u8"
+//   /scene/123/proxy-stream/stream/segment_0.ts -> streamPath = "stream", subPath = "segment_0.ts"
+router.get("/scene/:sceneId/proxy-stream/:streamPath/:subPath", proxyStashStream);
 router.get("/scene/:sceneId/proxy-stream/:streamPath", proxyStashStream);
 
 // Caption/subtitle proxy


### PR DESCRIPTION
## Summary
- **Fix O counter stale state**: Fixed prop name mismatch where `PlaybackControls` passed `onIncrement` but `OCounterButton` expects `onChange`, causing the counter to never update
- **Security: Strip API keys from stream URLs**: Added server-side HLS playlist rewriting and client-side URL sanitization to prevent Stash API keys from leaking to the browser

## Changes
- `PlaybackControls.jsx`: Changed `onIncrement` → `onChange` for all OCounterButton instances
- `scenePlayerReducer.js`: Reset oCounter to 0 in GOTO_SCENE_INDEX action
- `video.ts` (controller): Added `rewriteHlsPlaylist()` function to strip apikey from HLS playlist segment URLs
- `video.ts` (routes): Added second route for multi-segment HLS paths (`stream/segment_0.ts`)
- `useVideoPlayer.js`: Strip apikey client-side before building proxy URLs (defense in depth)

## Test plan
- [ ] Play a scene and verify O counter increments when clicked
- [ ] Navigate to next/prev scene in playlist and verify O counter resets and shows correct value
- [ ] Play HLS stream and verify no `apikey` appears in network requests
- [ ] Check browser dev tools network tab for any exposed API keys