### PR TITLE
fix: handle large exclusion sets by chunking NOT IN clauses

### DIFF
--- a/server/services/SceneQueryBuilder.ts
+++ b/server/services/SceneQueryBuilder.ts
@@ -83,18 +83,18 @@ class SceneQueryBuilder {
   /**
    * Build exclusion filter clause
    * Excludes scenes by ID (from user restrictions)
+   * Handles large sets by chunking into multiple NOT IN clauses
    */
   private buildExclusionFilter(excludedIds: Set<string>): FilterClause {
     if (!excludedIds || excludedIds.size === 0) {
       return { sql: "", params: [] };
     }
 
-    // For large exclusion sets, use a subquery approach
-    // SQLite handles IN clauses well up to ~1000 items
     const ids = Array.from(excludedIds);
+    const CHUNK_SIZE = 500;
 
-    if (ids.length <= 500) {
-      // Direct IN clause for smaller sets
+    if (ids.length <= CHUNK_SIZE) {
+      // Single NOT IN clause for small sets
       const placeholders = ids.map(() => "?").join(", ");
       return {
         sql: `s.id NOT IN (${placeholders})`,
@@ -102,16 +102,25 @@ class SceneQueryBuilder {
       };
     }
 
-    // For larger sets, we'll need to use a different approach
-    // This is a pragmatic limit - if you have >500 exclusions,
-    // consider pre-computing a materialized view
-    const placeholders = ids.slice(0, 500).map(() => "?").join(", ");
-    logger.warn("Exclusion set truncated to 500 items", {
-      originalSize: ids.length,
+    // Chunk large sets into multiple NOT IN clauses combined with AND
+    const clauses: string[] = [];
+    const allParams: string[] = [];
+
+    for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+      const chunk = ids.slice(i, i + CHUNK_SIZE);
+      const placeholders = chunk.map(() => "?").join(", ");
+      clauses.push(`s.id NOT IN (${placeholders})`);
+      allParams.push(...chunk);
+    }
+
+    logger.debug("Large exclusion set chunked", {
+      totalSize: ids.length,
+      chunks: clauses.length,
     });
+
     return {
-      sql: `s.id NOT IN (${placeholders})`,
-      params: ids.slice(0, 500),
+      sql: `(${clauses.join(" AND ")})`,
+      params: allParams,
     };
   }
 


### PR DESCRIPTION
## Summary

- Fixes content restriction exclusions being truncated to 500 items
- Users with >500 tag exclusions now see all excluded content properly filtered
- Chunks large exclusion sets into multiple NOT IN clauses combined with AND

## Problem

User logs showed:
```
"computed 1531 exclusions in 9ms"
"Exclusion set truncated to 500 items"
"originalSize": 1531
```

This caused excluded content to appear when browsing.

## Solution

Instead of truncating to 500 items, chunk the exclusion set into multiple NOT IN clauses:

```sql
WHERE (s.id NOT IN (chunk1) AND s.id NOT IN (chunk2) AND ...)
```

SQLite handles each chunk efficiently, and AND combination maintains correct semantics.

## Test plan

- [x] TypeScript builds successfully
- [x] All 466 tests pass
- [x] Lint passes
- [ ] Manual test with user having >500 tag exclusions

Closes #200 (Part 2)