### PR TITLE
fix: use most recent sync timestamp for incremental syncs

### DIFF
--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -1228,12 +1228,7 @@ class StashEntityService {
    * Uses the last sync timestamp as a version number
    */
   async getCacheVersion(): Promise<number> {
-    const syncState = await prisma.syncState.findFirst({
-      where: { entityType: "scene" },
-    });
-
-    // Use the last sync time as a cache version (convert to integer timestamp)
-    const lastSync = syncState?.lastIncrementalSync || syncState?.lastFullSync;
+    const lastSync = await this.getLastRefreshed();
     return lastSync ? lastSync.getTime() : 0;
   }
 


### PR DESCRIPTION
## Summary
- Fixes bug where incremental syncs used the wrong timestamp after a full sync
- Adds `getMostRecentSyncTime()` helper to correctly compare timestamps
- Refactors `getCacheVersion()` to reuse existing correct logic

## Test plan
- [x] All 8 new unit tests pass covering timestamp comparison scenarios
- [x] Full test suite (472 tests) passes
- [x] Build compiles without errors
- [x] Lint passes

Fixes #200