### PR TITLE
fix: correct timezone handling in sync timestamps

### DIFF
--- a/server/prisma/migrations/20251228000000_add_sync_display_timestamps/migration.sql
+++ b/server/prisma/migrations/20251228000000_add_sync_display_timestamps/migration.sql
@@ -1,0 +1,6 @@
+-- Add display timestamp fields to SyncState
+-- These store the actual UTC time for UI display, separate from the
+-- "fake UTC" timestamps used for Stash sync queries
+
+ALTER TABLE "SyncState" ADD COLUMN "lastFullSyncActual" DATETIME;
+ALTER TABLE "SyncState" ADD COLUMN "lastIncrementalSyncActual" DATETIME;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -869,8 +869,16 @@ model SyncState {
   stashInstanceId String?
   entityType      String // 'scene', 'performer', etc.
 
+  // Timestamps for Stash sync queries (stored as "fake UTC" - local time values in UTC format)
+  // These preserve Stash's local time so queries use correct timestamps
   lastFullSync        DateTime?
   lastIncrementalSync DateTime?
+
+  // Timestamps for UI display (actual UTC time when sync occurred)
+  // These are the real times for user-facing display
+  lastFullSyncActual        DateTime?
+  lastIncrementalSyncActual DateTime?
+
   lastSyncCount       Int       @default(0)
   lastSyncDurationMs  Int?
   lastError           String?

--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -1205,7 +1205,10 @@ class StashEntityService {
   }
 
   /**
-   * Get last refresh time (returns most recent of full or incremental sync)
+   * Get last refresh time for display (returns most recent actual sync time)
+   *
+   * Uses the "Actual" timestamp fields which store real UTC time (for display),
+   * as opposed to the "fake UTC" timestamps used for Stash sync queries.
    */
   async getLastRefreshed(): Promise<Date | null> {
     const syncState = await prisma.syncState.findFirst({
@@ -1214,7 +1217,9 @@ class StashEntityService {
 
     if (!syncState) return null;
 
-    const { lastFullSync, lastIncrementalSync } = syncState;
+    // Use actual timestamps for display (fall back to sync timestamps for backwards compatibility)
+    const lastFullSync = syncState.lastFullSyncActual ?? syncState.lastFullSync;
+    const lastIncrementalSync = syncState.lastIncrementalSyncActual ?? syncState.lastIncrementalSync;
 
     // Return whichever sync happened more recently
     if (!lastFullSync) return lastIncrementalSync;


### PR DESCRIPTION
## Summary

- Fixes timezone handling bug where incremental syncs were skipping newly added entities
- Stash's GraphQL API ignores timezone suffixes and interprets all timestamps as local time
- The previous fix (3.0.2-beta.1) still had issues due to UTC conversion during storage/retrieval
- Introduces `stashTimestampToFakeUtcDate()` which preserves local time values through the round-trip
- Adds separate display timestamp fields so UI shows the real sync time

## Root Cause

When Stash returns `2025-12-28T10:47:51-08:00` (10:47 AM Pacific):
1. Old code: `new Date()` converts to UTC internally → 17:47:51 UTC
2. Later: `toISOString()` → `2025-12-28T17:47:51.000Z` → strip Z → `17:47:51`
3. Stash interprets `17:47:51` as **5:47 PM local time**, not 9:47 AM!
4. Entities updated between 9:47 AM and 5:47 PM were missed

## The Fix

`stashTimestampToFakeUtcDate()`:
- Strips timezone: `2025-12-28T10:47:51-08:00` → `2025-12-28T10:47:51`
- Parses as UTC: `new Date("2025-12-28T10:47:51Z")` → internally `10:47:51 UTC`
- When retrieved: `toISOString()` → `10:47:51.000Z` → strip Z → `10:47:51` ✓

## Changes

- `server/services/StashSyncService.ts` - Core fix with new helper functions
- `server/services/StashEntityService.ts` - Use actual timestamps for UI display
- `server/prisma/schema.prisma` - New display timestamp fields
- Migration for new columns

## Test Plan

- [x] Verified with live Stash queries that timestamps are preserved correctly
- [x] All 472 unit tests pass
- [x] Build passes
- [x] Linting passes (no new warnings)
- [ ] Manual testing: upgrade, full sync, wait for incremental, verify new entities appear

## Upgrade Notes

**Requires a full sync after upgrading** - existing timestamps are in the wrong format

Fixes #200