### PR TITLE
fix: playlist item removal UX issues

### DIFF
--- a/client/src/components/pages/PlaylistDetail.jsx
+++ b/client/src/components/pages/PlaylistDetail.jsx
@@ -110,11 +110,15 @@ const PlaylistDetail = () => {
       await api.delete(
         `/playlists/${playlistId}/items/${sceneToRemove.sceneId}`
       );
+      // Optimistically update local state instead of refetching
+      setScenes((prev) =>
+        prev.filter((item) => item.sceneId !== sceneToRemove.sceneId)
+      );
       showSuccess("Scene removed from playlist");
-      loadPlaylist();
     } catch {
       showError("Failed to remove scene from playlist");
     } finally {
+      setRemoveConfirmOpen(false);
       setSceneToRemove(null);
     }
   };


### PR DESCRIPTION
## Summary
- Fix double confirmation dialog when removing playlist items (dialog wasn't closing)
- Use optimistic state update instead of full data refetch
- Scroll position now preserved after item removal

## Test plan
- [ ] Navigate to a playlist with multiple items
- [ ] Remove an item from the middle of the list
- [ ] Verify only one confirmation dialog appears
- [ ] Verify scroll position stays the same after removal
- [ ] Verify item count updates correctly