### PR TITLE
fix: improve Images page with O Count sort/filter and denser grid

### DIFF
--- a/client/src/components/pages/Images.jsx
+++ b/client/src/components/pages/Images.jsx
@@ -137,7 +137,7 @@ const Images = () => {
           {...searchControlsProps}
         >
           {isLoading ? (
-            <div className={STANDARD_GRID_CONTAINER_CLASSNAMES}>
+            <div className={`${STANDARD_GRID_CONTAINER_CLASSNAMES} xl:grid-cols-4 2xl:grid-cols-5`}>
               {[...Array(24)].map((_, i) => (
                 <div
                   key={i}
@@ -151,7 +151,7 @@ const Images = () => {
             </div>
           ) : (
             <>
-              <div ref={gridRef} className={STANDARD_GRID_CONTAINER_CLASSNAMES}>
+              <div ref={gridRef} className={`${STANDARD_GRID_CONTAINER_CLASSNAMES} xl:grid-cols-4 2xl:grid-cols-5`}>
                 {currentImages.map((image, index) => {
                   const itemProps = gridItemProps(index);
                   return (

--- a/client/src/utils/filterConfig.js
+++ b/client/src/utils/filterConfig.js
@@ -1275,6 +1275,14 @@ export const IMAGE_FILTER_OPTIONS = [
     defaultValue: false,
     placeholder: "Favorites Only",
   },
+  {
+    key: "oCounter",
+    label: "O Count",
+    type: "range",
+    defaultValue: {},
+    min: 0,
+    max: 1000,
+  },
 ];
 
 /**
@@ -2752,6 +2760,27 @@ export const buildImageFilter = (filters) => {
       value: filters.galleryIds.map(String),
       modifier: filters.galleryIdsModifier || "INCLUDES",
     };
+  }
+
+  // O Counter filter
+  if (filters.oCounter?.min !== undefined || filters.oCounter?.max !== undefined) {
+    imageFilter.o_counter = {};
+    const hasMin =
+      filters.oCounter.min !== undefined && filters.oCounter.min !== "";
+    const hasMax =
+      filters.oCounter.max !== undefined && filters.oCounter.max !== "";
+
+    if (hasMin && hasMax) {
+      imageFilter.o_counter.modifier = "BETWEEN";
+      imageFilter.o_counter.value = parseInt(filters.oCounter.min);
+      imageFilter.o_counter.value2 = parseInt(filters.oCounter.max);
+    } else if (hasMin) {
+      imageFilter.o_counter.modifier = "GREATER_THAN";
+      imageFilter.o_counter.value = parseInt(filters.oCounter.min) - 1;
+    } else if (hasMax) {
+      imageFilter.o_counter.modifier = "LESS_THAN";
+      imageFilter.o_counter.value = parseInt(filters.oCounter.max) + 1;
+    }
   }
 
   return imageFilter;

--- a/server/controllers/library/images.ts
+++ b/server/controllers/library/images.ts
@@ -91,6 +91,20 @@ async function applyImageFiltersWithInheritance(
     });
   }
 
+  // Filter by o_counter
+  if (filters?.o_counter) {
+    const { modifier, value, value2 } = filters.o_counter;
+    filtered = filtered.filter((img) => {
+      const oCounter = img.oCounter ?? img.o_counter ?? 0;
+      if (modifier === "GREATER_THAN") return oCounter > value;
+      if (modifier === "LESS_THAN") return oCounter < value;
+      if (modifier === "EQUALS") return oCounter === value;
+      if (modifier === "NOT_EQUALS") return oCounter !== value;
+      if (modifier === "BETWEEN") return oCounter >= value && oCounter <= value2;
+      return true;
+    });
+  }
+
   // Filter by performers (with gallery-umbrella inheritance)
   if (filters?.performers?.value) {
     const performerIds = new Set(filters.performers.value.map(String));
@@ -213,8 +227,8 @@ function sortImages(
         bVal = b.rating100 || 0;
         break;
       case "o_counter":
-        aVal = a.o_counter || 0;
-        bVal = b.o_counter || 0;
+        aVal = a.oCounter ?? a.o_counter ?? 0;
+        bVal = b.oCounter ?? b.o_counter ?? 0;
         break;
       case "filesize":
         aVal = Number(a.fileSize) || 0;


### PR DESCRIPTION
## Summary

- Fix O Count sorting for Images (field name mismatch between `oCounter` and `o_counter`)
- Add O Counter filter to Images page filter panel
- Increase grid density for Images page at `xl` (4 cols) and `2xl` (5 cols) breakpoints

## Test plan

- [ ] Verify O Count sorting works on Images page (sort by O Count ascending/descending)
- [ ] Verify O Counter filter appears in Images filter panel and filters correctly
- [ ] Verify grid shows 4 columns at 1280-1535px viewport width
- [ ] Verify grid shows 5 columns at 1536-1919px viewport width
- [ ] Verify other pages (Performers, Galleries, etc.) are unaffected