### PR TITLE
perf: improve scalability for large libraries (500k+ images)

### DIFF
--- a/server/services/EntityImageCountService.ts
+++ b/server/services/EntityImageCountService.ts
@@ -1,6 +1,5 @@
 import prisma from "../prisma/singleton.js";
 import { logger } from "../utils/logger.js";
-import { stashEntityService } from "./StashEntityService.js";
 
 /**
  * EntityImageCountService
@@ -16,39 +15,28 @@ import { stashEntityService } from "./StashEntityService.js";
  *
  * This service recalculates these counts after sync and stores them in the database
  * for fast retrieval on detail pages.
+ *
+ * PERFORMANCE: Uses SQL aggregation instead of loading all images into memory.
+ * This scales to millions of images without memory issues.
  */
-
-interface ImageWithRelations {
-  id: string;
-  studioId?: string | null;
-  performers?: Array<{ id: string }>;
-  tags?: Array<{ id: string }>;
-  galleries?: Array<{
-    id: string;
-    studioId?: string | null;
-    performers?: Array<{ id: string }>;
-    tags?: Array<{ id: string }>;
-  }>;
-}
 
 class EntityImageCountService {
   /**
    * Rebuild inherited image counts for all entity types.
    * Called after sync completes to ensure counts reflect gallery inheritance.
+   *
+   * Uses SQL UNION queries to count images efficiently without loading them into memory.
    */
   async rebuildAllImageCounts(): Promise<void> {
     const startTime = Date.now();
     logger.info("Rebuilding inherited image counts for all entities...");
 
     try {
-      // Load all images with their relationships once
-      const allImages = await stashEntityService.getAllImages();
-
-      // Rebuild counts for each entity type in parallel
+      // Rebuild counts for each entity type in parallel using SQL aggregation
       await Promise.all([
-        this.rebuildPerformerImageCounts(allImages),
-        this.rebuildStudioImageCounts(allImages),
-        this.rebuildTagImageCounts(allImages),
+        this.rebuildPerformerImageCountsSQL(),
+        this.rebuildStudioImageCountsSQL(),
+        this.rebuildTagImageCountsSQL(),
       ]);
 
       const duration = Date.now() - startTime;
@@ -62,229 +50,141 @@ class EntityImageCountService {
   }
 
   /**
-   * Rebuild image counts for all performers.
+   * Rebuild image counts for all performers using SQL aggregation.
    * Counts images where performer is directly tagged OR tagged on a parent gallery.
+   *
+   * Uses UNION to combine:
+   * 1. Direct: ImagePerformer joins
+   * 2. Inherited: ImageGallery -> GalleryPerformer joins
    */
-  async rebuildPerformerImageCounts(allImages?: ImageWithRelations[]): Promise<void> {
+  private async rebuildPerformerImageCountsSQL(): Promise<void> {
     const startTime = Date.now();
 
-    // Load images if not provided
-    const images = allImages ?? await stashEntityService.getAllImages();
+    // Single SQL query that:
+    // 1. Finds all distinct (imageId, performerId) pairs from direct + inherited relations
+    // 2. Groups by performerId to get counts
+    // 3. Updates all performers in one batch
+    await prisma.$executeRaw`
+      UPDATE StashPerformer
+      SET imageCount = COALESCE((
+        SELECT COUNT(DISTINCT imageId) FROM (
+          -- Direct: image has performer directly
+          SELECT ip.imageId, ip.performerId
+          FROM ImagePerformer ip
+          JOIN StashImage si ON ip.imageId = si.id AND si.deletedAt IS NULL
 
-    // Get all performer IDs
-    const performers = await prisma.stashPerformer.findMany({
-      where: { deletedAt: null },
-      select: { id: true },
-    });
+          UNION
 
-    if (performers.length === 0) {
-      logger.debug("No performers to update image counts for");
-      return;
-    }
-
-    // Calculate counts for each performer
-    const counts = new Map<string, number>();
-
-    for (const performer of performers) {
-      const count = this.countImagesForPerformer(images, performer.id);
-      counts.set(performer.id, count);
-    }
-
-    // Batch update all performers
-    await this.batchUpdatePerformerImageCounts(counts);
+          -- Inherited: image is in gallery that has performer
+          SELECT ig.imageId, gp.performerId
+          FROM ImageGallery ig
+          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL
+          JOIN GalleryPerformer gp ON ig.galleryId = gp.galleryId
+        ) AS combined
+        WHERE combined.performerId = StashPerformer.id
+      ), 0)
+      WHERE StashPerformer.deletedAt IS NULL
+    `;
 
     const duration = Date.now() - startTime;
-    logger.debug(`Performer image counts rebuilt in ${duration}ms`, {
-      performerCount: performers.length,
-    });
+    logger.debug(`Performer image counts rebuilt via SQL in ${duration}ms`);
   }
 
   /**
-   * Rebuild image counts for all studios.
+   * Rebuild image counts for all studios using SQL aggregation.
    * Counts images where studio is directly set OR set on a parent gallery.
    */
-  async rebuildStudioImageCounts(allImages?: ImageWithRelations[]): Promise<void> {
+  private async rebuildStudioImageCountsSQL(): Promise<void> {
     const startTime = Date.now();
 
-    const images = allImages ?? await stashEntityService.getAllImages();
+    await prisma.$executeRaw`
+      UPDATE StashStudio
+      SET imageCount = COALESCE((
+        SELECT COUNT(DISTINCT imageId) FROM (
+          -- Direct: image has studio directly
+          SELECT si.id AS imageId, si.studioId
+          FROM StashImage si
+          WHERE si.deletedAt IS NULL AND si.studioId IS NOT NULL
 
-    const studios = await prisma.stashStudio.findMany({
-      where: { deletedAt: null },
-      select: { id: true },
-    });
+          UNION
 
-    if (studios.length === 0) {
-      logger.debug("No studios to update image counts for");
-      return;
-    }
-
-    const counts = new Map<string, number>();
-
-    for (const studio of studios) {
-      const count = this.countImagesForStudio(images, studio.id);
-      counts.set(studio.id, count);
-    }
-
-    await this.batchUpdateStudioImageCounts(counts);
+          -- Inherited: image is in gallery that has studio
+          SELECT ig.imageId, sg.studioId
+          FROM ImageGallery ig
+          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL AND sg.studioId IS NOT NULL
+        ) AS combined
+        WHERE combined.studioId = StashStudio.id
+      ), 0)
+      WHERE StashStudio.deletedAt IS NULL
+    `;
 
     const duration = Date.now() - startTime;
-    logger.debug(`Studio image counts rebuilt in ${duration}ms`, {
-      studioCount: studios.length,
-    });
+    logger.debug(`Studio image counts rebuilt via SQL in ${duration}ms`);
   }
 
   /**
-   * Rebuild image counts for all tags.
+   * Rebuild image counts for all tags using SQL aggregation.
    * Counts images where tag is directly set OR set on a parent gallery.
    */
-  async rebuildTagImageCounts(allImages?: ImageWithRelations[]): Promise<void> {
+  private async rebuildTagImageCountsSQL(): Promise<void> {
     const startTime = Date.now();
 
-    const images = allImages ?? await stashEntityService.getAllImages();
+    await prisma.$executeRaw`
+      UPDATE StashTag
+      SET imageCount = COALESCE((
+        SELECT COUNT(DISTINCT imageId) FROM (
+          -- Direct: image has tag directly
+          SELECT it.imageId, it.tagId
+          FROM ImageTag it
+          JOIN StashImage si ON it.imageId = si.id AND si.deletedAt IS NULL
 
-    const tags = await prisma.stashTag.findMany({
-      where: { deletedAt: null },
-      select: { id: true },
-    });
+          UNION
 
-    if (tags.length === 0) {
-      logger.debug("No tags to update image counts for");
-      return;
-    }
-
-    const counts = new Map<string, number>();
-
-    for (const tag of tags) {
-      const count = this.countImagesForTag(images, tag.id);
-      counts.set(tag.id, count);
-    }
-
-    await this.batchUpdateTagImageCounts(counts);
+          -- Inherited: image is in gallery that has tag
+          SELECT ig.imageId, gt.tagId
+          FROM ImageGallery ig
+          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL
+          JOIN GalleryTag gt ON ig.galleryId = gt.galleryId
+        ) AS combined
+        WHERE combined.tagId = StashTag.id
+      ), 0)
+      WHERE StashTag.deletedAt IS NULL
+    `;
 
     const duration = Date.now() - startTime;
-    logger.debug(`Tag image counts rebuilt in ${duration}ms`, {
-      tagCount: tags.length,
-    });
+    logger.debug(`Tag image counts rebuilt via SQL in ${duration}ms`);
+  }
+
+  // ============================================================================
+  // Legacy methods kept for backwards compatibility / individual entity updates
+  // These use the old approach but are only called for single-entity updates
+  // ============================================================================
+
+  /**
+   * Rebuild image counts for all performers (legacy method).
+   * @deprecated Use rebuildPerformerImageCountsSQL for bulk operations
+   */
+  async rebuildPerformerImageCounts(): Promise<void> {
+    return this.rebuildPerformerImageCountsSQL();
   }
 
   /**
-   * Count images for a performer using gallery inheritance.
+   * Rebuild image counts for all studios (legacy method).
+   * @deprecated Use rebuildStudioImageCountsSQL for bulk operations
    */
-  private countImagesForPerformer(images: ImageWithRelations[], performerId: string): number {
-    return images.filter((img) => {
-      // Check direct performers
-      if (img.performers?.some((p) => String(p.id) === String(performerId))) {
-        return true;
-      }
-      // Check gallery performers (inheritance)
-      if (img.galleries?.some((g) =>
-        g.performers?.some((p) => String(p.id) === String(performerId))
-      )) {
-        return true;
-      }
-      return false;
-    }).length;
+  async rebuildStudioImageCounts(): Promise<void> {
+    return this.rebuildStudioImageCountsSQL();
   }
 
   /**
-   * Count images for a studio using gallery inheritance.
+   * Rebuild image counts for all tags (legacy method).
+   * @deprecated Use rebuildTagImageCountsSQL for bulk operations
    */
-  private countImagesForStudio(images: ImageWithRelations[], studioId: string): number {
-    return images.filter((img) => {
-      // Check direct studio
-      if (String(img.studioId) === String(studioId)) {
-        return true;
-      }
-      // Check gallery studio (inheritance)
-      if (img.galleries?.some((g) => String(g.studioId) === String(studioId))) {
-        return true;
-      }
-      return false;
-    }).length;
-  }
-
-  /**
-   * Count images for a tag using gallery inheritance.
-   */
-  private countImagesForTag(images: ImageWithRelations[], tagId: string): number {
-    return images.filter((img) => {
-      // Check direct tags
-      if (img.tags?.some((t) => String(t.id) === String(tagId))) {
-        return true;
-      }
-      // Check gallery tags (inheritance)
-      if (img.galleries?.some((g) =>
-        g.tags?.some((t) => String(t.id) === String(tagId))
-      )) {
-        return true;
-      }
-      return false;
-    }).length;
-  }
-
-  /**
-   * Batch update performer image counts in the database.
-   * Uses raw SQL for performance with large datasets.
-   */
-  private async batchUpdatePerformerImageCounts(counts: Map<string, number>): Promise<void> {
-    if (counts.size === 0) return;
-
-    // Build CASE statement for batch update
-    const cases = Array.from(counts.entries())
-      .map(([id, count]) => `WHEN '${id}' THEN ${count}`)
-      .join(" ");
-
-    const ids = Array.from(counts.keys())
-      .map((id) => `'${id}'`)
-      .join(", ");
-
-    await prisma.$executeRawUnsafe(`
-      UPDATE StashPerformer
-      SET imageCount = CASE id ${cases} ELSE imageCount END
-      WHERE id IN (${ids})
-    `);
-  }
-
-  /**
-   * Batch update studio image counts in the database.
-   */
-  private async batchUpdateStudioImageCounts(counts: Map<string, number>): Promise<void> {
-    if (counts.size === 0) return;
-
-    const cases = Array.from(counts.entries())
-      .map(([id, count]) => `WHEN '${id}' THEN ${count}`)
-      .join(" ");
-
-    const ids = Array.from(counts.keys())
-      .map((id) => `'${id}'`)
-      .join(", ");
-
-    await prisma.$executeRawUnsafe(`
-      UPDATE StashStudio
-      SET imageCount = CASE id ${cases} ELSE imageCount END
-      WHERE id IN (${ids})
-    `);
-  }
-
-  /**
-   * Batch update tag image counts in the database.
-   */
-  private async batchUpdateTagImageCounts(counts: Map<string, number>): Promise<void> {
-    if (counts.size === 0) return;
-
-    const cases = Array.from(counts.entries())
-      .map(([id, count]) => `WHEN '${id}' THEN ${count}`)
-      .join(" ");
-
-    const ids = Array.from(counts.keys())
-      .map((id) => `'${id}'`)
-      .join(", ");
-
-    await prisma.$executeRawUnsafe(`
-      UPDATE StashTag
-      SET imageCount = CASE id ${cases} ELSE imageCount END
-      WHERE id IN (${ids})
-    `);
+  async rebuildTagImageCounts(): Promise<void> {
+    return this.rebuildTagImageCountsSQL();
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses scalability issues reported in #218 for libraries with 500k+ images. These changes reduce memory usage and improve performance for sync operations and query filtering.

## Changes

### EntityImageCountService (Critical Fix)
- **Before**: Loaded ALL images into memory with full relations, then filtered in JavaScript
- **After**: Uses SQL UNION queries to count inherited images directly in the database
- **Impact**: Memory usage reduced from O(n×m) to O(1) where n=images, m=relations

### UserRestrictionService (High Priority)
- **Before**: Loaded all scene IDs up to 7+ times per INCLUDE restriction check
- **After**: Caches allSceneIds once per request when needed
- **Impact**: Reduces full-table scans from 7+ to 1

### mergeScenesWithUserData (Moderate)
- **Before**: Loaded entire watch history table for every scene merge
- **After**: Filters by sceneId when merging <100 scenes
- **Impact**: Faster page loads for detail pages and small result sets

### getGalleryImages (Moderate)
- **Before**: No pagination support, loaded all images at once
- **After**: Optional pagination via \`?per_page=N&page=M\` (backwards compatible)
- **Impact**: Client can now paginate large galleries

## Local Testing Plan

1. **Sync operation test**:
   - Trigger a full sync via Settings > Sync > Full Sync
   - Monitor logs for "Inherited image counts rebuilt" timing
   - Verify image counts appear correctly on detail pages

2. **Scene filtering test**:
   - If you have INCLUDE content restrictions, browse scenes
   - Verify filtering still works correctly
   - Check console for timing improvements in \`getExcludedSceneIds\`

3. **Scene detail page test**:
   - Open a scene detail page
   - Verify watch history and ratings display correctly

4. **Gallery pagination test** (optional):
   - Call \`/api/library/galleries/{id}/images?per_page=50&page=1\`
   - Verify pagination metadata is returned

## Unraid Testing Plan

After deploying to Unraid:

1. **Check sync timing**:
   \`\`\`bash
   docker logs Peek --tail 50 | grep "Inherited image counts rebuilt"
   \`\`\`
   - Should show reduced time (e.g., from 30s to <5s)

2. **Verify no Prisma errors**:
   \`\`\`bash
   docker logs Peek --tail 200 | grep -i "error"
   \`\`\`
   - Should show no "Failed to convert rust String" errors

3. **Monitor memory usage**:
   - Check container memory before/after sync
   - Should show reduced peak memory during sync

## Related

Closes #218