### PR TITLE
Enable Proxy Authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ JWT_SECRET=your-super-secure-jwt-secret-key-here-change-me
 JWT_EXPIRES_IN=7d
 
 # ----------------------------------------------------------------------------
+# PROXY AUTH CONFIGURATION
+# ----------------------------------------------------------------------------
+# Allow your reverse proxy to handle authentication by providing a header to
+# all proxied requests with the user's username. Falls back to token-based auth
+# when disabled or no header value is present.
+# PROXY_AUTH_HEADER=X-Peek-Username
+
+# ----------------------------------------------------------------------------
 # STASH SERVER CONFIGURATION
 # ----------------------------------------------------------------------------
 # URL to your Stash GraphQL endpoint

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Peek is a web-based browser for your Stash library, offering:
 - **Subtitle Support** - VTT captions just like Stash
 - **Modern UI** - Responsive interface with theme support
 - **Full Keyboard Navigation** - TV remote and keyboard control support
+- **Proxy Authentication** - Integrate with SSO/auth proxies (Authelia, Authentik, oauth2-proxy, etc.)
 
 Think of it as a sleek, modern interface for browsing your "documentary" collection.
 
@@ -118,12 +119,15 @@ The wizard stores your Stash connection details securely in the database.
 
 ### Environment Variables
 
-| Variable     | Required | Default        | Description                                         |
-| ------------ | -------- | -------------- | --------------------------------------------------- |
-| `JWT_SECRET` | Yes      | Auto-generated | Secret for JWT tokens (recommended to set manually) |
-| `CONFIG_DIR` | No       | `/app/data`    | Directory for database and library data             |
+| Variable            | Required | Default        | Description                                            |
+| ------------------- | -------- | -------------- | ------------------------------------------------------ |
+| `JWT_SECRET`        | Yes      | Auto-generated | Secret for JWT tokens (recommended to set manually)    |
+| `CONFIG_DIR`        | No       | `/app/data`    | Directory for database and library data                |
+| `PROXY_AUTH_HEADER` | No       | (disabled)     | Enable proxy authentication (e.g., `X-Forwarded-User`) |
 
 > **Note**: Stash connection details (URL and API key) are configured via the Setup Wizard and stored in the database. No environment variables needed!
+
+> **Proxy Authentication**: For SSO/auth proxy integration (Authelia, Authentik, etc.), see the [Proxy Authentication](https://carrotwaxr.github.io/peek-stash-browser/getting-started/configuration/#proxy-authentication) documentation. **Important**: Peek must not be publicly accessible when using proxy auth.
 
 ## Updating Peek
 

--- a/server/initializers/api.ts
+++ b/server/initializers/api.ts
@@ -11,10 +11,11 @@ import {
   proxyStashMedia,
 } from "../controllers/proxy.js";
 import * as statsController from "../controllers/stats.js";
-import { authenticateToken, requireAdmin } from "../middleware/auth.js";
+import { authenticate, requireAdmin } from "../middleware/auth.js";
 import authRoutes from "../routes/auth.js";
 import carouselRoutes from "../routes/carousel.js";
 import customThemeRoutes from "../routes/customTheme.js";
+import imageViewHistoryRoutes from "../routes/imageViewHistory.js";
 import libraryGalleriesRoutes from "../routes/library/galleries.js";
 import libraryGroupsRoutes from "../routes/library/groups.js";
 import libraryImagesRoutes from "../routes/library/images.js";
@@ -29,7 +30,6 @@ import syncRoutes from "../routes/sync.js";
 import userRoutes from "../routes/user.js";
 import videoRoutes from "../routes/video.js";
 import watchHistoryRoutes from "../routes/watchHistory.js";
-import imageViewHistoryRoutes from "../routes/imageViewHistory.js";
 import { logger } from "../utils/logger.js";
 
 // ES module equivalent of __dirname
@@ -81,17 +81,12 @@ export const setupAPI = () => {
   });
 
   // Server stats endpoint (admin only - authenticated)
-  app.get(
-    "/api/stats",
-    authenticateToken,
-    requireAdmin,
-    statsController.getStats
-  );
+  app.get("/api/stats", authenticate, requireAdmin, statsController.getStats);
 
   // Refresh cache endpoint (admin only)
   app.post(
     "/api/stats/refresh-cache",
-    authenticateToken,
+    authenticate,
     requireAdmin,
     statsController.refreshCache
   );

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import prisma from "../prisma/singleton.js";
@@ -45,6 +46,58 @@ export const verifyToken = (token: string) => {
   };
 };
 
+export const authenticate = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const proxyAuthHeader = process.env.PROXY_AUTH_HEADER;
+  const username = req.header(proxyAuthHeader || "");
+  if (proxyAuthHeader && username) {
+    return await authenticateUser(username, req, res, next);
+  }
+
+  return await authenticateToken(req, res, next);
+};
+
+const lookupUser = (where: Prisma.UserWhereUniqueInput) =>
+  prisma.user.findUnique({
+    where,
+    select: {
+      id: true,
+      username: true,
+      role: true,
+      preferredQuality: true,
+      preferredPlaybackMode: true,
+      preferredPreviewQuality: true,
+      enableCast: true,
+      theme: true,
+      hideConfirmationDisabled: true,
+    },
+  });
+
+const authenticateUser = async (
+  username: string,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const user = await lookupUser({ username });
+    if (!user) {
+      throw new Error(
+        "Unable to locate user. Falling back to authenticateToken"
+      );
+    }
+
+    // Cast to AuthenticatedRequest to set user property
+    (req as AuthenticatedRequest).user = user;
+    next();
+  } catch {
+    return await authenticateToken(req, res, next);
+  }
+};
+
 export const authenticateToken = async (
   req: Request,
   res: Response,
@@ -59,21 +112,7 @@ export const authenticateToken = async (
 
   try {
     const decoded = verifyToken(token);
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.id },
-      select: {
-        id: true,
-        username: true,
-        role: true,
-        preferredQuality: true,
-        preferredPlaybackMode: true,
-        preferredPreviewQuality: true,
-        enableCast: true,
-        theme: true,
-        hideConfirmationDisabled: true,
-      },
-    });
-
+    const user = await lookupUser({ id: decoded.id });
     if (!user) {
       return res.status(401).json({ error: "Invalid token. User not found." });
     }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -2,7 +2,7 @@ import bcrypt from "bcryptjs";
 import express, { Response } from "express";
 import {
   AuthenticatedRequest,
-  authenticateToken,
+  authenticate,
   generateToken,
 } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
@@ -70,7 +70,7 @@ router.post("/logout", (req, res) => {
 // Get current user
 router.get(
   "/me",
-  authenticateToken,
+  authenticate,
   authenticated((req: AuthenticatedRequest, res: Response) => {
     res.json({
       user: req.user,
@@ -81,7 +81,7 @@ router.get(
 // Check if authenticated
 router.get(
   "/check",
-  authenticateToken,
+  authenticate,
   authenticated((req: AuthenticatedRequest, res: Response) => {
     res.json({ authenticated: true, user: req.user });
   })

--- a/server/routes/carousel.ts
+++ b/server/routes/carousel.ts
@@ -1,20 +1,20 @@
 import express from "express";
 import {
-  getUserCarousels,
-  getCarousel,
   createCarousel,
-  updateCarousel,
   deleteCarousel,
-  previewCarousel,
   executeCarouselById,
+  getCarousel,
+  getUserCarousels,
+  previewCarousel,
+  updateCarousel,
 } from "../controllers/carousel.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All carousel routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Get all user's custom carousels
 router.get("/", authenticated(getUserCarousels));

--- a/server/routes/customTheme.ts
+++ b/server/routes/customTheme.ts
@@ -7,13 +7,13 @@ import {
   getUserCustomThemes,
   updateCustomTheme,
 } from "../controllers/customTheme.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All custom theme routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Get all user custom themes
 router.get("/", authenticated(getUserCustomThemes));

--- a/server/routes/imageViewHistory.ts
+++ b/server/routes/imageViewHistory.ts
@@ -4,13 +4,13 @@ import {
   incrementImageOCounter,
   recordImageView,
 } from "../controllers/imageViewHistory.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All image view history routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Increment O counter for image
 router.post("/increment-o", authenticated(incrementImageOCounter));

--- a/server/routes/library/galleries.ts
+++ b/server/routes/library/galleries.ts
@@ -5,39 +5,39 @@ import {
   findGalleryById,
   getGalleryImages,
 } from "../../controllers/library/galleries.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All rating routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Update ratings and favorites
 router.post(
   "/galleries",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(findGalleries)
 );
 
 router.post(
   "/galleries/minimal",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(findGalleriesMinimal)
 );
 
 router.get(
   "/galleries/:id",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(findGalleryById)
 );
 
 router.get(
   "/galleries/:galleryId/images",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(getGalleryImages)
 );

--- a/server/routes/library/groups.ts
+++ b/server/routes/library/groups.ts
@@ -3,13 +3,13 @@ import {
   findGroups,
   findGroupsMinimal,
 } from "../../controllers/library/groups.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All group routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Find groups with filters
 router.post("/groups", requireCacheReady, authenticated(findGroups));

--- a/server/routes/library/images.ts
+++ b/server/routes/library/images.ts
@@ -1,6 +1,6 @@
 import express from "express";
-import { findImages, findImageById } from "../../controllers/library/images.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { findImageById, findImages } from "../../controllers/library/images.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
@@ -8,7 +8,7 @@ const router = express.Router();
 // Find images (with filters, pagination, sorting)
 router.post(
   "/images",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(findImages)
 );
@@ -16,7 +16,7 @@ router.post(
 // Get single image by ID
 router.get(
   "/images/:id",
-  authenticateToken,
+  authenticate,
   requireCacheReady,
   authenticated(findImageById)
 );

--- a/server/routes/library/performers.ts
+++ b/server/routes/library/performers.ts
@@ -4,13 +4,13 @@ import {
   findPerformersMinimal,
   updatePerformer,
 } from "../../controllers/library/performers.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All performer routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Find performers with filters
 router.post("/performers", requireCacheReady, authenticated(findPerformers));

--- a/server/routes/library/scenes.ts
+++ b/server/routes/library/scenes.ts
@@ -5,13 +5,13 @@ import {
   getRecommendedScenes,
   updateScene,
 } from "../../controllers/library/scenes.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All scene routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Find scenes with filters
 router.post("/scenes", requireCacheReady, authenticated(findScenes));

--- a/server/routes/library/studios.ts
+++ b/server/routes/library/studios.ts
@@ -4,13 +4,13 @@ import {
   findStudiosMinimal,
   updateStudio,
 } from "../../controllers/library/studios.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All studio routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Find studios with filters
 router.post("/studios", requireCacheReady, authenticated(findStudios));

--- a/server/routes/library/tags.ts
+++ b/server/routes/library/tags.ts
@@ -4,13 +4,13 @@ import {
   findTagsMinimal,
   updateTag,
 } from "../../controllers/library/tags.js";
-import { authenticateToken, requireCacheReady } from "../../middleware/auth.js";
+import { authenticate, requireCacheReady } from "../../middleware/auth.js";
 import { authenticated } from "../../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All tag routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Find tags with filters
 router.post("/tags", requireCacheReady, authenticated(findTags));

--- a/server/routes/playlist.ts
+++ b/server/routes/playlist.ts
@@ -9,13 +9,13 @@ import {
   reorderPlaylist,
   updatePlaylist,
 } from "../controllers/playlist.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All playlist routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Get all user playlists
 router.get("/", authenticated(getUserPlaylists));

--- a/server/routes/ratings.ts
+++ b/server/routes/ratings.ts
@@ -8,12 +8,12 @@ import {
   updateStudioRating,
   updateTagRating,
 } from "../controllers/ratings.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 
 const router = express.Router();
 
 // All rating routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Update ratings and favorites
 router.put("/scene/:sceneId", updateSceneRating);

--- a/server/routes/setup.ts
+++ b/server/routes/setup.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import { authenticateToken } from "../middleware/auth.js";
 import {
   createFirstAdmin,
   createFirstStashInstance,
@@ -8,6 +7,7 @@ import {
   resetSetup,
   testStashConnection,
 } from "../controllers/setup.js";
+import { authenticate } from "../middleware/auth.js";
 
 const router = express.Router();
 
@@ -19,6 +19,6 @@ router.post("/create-stash-instance", createFirstStashInstance);
 router.post("/reset", resetSetup);
 
 // Protected routes (require authentication)
-router.get("/stash-instance", authenticateToken, getStashInstance);
+router.get("/stash-instance", authenticate, getStashInstance);
 
 export default router;

--- a/server/routes/sync.ts
+++ b/server/routes/sync.ts
@@ -7,9 +7,8 @@
  * - POST /api/sync/notify - Webhook for Stash plugin (admin only)
  * - PUT /api/sync/settings - Update sync settings (admin only)
  */
-
 import express from "express";
-import { authenticateToken, requireAdmin } from "../middleware/auth.js";
+import { authenticate, requireAdmin } from "../middleware/auth.js";
 import { stashSyncService } from "../services/StashSyncService.js";
 import { syncScheduler } from "../services/SyncScheduler.js";
 import { authenticated } from "../utils/routeHelpers.js";
@@ -17,7 +16,7 @@ import { authenticated } from "../utils/routeHelpers.js";
 const router = express.Router();
 
 // All sync routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 /**
  * GET /api/sync/status
@@ -198,8 +197,11 @@ router.put(
   requireAdmin,
   authenticated(async (req, res) => {
     try {
-      const { syncIntervalMinutes, enableScanSubscription, enablePluginWebhook } =
-        req.body;
+      const {
+        syncIntervalMinutes,
+        enableScanSubscription,
+        enablePluginWebhook,
+      } = req.body;
 
       // Validate syncIntervalMinutes
       if (syncIntervalMinutes !== undefined) {
@@ -210,7 +212,8 @@ router.put(
         ) {
           return res.status(400).json({
             error: "Invalid sync interval",
-            message: "Sync interval must be between 5 and 1440 minutes (24 hours)",
+            message:
+              "Sync interval must be between 5 and 1440 minutes (24 hours)",
           });
         }
       }

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -23,13 +23,13 @@ import {
   updateUserRole,
   updateUserSettings,
 } from "../controllers/user.js";
-import { authenticateToken, requireAdmin } from "../middleware/auth.js";
+import { authenticate, requireAdmin } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All user routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // User settings routes
 router.get("/settings", authenticated(getUserSettings));
@@ -92,9 +92,6 @@ router.get("/hidden-entities", authenticated(getHiddenEntities)); // Get all hid
 router.get("/hidden-entities/ids", authenticated(getHiddenEntityIds)); // Get hidden entity IDs organized by type
 
 // Hide confirmation preference
-router.put(
-  "/hide-confirmation",
-  authenticated(updateHideConfirmation)
-); // Update hide confirmation preference
+router.put("/hide-confirmation", authenticated(updateHideConfirmation)); // Update hide confirmation preference
 
 export default router;

--- a/server/routes/watchHistory.ts
+++ b/server/routes/watchHistory.ts
@@ -8,13 +8,13 @@ import {
   pingWatchHistory,
   saveActivity,
 } from "../controllers/watchHistory.js";
-import { authenticateToken } from "../middleware/auth.js";
+import { authenticate } from "../middleware/auth.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
 // All watch history routes require authentication
-router.use(authenticateToken);
+router.use(authenticate);
 
 // Ping watch history (legacy - called every 30 seconds during playback)
 router.post("/ping", authenticated(pingWatchHistory));


### PR DESCRIPTION
Allows a new `PROXY_AUTH_HEADER` environment variable to configure a trusted header that can be provided by a reverse proxy containing a username. Falls back to token-based authentication when disabled or no header value is present.