### PR TITLE
feat(types): add API types for remaining controllers (Phase 3)

### DIFF
--- a/server/controllers/carousel.ts
+++ b/server/controllers/carousel.ts
@@ -1,11 +1,28 @@
-import type { Response } from "express";
 import type { Prisma } from "@prisma/client";
-import type { AuthenticatedRequest } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
 import { stashEntityService } from "../services/StashEntityService.js";
 import { entityExclusionHelper } from "../services/EntityExclusionHelper.js";
 import { sceneQueryBuilder } from "../services/SceneQueryBuilder.js";
 import type { NormalizedScene, PeekSceneFilter } from "../types/index.js";
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  GetUserCarouselsResponse,
+  GetCarouselParams,
+  GetCarouselResponse,
+  CreateCarouselRequest,
+  CreateCarouselResponse,
+  UpdateCarouselParams,
+  UpdateCarouselRequest,
+  UpdateCarouselResponse,
+  DeleteCarouselParams,
+  DeleteCarouselResponse,
+  PreviewCarouselRequest,
+  PreviewCarouselResponse,
+  ExecuteCarouselByIdParams,
+  ExecuteCarouselByIdResponse,
+} from "../types/api/index.js";
 import { logger } from "../utils/logger.js";
 import {
   mergeScenesWithUserData,
@@ -28,8 +45,8 @@ const USE_SQL_QUERY_BUILDER = process.env.USE_SQL_QUERY_BUILDER !== "false";
  * Get all custom carousels for the current user
  */
 export const getUserCarousels = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest,
+  res: TypedResponse<GetUserCarouselsResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -53,7 +70,10 @@ export const getUserCarousels = async (
 /**
  * Get a single carousel by ID
  */
-export const getCarousel = async (req: AuthenticatedRequest, res: Response) => {
+export const getCarousel = async (
+  req: TypedAuthRequest<unknown, GetCarouselParams>,
+  res: TypedResponse<GetCarouselResponse | ApiErrorResponse>
+) => {
   try {
     const userId = req.user?.id;
     const carouselId = req.params.id;
@@ -90,8 +110,8 @@ interface CarouselPreference {
  * Create a new custom carousel
  */
 export const createCarousel = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<CreateCarouselRequest>,
+  res: TypedResponse<CreateCarouselResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -167,8 +187,8 @@ export const createCarousel = async (
  * Update an existing carousel
  */
 export const updateCarousel = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateCarouselRequest, UpdateCarouselParams>,
+  res: TypedResponse<UpdateCarouselResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -219,8 +239,8 @@ export const updateCarousel = async (
  * Delete a carousel
  */
 export const deleteCarousel = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, DeleteCarouselParams>,
+  res: TypedResponse<DeleteCarouselResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -258,8 +278,8 @@ export const deleteCarousel = async (
  * Executes the carousel query and returns matching scenes
  */
 export const previewCarousel = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<PreviewCarouselRequest>,
+  res: TypedResponse<PreviewCarouselResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -431,8 +451,8 @@ export async function executeCarouselQuery(
  * Used by the homepage to render a specific carousel
  */
 export const executeCarouselById = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, ExecuteCarouselByIdParams>,
+  res: TypedResponse<ExecuteCarouselByIdResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;

--- a/server/controllers/customTheme.ts
+++ b/server/controllers/customTheme.ts
@@ -1,36 +1,22 @@
-import { Response } from "express";
-import { AuthenticatedRequest } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
-
-/**
- * Theme config validation schema
- */
-interface ThemeConfig {
-  mode: "dark" | "light";
-  fonts: {
-    brand: string;
-    heading: string;
-    body: string;
-    mono: string;
-  };
-  colors: {
-    background: string;
-    backgroundSecondary: string;
-    backgroundCard: string;
-    text: string;
-    border: string;
-  };
-  accents: {
-    primary: string;
-    secondary: string;
-  };
-  status: {
-    success: string;
-    error: string;
-    info: string;
-    warning: string;
-  };
-}
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  ThemeConfig,
+  GetUserCustomThemesResponse,
+  GetCustomThemeParams,
+  GetCustomThemeResponse,
+  CreateCustomThemeRequest,
+  CreateCustomThemeResponse,
+  UpdateCustomThemeParams,
+  UpdateCustomThemeRequest,
+  UpdateCustomThemeResponse,
+  DeleteCustomThemeParams,
+  DeleteCustomThemeResponse,
+  DuplicateCustomThemeParams,
+  DuplicateCustomThemeResponse,
+} from "../types/api/index.js";
 
 /**
  * Validate hex color format
@@ -97,8 +83,8 @@ const validateThemeConfig = (config: ThemeConfig): config is ThemeConfig => {
  * Get all custom themes for current user
  */
 export const getUserCustomThemes = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest,
+  res: TypedResponse<GetUserCustomThemesResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -130,8 +116,8 @@ export const getUserCustomThemes = async (
  * Get single custom theme
  */
 export const getCustomTheme = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, GetCustomThemeParams>,
+  res: TypedResponse<GetCustomThemeResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -167,8 +153,8 @@ export const getCustomTheme = async (
  * Create new custom theme
  */
 export const createCustomTheme = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<CreateCustomThemeRequest>,
+  res: TypedResponse<CreateCustomThemeResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -228,8 +214,8 @@ export const createCustomTheme = async (
  * Update custom theme
  */
 export const updateCustomTheme = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateCustomThemeRequest, UpdateCustomThemeParams>,
+  res: TypedResponse<UpdateCustomThemeResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -311,8 +297,8 @@ export const updateCustomTheme = async (
  * Delete custom theme
  */
 export const deleteCustomTheme = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, DeleteCustomThemeParams>,
+  res: TypedResponse<DeleteCustomThemeResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -354,8 +340,8 @@ export const deleteCustomTheme = async (
  * Duplicate custom theme
  */
 export const duplicateCustomTheme = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, DuplicateCustomThemeParams>,
+  res: TypedResponse<DuplicateCustomThemeResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;

--- a/server/controllers/imageViewHistory.ts
+++ b/server/controllers/imageViewHistory.ts
@@ -1,14 +1,23 @@
-import { Response } from "express";
-import { AuthenticatedRequest } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  IncrementImageOCounterRequest,
+  IncrementImageOCounterResponse,
+  RecordImageViewRequest,
+  RecordImageViewResponse,
+  GetImageViewHistoryParams,
+  GetImageViewHistoryResponse,
+} from "../types/api/index.js";
 import { logger } from "../utils/logger.js";
 
 /**
  * Increment O counter for an image
  */
 export async function incrementImageOCounter(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<IncrementImageOCounterRequest>,
+  res: TypedResponse<IncrementImageOCounterResponse | ApiErrorResponse>
 ) {
   try {
     const { imageId } = req.body;
@@ -90,8 +99,8 @@ export async function incrementImageOCounter(
  * Record image view (when opened in Lightbox)
  */
 export async function recordImageView(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<RecordImageViewRequest>,
+  res: TypedResponse<RecordImageViewResponse | ApiErrorResponse>
 ) {
   try {
     const { imageId } = req.body;
@@ -154,8 +163,8 @@ export async function recordImageView(
  * Get image view history for a specific image
  */
 export async function getImageViewHistory(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, GetImageViewHistoryParams>,
+  res: TypedResponse<GetImageViewHistoryResponse | ApiErrorResponse>
 ) {
   try {
     const { imageId } = req.params;

--- a/server/controllers/playlist.ts
+++ b/server/controllers/playlist.ts
@@ -1,10 +1,31 @@
-import { Response } from "express";
 import { Scene } from "stashapp-api";
-import { AuthenticatedRequest } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
 import { stashEntityService } from "../services/StashEntityService.js";
 import { entityExclusionHelper } from "../services/EntityExclusionHelper.js";
 import type { NormalizedScene } from "../types/index.js";
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  GetUserPlaylistsResponse,
+  GetPlaylistParams,
+  GetPlaylistResponse,
+  CreatePlaylistRequest,
+  CreatePlaylistResponse,
+  UpdatePlaylistParams,
+  UpdatePlaylistRequest,
+  UpdatePlaylistResponse,
+  DeletePlaylistParams,
+  DeletePlaylistResponse,
+  AddSceneToPlaylistParams,
+  AddSceneToPlaylistRequest,
+  AddSceneToPlaylistResponse,
+  RemoveSceneFromPlaylistParams,
+  RemoveSceneFromPlaylistResponse,
+  ReorderPlaylistParams,
+  ReorderPlaylistRequest,
+  ReorderPlaylistResponse,
+} from "../types/api/index.js";
 import { transformScene } from "../utils/stashUrlProxy.js";
 
 /**
@@ -30,8 +51,8 @@ const DEFAULT_SCENE_USER_FIELDS = {
  * Includes first 4 items with scene preview data for thumbnail display
  */
 export const getUserPlaylists = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest,
+  res: TypedResponse<GetUserPlaylistsResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -121,7 +142,10 @@ export const getUserPlaylists = async (
 /**
  * Get single playlist with items and scene details from cache
  */
-export const getPlaylist = async (req: AuthenticatedRequest, res: Response) => {
+export const getPlaylist = async (
+  req: TypedAuthRequest<unknown, GetPlaylistParams>,
+  res: TypedResponse<GetPlaylistResponse | ApiErrorResponse>
+) => {
   try {
     const userId = req.user?.id;
     const playlistId = parseInt(req.params.id);
@@ -222,8 +246,8 @@ export const getPlaylist = async (req: AuthenticatedRequest, res: Response) => {
  * Create new playlist
  */
 export const createPlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<CreatePlaylistRequest>,
+  res: TypedResponse<CreatePlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -263,8 +287,8 @@ export const createPlaylist = async (
  * Update playlist
  */
 export const updatePlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdatePlaylistRequest, UpdatePlaylistParams>,
+  res: TypedResponse<UpdatePlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -321,8 +345,8 @@ export const updatePlaylist = async (
  * Delete playlist
  */
 export const deletePlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, DeletePlaylistParams>,
+  res: TypedResponse<DeletePlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -364,8 +388,8 @@ export const deletePlaylist = async (
  * Add scene to playlist
  */
 export const addSceneToPlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<AddSceneToPlaylistRequest, AddSceneToPlaylistParams>,
+  res: TypedResponse<AddSceneToPlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -442,8 +466,8 @@ export const addSceneToPlaylist = async (
  * Remove scene from playlist
  */
 export const removeSceneFromPlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, RemoveSceneFromPlaylistParams>,
+  res: TypedResponse<RemoveSceneFromPlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;
@@ -491,8 +515,8 @@ export const removeSceneFromPlaylist = async (
  * Reorder playlist items
  */
 export const reorderPlaylist = async (
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<ReorderPlaylistRequest, ReorderPlaylistParams>,
+  res: TypedResponse<ReorderPlaylistResponse | ApiErrorResponse>
 ) => {
   try {
     const userId = req.user?.id;

--- a/server/controllers/ratings.ts
+++ b/server/controllers/ratings.ts
@@ -1,15 +1,20 @@
-import { Request, Response } from "express";
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  UpdateRatingRequest,
+  UpdateRatingResponse,
+  UpdateSceneRatingParams,
+  UpdatePerformerRatingParams,
+  UpdateStudioRatingParams,
+  UpdateTagRatingParams,
+  UpdateGalleryRatingParams,
+  UpdateGroupRatingParams,
+  UpdateImageRatingParams,
+  ApiErrorResponse,
+} from "../types/api/index.js";
 import prisma from "../prisma/singleton.js";
 import { stashInstanceManager } from "../services/StashInstanceManager.js";
 import { logger } from "../utils/logger.js";
-
-interface AuthenticatedRequest extends Request {
-  user?: {
-    id: number;
-    username: string;
-    role: string;
-  };
-}
 
 /**
  * IMPORTANT: Rating and Favorite Sync Policy
@@ -40,8 +45,8 @@ interface AuthenticatedRequest extends Request {
  * Syncs rating to Stash if user.syncToStash is enabled (favorite NOT synced for scenes)
  */
 export async function updateSceneRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateSceneRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -134,8 +139,8 @@ export async function updateSceneRating(
  * Syncs both rating and favorite to Stash if user.syncToStash is enabled
  */
 export async function updatePerformerRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdatePerformerRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -234,8 +239,8 @@ export async function updatePerformerRating(
  * Syncs both rating and favorite to Stash if user.syncToStash is enabled
  */
 export async function updateStudioRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateStudioRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -334,8 +339,8 @@ export async function updateStudioRating(
  * Syncs favorite only to Stash if user.syncToStash is enabled (tags don't support rating in Stash)
  */
 export async function updateTagRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateTagRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -427,8 +432,8 @@ export async function updateTagRating(
  * Syncs rating only to Stash if user.syncToStash is enabled (galleries don't support favorite in Stash)
  */
 export async function updateGalleryRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateGalleryRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -525,8 +530,8 @@ export async function updateGalleryRating(
  * Syncs rating only to Stash if user.syncToStash is enabled (groups don't support favorite in Stash)
  */
 export async function updateGroupRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateGroupRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -618,8 +623,8 @@ export async function updateGroupRating(
  * Syncs rating only to Stash if user.syncToStash is enabled (images don't support favorite in Stash)
  */
 export async function updateImageRating(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<UpdateRatingRequest, UpdateImageRatingParams>,
+  res: TypedResponse<UpdateRatingResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;

--- a/server/controllers/setup.ts
+++ b/server/controllers/setup.ts
@@ -1,9 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
-import { Request, Response } from "express";
+import { Request } from "express";
 import { StashApp } from "stashapp-api";
 import { stashSyncService } from "../services/StashSyncService.js";
 import { stashInstanceManager } from "../services/StashInstanceManager.js";
+import type {
+  TypedRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  GetSetupStatusResponse,
+  CreateFirstAdminRequest,
+  CreateFirstAdminResponse,
+  TestStashConnectionRequest,
+  TestStashConnectionResponse,
+  CreateFirstStashInstanceRequest,
+  CreateFirstStashInstanceResponse,
+  GetStashInstanceResponse,
+  ResetSetupResponse,
+} from "../types/api/index.js";
 import { logger } from "../utils/logger.js";
 
 const prisma = new PrismaClient();
@@ -33,7 +47,10 @@ const getDefaultCarouselPreferences = (): CarouselPreference[] => [
  * Check setup status (for determining if wizard is needed)
  * Checks for both user existence and Stash instance configuration
  */
-export const getSetupStatus = async (req: Request, res: Response) => {
+export const getSetupStatus = async (
+  req: Request,
+  res: TypedResponse<GetSetupStatusResponse | ApiErrorResponse>
+) => {
   try {
     // Check if at least one user exists
     const userCount = await prisma.user.count();
@@ -68,7 +85,10 @@ export const getSetupStatus = async (req: Request, res: Response) => {
  * Create first admin user (public endpoint for setup wizard)
  * Only works if NO users exist yet
  */
-export const createFirstAdmin = async (req: Request, res: Response) => {
+export const createFirstAdmin = async (
+  req: TypedRequest<CreateFirstAdminRequest>,
+  res: TypedResponse<CreateFirstAdminResponse | ApiErrorResponse>
+) => {
   try {
     // Check if any users already exist
     const userCount = await prisma.user.count();
@@ -134,7 +154,10 @@ export const createFirstAdmin = async (req: Request, res: Response) => {
  * Test connection to a Stash server
  * POST /api/setup/test-stash-connection
  */
-export const testStashConnection = async (req: Request, res: Response) => {
+export const testStashConnection = async (
+  req: TypedRequest<TestStashConnectionRequest>,
+  res: TypedResponse<TestStashConnectionResponse | ApiErrorResponse>
+) => {
   try {
     const { url, apiKey } = req.body;
 
@@ -235,7 +258,10 @@ export const testStashConnection = async (req: Request, res: Response) => {
  * Only works if NO Stash instances exist yet
  * POST /api/setup/create-stash-instance
  */
-export const createFirstStashInstance = async (req: Request, res: Response) => {
+export const createFirstStashInstance = async (
+  req: TypedRequest<CreateFirstStashInstanceRequest>,
+  res: TypedResponse<CreateFirstStashInstanceResponse | ApiErrorResponse>
+) => {
   try {
     // Check if any Stash instances already exist
     const instanceCount = await prisma.stashInstance.count();
@@ -330,7 +356,10 @@ export const createFirstStashInstance = async (req: Request, res: Response) => {
  * GET /api/setup/stash-instance
  * Requires authentication
  */
-export const getStashInstance = async (req: Request, res: Response) => {
+export const getStashInstance = async (
+  req: Request,
+  res: TypedResponse<GetStashInstanceResponse | ApiErrorResponse>
+) => {
   try {
     const instances = await prisma.stashInstance.findMany({
       select: {
@@ -369,7 +398,10 @@ export const getStashInstance = async (req: Request, res: Response) => {
  * SECURITY: Only works if setup is incomplete AND there's at most 1 user.
  * This prevents accidental data loss on systems with multiple users.
  */
-export const resetSetup = async (req: Request, res: Response) => {
+export const resetSetup = async (
+  req: Request,
+  res: TypedResponse<ResetSetupResponse | ApiErrorResponse>
+) => {
   try {
     // Check current setup state
     const userCount = await prisma.user.count();

--- a/server/controllers/watchHistory.ts
+++ b/server/controllers/watchHistory.ts
@@ -1,7 +1,23 @@
 import { WatchHistory } from "@prisma/client";
-import { Response } from "express";
-import { AuthenticatedRequest } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
+import type {
+  TypedAuthRequest,
+  TypedResponse,
+  ApiErrorResponse,
+  PingWatchHistoryRequest,
+  PingWatchHistoryResponse,
+  SaveActivityRequest,
+  SaveActivityResponse,
+  IncrementPlayCountRequest,
+  IncrementPlayCountResponse,
+  IncrementOCounterRequest,
+  IncrementOCounterResponse,
+  GetAllWatchHistoryQuery,
+  GetAllWatchHistoryResponse,
+  GetWatchHistoryParams,
+  GetWatchHistoryResponse,
+  ClearAllWatchHistoryResponse,
+} from "../types/api/index.js";
 import { stashInstanceManager } from "../services/StashInstanceManager.js";
 import { userStatsService } from "../services/UserStatsService.js";
 import { logger } from "../utils/logger.js";
@@ -19,8 +35,8 @@ function getSessionKey(userId: number, sceneId: string): string {
  * Tracks playback progress matching Stash's pattern with per-user tracking
  */
 export async function pingWatchHistory(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<PingWatchHistoryRequest>,
+  res: TypedResponse<PingWatchHistoryResponse | ApiErrorResponse>
 ) {
   try {
     const { sceneId, currentTime, quality, sessionStart, seekEvents } =
@@ -295,8 +311,8 @@ export async function pingWatchHistory(
  * Increment O counter for a scene
  */
 export async function incrementOCounter(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<IncrementOCounterRequest>,
+  res: TypedResponse<IncrementOCounterResponse | ApiErrorResponse>
 ) {
   try {
     const { sceneId } = req.body;
@@ -421,8 +437,8 @@ export async function incrementOCounter(
  * Get watch history for a specific scene
  */
 export async function getWatchHistory(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, GetWatchHistoryParams>,
+  res: TypedResponse<GetWatchHistoryResponse | ApiErrorResponse>
 ) {
   try {
     const { sceneId } = req.params;
@@ -484,8 +500,8 @@ export async function getWatchHistory(
  * Get all watch history for current user (for Continue Watching carousel)
  */
 export async function getAllWatchHistory(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<unknown, Record<string, string>, GetAllWatchHistoryQuery>,
+  res: TypedResponse<GetAllWatchHistoryResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -533,8 +549,8 @@ export async function getAllWatchHistory(
  * This includes O counters, play counts, and all viewing statistics
  */
 export async function clearAllWatchHistory(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest,
+  res: TypedResponse<ClearAllWatchHistoryResponse | ApiErrorResponse>
 ) {
   try {
     const userId = req.user?.id;
@@ -586,7 +602,10 @@ export async function clearAllWatchHistory(
  * Save activity (resume time and play duration delta)
  * Simplified endpoint matching Stash's pattern - called by track-activity plugin
  */
-export async function saveActivity(req: AuthenticatedRequest, res: Response) {
+export async function saveActivity(
+  req: TypedAuthRequest<SaveActivityRequest>,
+  res: TypedResponse<SaveActivityResponse | ApiErrorResponse>
+) {
   try {
     const { sceneId, resumeTime, playDuration } = req.body;
     const userId = req.user?.id;
@@ -683,8 +702,8 @@ export async function saveActivity(req: AuthenticatedRequest, res: Response) {
  * Called by track-activity plugin when minimum play percentage is reached
  */
 export async function incrementPlayCount(
-  req: AuthenticatedRequest,
-  res: Response
+  req: TypedAuthRequest<IncrementPlayCountRequest>,
+  res: TypedResponse<IncrementPlayCountResponse | ApiErrorResponse>
 ) {
   try {
     const { sceneId } = req.body;

--- a/server/routes/ratings.ts
+++ b/server/routes/ratings.ts
@@ -9,6 +9,7 @@ import {
   updateTagRating,
 } from "../controllers/ratings.js";
 import { authenticate } from "../middleware/auth.js";
+import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
 
@@ -16,12 +17,12 @@ const router = express.Router();
 router.use(authenticate);
 
 // Update ratings and favorites
-router.put("/scene/:sceneId", updateSceneRating);
-router.put("/performer/:performerId", updatePerformerRating);
-router.put("/studio/:studioId", updateStudioRating);
-router.put("/tag/:tagId", updateTagRating);
-router.put("/gallery/:galleryId", updateGalleryRating);
-router.put("/group/:groupId", updateGroupRating);
-router.put("/image/:imageId", updateImageRating);
+router.put("/scene/:sceneId", authenticated(updateSceneRating));
+router.put("/performer/:performerId", authenticated(updatePerformerRating));
+router.put("/studio/:studioId", authenticated(updateStudioRating));
+router.put("/tag/:tagId", authenticated(updateTagRating));
+router.put("/gallery/:galleryId", authenticated(updateGalleryRating));
+router.put("/group/:groupId", authenticated(updateGroupRating));
+router.put("/image/:imageId", authenticated(updateImageRating));
 
 export default router;

--- a/server/types/api/carousel.ts
+++ b/server/types/api/carousel.ts
@@ -1,0 +1,156 @@
+// server/types/api/carousel.ts
+/**
+ * Carousel API Types
+ *
+ * Request and response types for /api/carousels/* endpoints.
+ */
+import type { JsonValue } from "@prisma/client/runtime/library";
+import type { NormalizedScene, PeekSceneFilter } from "../index.js";
+
+// =============================================================================
+// COMMON TYPES
+// =============================================================================
+
+/**
+ * Carousel data structure
+ * Note: rules is JsonValue from Prisma since it's stored as JSON
+ */
+export interface CarouselData {
+  id: string;
+  userId: number;
+  title: string;
+  icon: string;
+  rules: JsonValue;
+  sort: string;
+  direction: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// =============================================================================
+// GET USER CAROUSELS
+// =============================================================================
+
+/**
+ * GET /api/carousels
+ * Get all custom carousels for the current user
+ */
+export interface GetUserCarouselsResponse {
+  carousels: CarouselData[];
+}
+
+// =============================================================================
+// GET CAROUSEL
+// =============================================================================
+
+/**
+ * GET /api/carousels/:id
+ * Get a single carousel by ID
+ */
+export interface GetCarouselParams extends Record<string, string> {
+  id: string;
+}
+
+export interface GetCarouselResponse {
+  carousel: CarouselData;
+}
+
+// =============================================================================
+// CREATE CAROUSEL
+// =============================================================================
+
+/**
+ * POST /api/carousels
+ * Create a new custom carousel
+ */
+export interface CreateCarouselRequest {
+  title: string;
+  icon?: string;
+  rules: PeekSceneFilter;
+  sort?: string;
+  direction?: string;
+}
+
+export interface CreateCarouselResponse {
+  carousel: CarouselData;
+}
+
+// =============================================================================
+// UPDATE CAROUSEL
+// =============================================================================
+
+/**
+ * PUT /api/carousels/:id
+ * Update an existing carousel
+ */
+export interface UpdateCarouselParams extends Record<string, string> {
+  id: string;
+}
+
+export interface UpdateCarouselRequest {
+  title?: string;
+  icon?: string;
+  rules?: PeekSceneFilter;
+  sort?: string;
+  direction?: string;
+}
+
+export interface UpdateCarouselResponse {
+  carousel: CarouselData;
+}
+
+// =============================================================================
+// DELETE CAROUSEL
+// =============================================================================
+
+/**
+ * DELETE /api/carousels/:id
+ * Delete a carousel
+ */
+export interface DeleteCarouselParams extends Record<string, string> {
+  id: string;
+}
+
+export interface DeleteCarouselResponse {
+  success: true;
+  message: string;
+}
+
+// =============================================================================
+// PREVIEW CAROUSEL
+// =============================================================================
+
+/**
+ * POST /api/carousels/preview
+ * Preview carousel results without saving
+ */
+export interface PreviewCarouselRequest {
+  rules: PeekSceneFilter;
+  sort?: string;
+  direction?: string;
+}
+
+export interface PreviewCarouselResponse {
+  scenes: NormalizedScene[];
+}
+
+// =============================================================================
+// EXECUTE CAROUSEL BY ID
+// =============================================================================
+
+/**
+ * GET /api/carousels/:id/execute
+ * Execute a carousel by ID and return its scenes
+ */
+export interface ExecuteCarouselByIdParams extends Record<string, string> {
+  id: string;
+}
+
+export interface ExecuteCarouselByIdResponse {
+  carousel: {
+    id: string;
+    title: string;
+    icon: string;
+  };
+  scenes: NormalizedScene[];
+}

--- a/server/types/api/common.ts
+++ b/server/types/api/common.ts
@@ -21,6 +21,7 @@ export interface PaginationFilter {
  */
 export interface ApiErrorResponse {
   error: string;
+  message?: string;
   details?: string;
   errorType?: string;
 }

--- a/server/types/api/customTheme.ts
+++ b/server/types/api/customTheme.ts
@@ -1,0 +1,150 @@
+// server/types/api/customTheme.ts
+/**
+ * Custom Theme API Types
+ *
+ * Request and response types for /api/custom-themes/* endpoints.
+ */
+import type { JsonValue } from "@prisma/client/runtime/library";
+
+// =============================================================================
+// COMMON TYPES
+// =============================================================================
+
+/**
+ * Theme configuration structure
+ */
+export interface ThemeConfig {
+  mode: "dark" | "light";
+  fonts: {
+    brand: string;
+    heading: string;
+    body: string;
+    mono: string;
+  };
+  colors: {
+    background: string;
+    backgroundSecondary: string;
+    backgroundCard: string;
+    text: string;
+    border: string;
+  };
+  accents: {
+    primary: string;
+    secondary: string;
+  };
+  status: {
+    success: string;
+    error: string;
+    info: string;
+    warning: string;
+  };
+}
+
+/**
+ * Custom theme data structure
+ */
+export interface CustomThemeData {
+  id: number;
+  name: string;
+  config: JsonValue;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// =============================================================================
+// GET USER CUSTOM THEMES
+// =============================================================================
+
+/**
+ * GET /api/custom-themes
+ * Get all custom themes for current user
+ */
+export interface GetUserCustomThemesResponse {
+  themes: CustomThemeData[];
+}
+
+// =============================================================================
+// GET CUSTOM THEME
+// =============================================================================
+
+/**
+ * GET /api/custom-themes/:id
+ * Get single custom theme
+ */
+export interface GetCustomThemeParams extends Record<string, string> {
+  id: string;
+}
+
+export interface GetCustomThemeResponse {
+  theme: CustomThemeData & { userId: number };
+}
+
+// =============================================================================
+// CREATE CUSTOM THEME
+// =============================================================================
+
+/**
+ * POST /api/custom-themes
+ * Create new custom theme
+ */
+export interface CreateCustomThemeRequest {
+  name: string;
+  config: ThemeConfig;
+}
+
+export interface CreateCustomThemeResponse {
+  theme: CustomThemeData & { userId: number };
+}
+
+// =============================================================================
+// UPDATE CUSTOM THEME
+// =============================================================================
+
+/**
+ * PUT /api/custom-themes/:id
+ * Update custom theme
+ */
+export interface UpdateCustomThemeParams extends Record<string, string> {
+  id: string;
+}
+
+export interface UpdateCustomThemeRequest {
+  name?: string;
+  config?: ThemeConfig;
+}
+
+export interface UpdateCustomThemeResponse {
+  theme: CustomThemeData & { userId: number };
+}
+
+// =============================================================================
+// DELETE CUSTOM THEME
+// =============================================================================
+
+/**
+ * DELETE /api/custom-themes/:id
+ * Delete custom theme
+ */
+export interface DeleteCustomThemeParams extends Record<string, string> {
+  id: string;
+}
+
+export interface DeleteCustomThemeResponse {
+  success: true;
+}
+
+// =============================================================================
+// DUPLICATE CUSTOM THEME
+// =============================================================================
+
+/**
+ * POST /api/custom-themes/:id/duplicate
+ * Duplicate custom theme
+ */
+export interface DuplicateCustomThemeParams extends Record<string, string> {
+  id: string;
+}
+
+export interface DuplicateCustomThemeResponse {
+  theme: CustomThemeData & { userId: number };
+}

--- a/server/types/api/imageViewHistory.ts
+++ b/server/types/api/imageViewHistory.ts
@@ -1,0 +1,63 @@
+// server/types/api/imageViewHistory.ts
+/**
+ * Image View History API Types
+ *
+ * Request and response types for /api/image-view-history/* endpoints.
+ */
+
+// =============================================================================
+// INCREMENT IMAGE O COUNTER
+// =============================================================================
+
+/**
+ * POST /api/image-view-history/increment-o
+ * Increment O counter for an image
+ */
+export interface IncrementImageOCounterRequest {
+  imageId: string;
+}
+
+export interface IncrementImageOCounterResponse {
+  success: true;
+  oCount: number;
+  timestamp: string;
+}
+
+// =============================================================================
+// RECORD IMAGE VIEW
+// =============================================================================
+
+/**
+ * POST /api/image-view-history/view
+ * Record image view when opened in Lightbox
+ */
+export interface RecordImageViewRequest {
+  imageId: string;
+}
+
+export interface RecordImageViewResponse {
+  success: true;
+  viewCount: number;
+  lastViewedAt: Date | null;
+}
+
+// =============================================================================
+// GET IMAGE VIEW HISTORY
+// =============================================================================
+
+/**
+ * GET /api/image-view-history/:imageId
+ * Get view history for a specific image
+ */
+export interface GetImageViewHistoryParams extends Record<string, string> {
+  imageId: string;
+}
+
+export interface GetImageViewHistoryResponse {
+  exists: boolean;
+  viewCount: number;
+  viewHistory?: string[];
+  oCount: number;
+  oHistory?: string[];
+  lastViewedAt?: Date | null;
+}

--- a/server/types/api/index.ts
+++ b/server/types/api/index.ts
@@ -82,3 +82,119 @@ export type {
   GetImageParams,
   GetImageResponse,
 } from "./library.js";
+
+// Ratings endpoint types
+export type {
+  UpdateRatingRequest,
+  UpdateRatingResponse,
+  UpdateSceneRatingParams,
+  UpdatePerformerRatingParams,
+  UpdateStudioRatingParams,
+  UpdateTagRatingParams,
+  UpdateGalleryRatingParams,
+  UpdateGroupRatingParams,
+  UpdateImageRatingParams,
+} from "./ratings.js";
+
+// Watch History endpoint types
+export type {
+  WatchHistoryData,
+  FullWatchHistoryRecord,
+  PingWatchHistoryRequest,
+  PingWatchHistoryResponse,
+  SaveActivityRequest,
+  SaveActivityResponse,
+  IncrementPlayCountRequest,
+  IncrementPlayCountResponse,
+  IncrementOCounterRequest,
+  IncrementOCounterResponse,
+  GetAllWatchHistoryQuery,
+  GetAllWatchHistoryResponse,
+  GetWatchHistoryParams,
+  GetWatchHistoryResponse,
+  ClearAllWatchHistoryResponse,
+} from "./watchHistory.js";
+
+// Image View History endpoint types
+export type {
+  IncrementImageOCounterRequest,
+  IncrementImageOCounterResponse,
+  RecordImageViewRequest,
+  RecordImageViewResponse,
+  GetImageViewHistoryParams,
+  GetImageViewHistoryResponse,
+} from "./imageViewHistory.js";
+
+// Playlist endpoint types
+export type {
+  PlaylistItemWithScene,
+  PlaylistData,
+  GetUserPlaylistsResponse,
+  GetPlaylistParams,
+  GetPlaylistResponse,
+  CreatePlaylistRequest,
+  CreatePlaylistResponse,
+  UpdatePlaylistParams,
+  UpdatePlaylistRequest,
+  UpdatePlaylistResponse,
+  DeletePlaylistParams,
+  DeletePlaylistResponse,
+  AddSceneToPlaylistParams,
+  AddSceneToPlaylistRequest,
+  AddSceneToPlaylistResponse,
+  RemoveSceneFromPlaylistParams,
+  RemoveSceneFromPlaylistResponse,
+  ReorderPlaylistParams,
+  ReorderPlaylistRequest,
+  ReorderPlaylistResponse,
+} from "./playlist.js";
+
+// Carousel endpoint types
+export type {
+  CarouselData,
+  GetUserCarouselsResponse,
+  GetCarouselParams,
+  GetCarouselResponse,
+  CreateCarouselRequest,
+  CreateCarouselResponse,
+  UpdateCarouselParams,
+  UpdateCarouselRequest,
+  UpdateCarouselResponse,
+  DeleteCarouselParams,
+  DeleteCarouselResponse,
+  PreviewCarouselRequest,
+  PreviewCarouselResponse,
+  ExecuteCarouselByIdParams,
+  ExecuteCarouselByIdResponse,
+} from "./carousel.js";
+
+// Custom Theme endpoint types
+export type {
+  ThemeConfig,
+  CustomThemeData,
+  GetUserCustomThemesResponse,
+  GetCustomThemeParams,
+  GetCustomThemeResponse,
+  CreateCustomThemeRequest,
+  CreateCustomThemeResponse,
+  UpdateCustomThemeParams,
+  UpdateCustomThemeRequest,
+  UpdateCustomThemeResponse,
+  DeleteCustomThemeParams,
+  DeleteCustomThemeResponse,
+  DuplicateCustomThemeParams,
+  DuplicateCustomThemeResponse,
+} from "./customTheme.js";
+
+// Setup endpoint types
+export type {
+  GetSetupStatusResponse,
+  CreateFirstAdminRequest,
+  CreateFirstAdminResponse,
+  TestStashConnectionRequest,
+  TestStashConnectionResponse,
+  CreateFirstStashInstanceRequest,
+  CreateFirstStashInstanceResponse,
+  GetStashInstanceResponse,
+  ResetSetupResponse,
+} from "./setup.js";

--- a/server/types/api/playlist.ts
+++ b/server/types/api/playlist.ts
@@ -1,0 +1,199 @@
+// server/types/api/playlist.ts
+/**
+ * Playlist API Types
+ *
+ * Request and response types for /api/playlists/* endpoints.
+ */
+import type { Scene } from "stashapp-api";
+import type { NormalizedScene } from "../index.js";
+
+// =============================================================================
+// COMMON TYPES
+// =============================================================================
+
+/**
+ * Playlist item with optional scene data (can be raw Scene or NormalizedScene)
+ */
+export interface PlaylistItemWithScene {
+  id: number;
+  playlistId: number;
+  sceneId: string;
+  position: number;
+  addedAt: Date;
+  scene?: Scene | NormalizedScene | null;
+}
+
+/**
+ * Playlist with item count and optional items
+ * Uses Partial for optional fields since not all queries return all data
+ */
+export interface PlaylistData {
+  id: number;
+  userId: number;
+  name: string;
+  description: string | null;
+  isPublic: boolean;
+  shuffle: boolean;
+  repeat: string;
+  createdAt: Date;
+  updatedAt: Date;
+  _count?: {
+    items: number;
+  };
+  items?: PlaylistItemWithScene[];
+}
+
+// =============================================================================
+// GET USER PLAYLISTS
+// =============================================================================
+
+/**
+ * GET /api/playlists
+ * Get all playlists for current user
+ */
+export interface GetUserPlaylistsResponse {
+  playlists: PlaylistData[];
+}
+
+// =============================================================================
+// GET PLAYLIST
+// =============================================================================
+
+/**
+ * GET /api/playlists/:id
+ * Get single playlist with items and scene details
+ */
+export interface GetPlaylistParams extends Record<string, string> {
+  id: string;
+}
+
+export interface GetPlaylistResponse {
+  playlist: PlaylistData;
+}
+
+// =============================================================================
+// CREATE PLAYLIST
+// =============================================================================
+
+/**
+ * POST /api/playlists
+ * Create new playlist
+ */
+export interface CreatePlaylistRequest {
+  name: string;
+  description?: string;
+  isPublic?: boolean;
+}
+
+export interface CreatePlaylistResponse {
+  playlist: PlaylistData;
+}
+
+// =============================================================================
+// UPDATE PLAYLIST
+// =============================================================================
+
+/**
+ * PUT /api/playlists/:id
+ * Update playlist
+ */
+export interface UpdatePlaylistParams extends Record<string, string> {
+  id: string;
+}
+
+export interface UpdatePlaylistRequest {
+  name?: string;
+  description?: string;
+  isPublic?: boolean;
+  shuffle?: boolean;
+  repeat?: string;
+}
+
+export interface UpdatePlaylistResponse {
+  playlist: PlaylistData;
+}
+
+// =============================================================================
+// DELETE PLAYLIST
+// =============================================================================
+
+/**
+ * DELETE /api/playlists/:id
+ * Delete playlist
+ */
+export interface DeletePlaylistParams extends Record<string, string> {
+  id: string;
+}
+
+export interface DeletePlaylistResponse {
+  success: true;
+  message: string;
+}
+
+// =============================================================================
+// ADD SCENE TO PLAYLIST
+// =============================================================================
+
+/**
+ * POST /api/playlists/:id/items
+ * Add scene to playlist
+ */
+export interface AddSceneToPlaylistParams extends Record<string, string> {
+  id: string;
+}
+
+export interface AddSceneToPlaylistRequest {
+  sceneId: string;
+}
+
+export interface AddSceneToPlaylistResponse {
+  item: {
+    id: number;
+    playlistId: number;
+    sceneId: string;
+    position: number;
+    addedAt: Date;
+  };
+}
+
+// =============================================================================
+// REMOVE SCENE FROM PLAYLIST
+// =============================================================================
+
+/**
+ * DELETE /api/playlists/:id/items/:sceneId
+ * Remove scene from playlist
+ */
+export interface RemoveSceneFromPlaylistParams extends Record<string, string> {
+  id: string;
+  sceneId: string;
+}
+
+export interface RemoveSceneFromPlaylistResponse {
+  success: true;
+  message: string;
+}
+
+// =============================================================================
+// REORDER PLAYLIST
+// =============================================================================
+
+/**
+ * PUT /api/playlists/:id/reorder
+ * Reorder playlist items
+ */
+export interface ReorderPlaylistParams extends Record<string, string> {
+  id: string;
+}
+
+export interface ReorderPlaylistRequest {
+  items: Array<{
+    sceneId: string;
+    position: number;
+  }>;
+}
+
+export interface ReorderPlaylistResponse {
+  success: true;
+  message: string;
+}

--- a/server/types/api/ratings.ts
+++ b/server/types/api/ratings.ts
@@ -1,0 +1,107 @@
+// server/types/api/ratings.ts
+/**
+ * Ratings API Types
+ *
+ * Request and response types for /api/ratings/* endpoints.
+ */
+
+// =============================================================================
+// COMMON RATING TYPES
+// =============================================================================
+
+/**
+ * Common request body for all rating updates
+ */
+export interface UpdateRatingRequest {
+  rating?: number | null;
+  favorite?: boolean;
+}
+
+/**
+ * Common response for all rating updates
+ */
+export interface UpdateRatingResponse {
+  success: true;
+  rating: {
+    id: number;
+    rating: number | null;
+    favorite: boolean;
+  };
+}
+
+// =============================================================================
+// SCENE RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/scenes/:sceneId
+ */
+export interface UpdateSceneRatingParams extends Record<string, string> {
+  sceneId: string;
+}
+
+// =============================================================================
+// PERFORMER RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/performers/:performerId
+ */
+export interface UpdatePerformerRatingParams extends Record<string, string> {
+  performerId: string;
+}
+
+// =============================================================================
+// STUDIO RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/studios/:studioId
+ */
+export interface UpdateStudioRatingParams extends Record<string, string> {
+  studioId: string;
+}
+
+// =============================================================================
+// TAG RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/tags/:tagId
+ */
+export interface UpdateTagRatingParams extends Record<string, string> {
+  tagId: string;
+}
+
+// =============================================================================
+// GALLERY RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/galleries/:galleryId
+ */
+export interface UpdateGalleryRatingParams extends Record<string, string> {
+  galleryId: string;
+}
+
+// =============================================================================
+// GROUP RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/groups/:groupId
+ */
+export interface UpdateGroupRatingParams extends Record<string, string> {
+  groupId: string;
+}
+
+// =============================================================================
+// IMAGE RATING
+// =============================================================================
+
+/**
+ * PUT /api/ratings/images/:imageId
+ */
+export interface UpdateImageRatingParams extends Record<string, string> {
+  imageId: string;
+}

--- a/server/types/api/setup.ts
+++ b/server/types/api/setup.ts
@@ -1,0 +1,129 @@
+// server/types/api/setup.ts
+/**
+ * Setup API Types
+ *
+ * Request and response types for /api/setup/* endpoints.
+ * These are public endpoints for initial setup wizard.
+ */
+
+// =============================================================================
+// GET SETUP STATUS
+// =============================================================================
+
+/**
+ * GET /api/setup/status
+ * Check setup status (for determining if wizard is needed)
+ */
+export interface GetSetupStatusResponse {
+  setupComplete: boolean;
+  hasUsers: boolean;
+  hasStashInstance: boolean;
+  userCount: number;
+  stashInstanceCount: number;
+}
+
+// =============================================================================
+// CREATE FIRST ADMIN
+// =============================================================================
+
+/**
+ * POST /api/setup/create-admin
+ * Create first admin user (only works if NO users exist)
+ */
+export interface CreateFirstAdminRequest {
+  username: string;
+  password: string;
+}
+
+export interface CreateFirstAdminResponse {
+  success: true;
+  user: {
+    id: number;
+    username: string;
+    role: string;
+    createdAt: Date;
+  };
+}
+
+// =============================================================================
+// TEST STASH CONNECTION
+// =============================================================================
+
+/**
+ * POST /api/setup/test-stash-connection
+ * Test connection to a Stash server
+ */
+export interface TestStashConnectionRequest {
+  url: string;
+  apiKey: string;
+}
+
+export interface TestStashConnectionResponse {
+  success: boolean;
+  message?: string;
+  error?: string;
+  details?: string;
+}
+
+// =============================================================================
+// CREATE FIRST STASH INSTANCE
+// =============================================================================
+
+/**
+ * POST /api/setup/create-stash-instance
+ * Create first Stash instance (only works if NO instances exist)
+ */
+export interface CreateFirstStashInstanceRequest {
+  name?: string;
+  url: string;
+  apiKey: string;
+}
+
+export interface CreateFirstStashInstanceResponse {
+  success: true;
+  instance: {
+    id: string;
+    name: string;
+    url: string;
+    enabled: boolean;
+    createdAt: Date;
+  };
+}
+
+// =============================================================================
+// GET STASH INSTANCE
+// =============================================================================
+
+/**
+ * GET /api/setup/stash-instance
+ * Get current Stash instance info (for Server Settings display)
+ */
+export interface GetStashInstanceResponse {
+  instance: {
+    id: string;
+    name: string;
+    url: string;
+    enabled: boolean;
+    priority: number;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  instanceCount: number;
+}
+
+// =============================================================================
+// RESET SETUP
+// =============================================================================
+
+/**
+ * POST /api/setup/reset
+ * Reset setup state for recovery from partial setup
+ */
+export interface ResetSetupResponse {
+  success: true;
+  message: string;
+  deleted: {
+    users: number;
+    stashInstances: number;
+  };
+}

--- a/server/types/api/watchHistory.ts
+++ b/server/types/api/watchHistory.ts
@@ -1,0 +1,171 @@
+// server/types/api/watchHistory.ts
+/**
+ * Watch History API Types
+ *
+ * Request and response types for /api/watch-history/* endpoints.
+ */
+
+// =============================================================================
+// COMMON TYPES
+// =============================================================================
+
+/**
+ * Watch history data returned in responses
+ */
+export interface WatchHistoryData {
+  playCount: number;
+  playDuration: number;
+  resumeTime: number | null;
+  lastPlayedAt: Date | null;
+}
+
+/**
+ * Full watch history record (includes oCount and history arrays)
+ */
+export interface FullWatchHistoryRecord {
+  id: number;
+  userId: number;
+  sceneId: string;
+  playCount: number;
+  playDuration: number;
+  resumeTime: number | null;
+  lastPlayedAt: Date | null;
+  oCount: number;
+  oHistory: string[];
+  playHistory: string[];
+}
+
+// =============================================================================
+// PING WATCH HISTORY
+// =============================================================================
+
+/**
+ * POST /api/watch-history/ping
+ * Periodic ping from video player to track playback progress
+ */
+export interface PingWatchHistoryRequest {
+  sceneId: string;
+  currentTime: number;
+  quality?: string;
+  sessionStart?: string;
+  seekEvents?: Array<{ from: number; to: number }>;
+}
+
+export interface PingWatchHistoryResponse {
+  success: true;
+  watchHistory: WatchHistoryData;
+}
+
+// =============================================================================
+// SAVE ACTIVITY
+// =============================================================================
+
+/**
+ * POST /api/watch-history/save-activity
+ * Save resume time and play duration delta (called by track-activity plugin)
+ */
+export interface SaveActivityRequest {
+  sceneId: string;
+  resumeTime?: number;
+  playDuration?: number;
+}
+
+export interface SaveActivityResponse {
+  success: true;
+  watchHistory: WatchHistoryData;
+}
+
+// =============================================================================
+// INCREMENT PLAY COUNT
+// =============================================================================
+
+/**
+ * POST /api/watch-history/increment-play-count
+ * Increment play count when minimum play percentage is reached
+ */
+export interface IncrementPlayCountRequest {
+  sceneId: string;
+}
+
+export interface IncrementPlayCountResponse {
+  success: true;
+  watchHistory: WatchHistoryData;
+}
+
+// =============================================================================
+// INCREMENT O COUNTER
+// =============================================================================
+
+/**
+ * POST /api/watch-history/increment-o
+ * Increment O counter for a scene
+ */
+export interface IncrementOCounterRequest {
+  sceneId: string;
+}
+
+export interface IncrementOCounterResponse {
+  success: true;
+  oCount: number;
+  timestamp: string;
+}
+
+// =============================================================================
+// GET ALL WATCH HISTORY
+// =============================================================================
+
+/**
+ * GET /api/watch-history
+ * Get all watch history for current user (Continue Watching carousel)
+ */
+export interface GetAllWatchHistoryQuery
+  extends Record<string, string | undefined> {
+  limit?: string;
+  inProgress?: string;
+}
+
+export interface GetAllWatchHistoryResponse {
+  watchHistory: FullWatchHistoryRecord[];
+}
+
+// =============================================================================
+// GET WATCH HISTORY
+// =============================================================================
+
+/**
+ * GET /api/watch-history/:sceneId
+ * Get watch history for a specific scene
+ */
+export interface GetWatchHistoryParams extends Record<string, string> {
+  sceneId: string;
+}
+
+export interface GetWatchHistoryResponse {
+  exists: boolean;
+  resumeTime: number | null;
+  playCount: number;
+  playDuration?: number;
+  lastPlayedAt?: Date | null;
+  oCount: number;
+  oHistory?: string[];
+  playHistory?: string[];
+}
+
+// =============================================================================
+// CLEAR ALL WATCH HISTORY
+// =============================================================================
+
+/**
+ * DELETE /api/watch-history
+ * Clear all watch history for current user
+ */
+export interface ClearAllWatchHistoryResponse {
+  success: true;
+  deletedCounts: {
+    watchHistory: number;
+    performerStats: number;
+    studioStats: number;
+    tagStats: number;
+  };
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Add typed request/response signatures for 7 controllers in Phase 3
- Create type files following established pattern from Phase 2
- All authenticated routes use `authenticated()` wrapper for type compatibility

## Controllers Typed

| Controller | Type File | Endpoints |
|------------|-----------|-----------|
| ratings | `ratings.ts` | scene, performer, studio, tag, gallery, group, image rating updates |
| watchHistory | `watchHistory.ts` | ping, save-activity, increment-play-count, increment-o, get-all, get-one, clear-all |
| imageViewHistory | `imageViewHistory.ts` | increment-o, record-view, get-history |
| playlist | `playlist.ts` | CRUD, add/remove scenes, reorder |
| carousel | `carousel.ts` | CRUD, preview, execute by ID |
| customTheme | `customTheme.ts` | CRUD, duplicate |
| setup | `setup.ts` | wizard endpoints (public, no auth) |

## Changes

### New files
- `server/types/api/ratings.ts`
- `server/types/api/watchHistory.ts`
- `server/types/api/imageViewHistory.ts`
- `server/types/api/playlist.ts`
- `server/types/api/carousel.ts`
- `server/types/api/customTheme.ts`
- `server/types/api/setup.ts`

### Modified files
- `server/types/api/common.ts` - Added `message` field to ApiErrorResponse
- `server/types/api/index.ts` - Re-exports for all new type files
- 7 controller files - Updated handler signatures
- `server/routes/ratings.ts` - Added `authenticated()` wrapper

## Deferred

- `user` controller saved for separate branch per discussion

## Test plan

- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] All 123 tests pass (`npm test`)
- [x] Linter passes with 0 errors
- [x] Code review completed
