### PR TITLE
fix: resolve proxy URL and exclusion unique constraint errors

### DIFF
--- a/server/utils/stashUrlProxy.ts
+++ b/server/utils/stashUrlProxy.ts
@@ -49,6 +49,11 @@ export const convertToProxyUrl = (url: string): string => {
       return url;
     }
 
+    // Skip URLs that are already proxy URLs (relative paths starting with /api/proxy)
+    if (url.startsWith("/api/proxy")) {
+      return url;
+    }
+
     const urlObj = new URL(url);
 
     // Extract the path and query string from the Stash URL


### PR DESCRIPTION
## Summary

Fix two bugs found during v3.1.0-beta.10 testing on Unraid:

### 1. ERR_INVALID_URL in stashUrlProxy.ts

**Error:**
```
Error converting URL to proxy: /api/proxy/stash?path=%2Fscene%2F...
{"error":{"code":"ERR_INVALID_URL","input":"/api/proxy/stash?path=..."}}
```

**Cause:** `convertToProxyUrl()` was receiving URLs that had already been converted to proxy URLs (relative paths starting with `/api/proxy`). When passed to `new URL()`, these relative URLs threw `ERR_INVALID_URL` because they lack a protocol/host.

**Fix:** Added early return for URLs already starting with `/api/proxy` - these don't need conversion.

### 2. Unique constraint violation in ExclusionComputationService.ts

**Error:**
```
PrismaClientKnownRequestError: Unique constraint failed on the fields: (`userId`,`entityType`,`entityId`)
```

**Cause:** When computing exclusions, the same entity could be excluded via multiple paths (e.g., a scene cascaded from an excluded performer AND cascaded from an excluded tag). The combined array contained duplicates, and `createMany()` failed on the unique constraint.

**Fix:** Added deduplication using a Set to track `entityType:entityId` before inserting. Only the first exclusion for each entity is kept.

## Test plan

- [x] TypeScript compiles without errors
- [x] All 500 tests pass
- [x] Linter passes (0 errors)
- [ ] Manual test: Create new user with content restrictions on Unraid

🤖 Generated with [Claude Code](https://claude.com/claude-code)