### PR TITLE
fix: ensure tmp directory exists before writing SQL files

### DIFF
--- a/server/initializers/database.ts
+++ b/server/initializers/database.ts
@@ -1,11 +1,12 @@
 import { exec } from "child_process";
-import { existsSync, writeFileSync, unlinkSync } from "fs";
+import { existsSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import path from "path";
 import { promisify } from "util";
 import { logger } from "../utils/logger.js";
 import { runSchemaCatchup } from "./schemaCatchup.js";
 
 const execAsync = promisify(exec);
+const TMP_DIR = "/app/data/tmp";
 
 // Track whether migrations were applied during startup
 let migrationsApplied = false;
@@ -20,7 +21,8 @@ export const wereMigrationsApplied = (): boolean => migrationsApplied;
  * Execute a SQLite query and return the result
  */
 async function sqliteQuery(dbPath: string, sql: string): Promise<string> {
-  const tmpFile = path.join("/app/data/tmp", `sql_${Date.now()}.sql`);
+  mkdirSync(TMP_DIR, { recursive: true });
+  const tmpFile = path.join(TMP_DIR, `sql_${Date.now()}.sql`);
   try {
     writeFileSync(tmpFile, sql);
     const { stdout } = await execAsync(

--- a/server/initializers/schemaCatchup.ts
+++ b/server/initializers/schemaCatchup.ts
@@ -30,18 +30,20 @@
  */
 
 import { exec } from "child_process";
-import { existsSync, writeFileSync, unlinkSync } from "fs";
+import { existsSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import path from "path";
 import { promisify } from "util";
 import { logger } from "../utils/logger.js";
 
 const execAsync = promisify(exec);
+const TMP_DIR = "/app/data/tmp";
 
 /**
  * Execute a SQLite query and return the result
  */
 async function sqliteQuery(dbPath: string, sql: string): Promise<string> {
-  const tmpFile = path.join("/app/data/tmp", `sql_${Date.now()}.sql`);
+  mkdirSync(TMP_DIR, { recursive: true });
+  const tmpFile = path.join(TMP_DIR, `sql_${Date.now()}.sql`);
   try {
     writeFileSync(tmpFile, sql);
     const { stdout } = await execAsync(`sqlite3 "${dbPath}" < "${tmpFile}" 2>/dev/null || true`);


### PR DESCRIPTION
## Summary
- Fix server crash on startup caused by missing `/app/data/tmp` directory
- The directory created during Docker build gets shadowed by the volume mount at runtime
- Add `mkdirSync` with `recursive: true` to create directory before writing temp SQL files

## Test plan
- [x] Verify server starts without ENOENT error
- [x] Lint passes
- [x] TypeScript compiles without errors