### PR TITLE
fix: use centralized indicator config for SceneCard, GalleryCard, ImageCard

### DIFF
--- a/client/src/components/cards/GalleryCard.jsx
+++ b/client/src/components/cards/GalleryCard.jsx
@@ -1,6 +1,8 @@
 import { forwardRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { BaseCard } from "../ui/BaseCard.jsx";
 import { TooltipEntityGrid } from "../ui/TooltipEntityGrid.jsx";
+import { getIndicatorBehavior } from "../../config/indicatorBehaviors.js";
 import { galleryTitle } from "../../utils/gallery.js";
 
 /**
@@ -8,6 +10,7 @@ import { galleryTitle } from "../../utils/gallery.js";
  */
 const GalleryCard = forwardRef(
   ({ gallery, referrerUrl, tabIndex, onHideSuccess, displayPreferences, ...rest }, ref) => {
+    const navigate = useNavigate();
 
     // Build subtitle from studio and date
     const galleryDate = gallery.date
@@ -24,10 +27,9 @@ const GalleryCard = forwardRef(
       return null;
     })();
 
-    // Build rich tooltip content for performers and tags
-    const performersTooltip =
-      gallery.performers &&
-      gallery.performers.length > 0 && (
+    // Build rich tooltip content for performers and tags (using centralized config)
+    const performersTooltip = getIndicatorBehavior('gallery', 'performers') === 'rich' &&
+      gallery.performers?.length > 0 && (
         <TooltipEntityGrid
           entityType="performer"
           entities={gallery.performers}
@@ -35,9 +37,8 @@ const GalleryCard = forwardRef(
         />
       );
 
-    const tagsTooltip =
-      gallery.tags &&
-      gallery.tags.length > 0 && (
+    const tagsTooltip = getIndicatorBehavior('gallery', 'tags') === 'rich' &&
+      gallery.tags?.length > 0 && (
         <TooltipEntityGrid
           entityType="tag"
           entities={gallery.tags}
@@ -45,9 +46,9 @@ const GalleryCard = forwardRef(
         />
       );
 
-    const scenesTooltip =
-      gallery.scenes &&
-      gallery.scenes.length > 0 && (
+    // Scenes indicator: config says 'nav' for gallery->scenes
+    const scenesTooltip = getIndicatorBehavior('gallery', 'scenes') === 'rich' &&
+      gallery.scenes?.length > 0 && (
         <TooltipEntityGrid
           entityType="scene"
           entities={gallery.scenes}
@@ -59,23 +60,35 @@ const GalleryCard = forwardRef(
       {
         type: "IMAGES",
         count: gallery.image_count,
-        tooltipContent:
-          gallery.image_count === 1 ? "1 Image" : `${gallery.image_count} Images`,
+        // Config says 'nav' for gallery->images
+        onClick: getIndicatorBehavior('gallery', 'images') === 'nav' && gallery.image_count > 0
+          ? () => navigate(`/images?galleryId=${gallery.id}`)
+          : undefined,
       },
       {
         type: "SCENES",
         count: gallery.scenes?.length || 0,
         tooltipContent: scenesTooltip,
+        // Config says 'nav' for gallery->scenes
+        onClick: getIndicatorBehavior('gallery', 'scenes') === 'nav' && gallery.scenes?.length > 0
+          ? () => navigate(`/scenes?galleryId=${gallery.id}`)
+          : undefined,
       },
       {
         type: "PERFORMERS",
         count: gallery.performers?.length || 0,
         tooltipContent: performersTooltip,
+        onClick: getIndicatorBehavior('gallery', 'performers') === 'nav' && gallery.performers?.length > 0
+          ? () => navigate(`/performers?galleryId=${gallery.id}`)
+          : undefined,
       },
       {
         type: "TAGS",
         count: gallery.tags?.length || 0,
         tooltipContent: tagsTooltip,
+        onClick: getIndicatorBehavior('gallery', 'tags') === 'nav' && gallery.tags?.length > 0
+          ? () => navigate(`/tags?galleryId=${gallery.id}`)
+          : undefined,
       },
     ];
 

--- a/client/src/components/cards/ImageCard.jsx
+++ b/client/src/components/cards/ImageCard.jsx
@@ -2,6 +2,7 @@ import { forwardRef } from "react";
 import { getEffectiveImageMetadata, getImageTitle } from "../../utils/imageGalleryInheritance.js";
 import { BaseCard } from "../ui/BaseCard.jsx";
 import { TooltipEntityGrid } from "../ui/TooltipEntityGrid.jsx";
+import { getIndicatorBehavior } from "../../config/indicatorBehaviors.js";
 
 /**
  * Format resolution string from width/height
@@ -37,8 +38,8 @@ const ImageCard = forwardRef(
 
     const galleries = image.galleries || [];
 
-    // Build rich tooltip content for performers, tags, and galleries
-    const performersTooltip =
+    // Build rich tooltip content using centralized config
+    const performersTooltip = getIndicatorBehavior('image', 'performers') === 'rich' &&
       effectivePerformers.length > 0 && (
         <TooltipEntityGrid
           entityType="performer"
@@ -47,7 +48,7 @@ const ImageCard = forwardRef(
         />
       );
 
-    const tagsTooltip =
+    const tagsTooltip = getIndicatorBehavior('image', 'tags') === 'rich' &&
       effectiveTags.length > 0 && (
         <TooltipEntityGrid
           entityType="tag"
@@ -57,7 +58,7 @@ const ImageCard = forwardRef(
       );
 
     const galleriesCount = galleries.length;
-    const galleriesContent =
+    const galleriesContent = getIndicatorBehavior('image', 'galleries') === 'rich' &&
       galleriesCount > 0 && (
         <TooltipEntityGrid
           entityType="gallery"

--- a/client/src/components/ui/SceneCard.jsx
+++ b/client/src/components/ui/SceneCard.jsx
@@ -8,6 +8,7 @@ import {
   getSceneTitle,
 } from "../../utils/format.js";
 import { formatRelativeTime } from "../../utils/date.js";
+import { getIndicatorBehavior } from "../../config/indicatorBehaviors.js";
 import BaseCard from "./BaseCard.jsx";
 import { SceneCardPreview, TooltipEntityGrid } from "./index.js";
 
@@ -88,35 +89,39 @@ const SceneCard = forwardRef(
     // Combine direct tags with server-computed inherited tags
     const allTags = useMemo(() => computeAllTags(scene), [scene]);
 
-    // Build indicators with JSX tooltips
+    // Build indicators using centralized config
     const indicators = useMemo(() => {
-      const performersTooltip = scene.performers && scene.performers.length > 0 && (
-        <TooltipEntityGrid
-          entityType="performer"
-          entities={scene.performers}
-          title="Performers"
-        />
-      );
+      const performersTooltip = getIndicatorBehavior('scene', 'performers') === 'rich' &&
+        scene.performers?.length > 0 && (
+          <TooltipEntityGrid
+            entityType="performer"
+            entities={scene.performers}
+            title="Performers"
+          />
+        );
 
-      const groupsTooltip = scene.groups && scene.groups.length > 0 && (
-        <TooltipEntityGrid
-          entityType="group"
-          entities={scene.groups}
-          title="Collections"
-        />
-      );
+      const groupsTooltip = getIndicatorBehavior('scene', 'groups') === 'rich' &&
+        scene.groups?.length > 0 && (
+          <TooltipEntityGrid
+            entityType="group"
+            entities={scene.groups}
+            title="Collections"
+          />
+        );
 
-      const tagsTooltip = allTags && allTags.length > 0 && (
-        <TooltipEntityGrid entityType="tag" entities={allTags} title="Tags" />
-      );
+      const tagsTooltip = getIndicatorBehavior('scene', 'tags') === 'rich' &&
+        allTags?.length > 0 && (
+          <TooltipEntityGrid entityType="tag" entities={allTags} title="Tags" />
+        );
 
-      const galleriesTooltip = scene.galleries && scene.galleries.length > 0 && (
-        <TooltipEntityGrid
-          entityType="gallery"
-          entities={scene.galleries}
-          title="Galleries"
-        />
-      );
+      const galleriesTooltip = getIndicatorBehavior('scene', 'galleries') === 'rich' &&
+        scene.galleries?.length > 0 && (
+          <TooltipEntityGrid
+            entityType="gallery"
+            entities={scene.galleries}
+            title="Galleries"
+          />
+        );
 
       return [
         {
@@ -128,33 +133,34 @@ const SceneCard = forwardRef(
           type: "PERFORMERS",
           count: scene.performers?.length,
           tooltipContent: performersTooltip,
-          onClick: scene.performers?.length > 0 ? () => {
-            navigate(`/performers?sceneId=${scene.id}`);
-          } : undefined,
+          // 'rich' behavior: tooltip only, no onClick (users navigate via entities in tooltip)
+          onClick: getIndicatorBehavior('scene', 'performers') === 'nav' && scene.performers?.length > 0
+            ? () => navigate(`/performers?sceneId=${scene.id}`)
+            : undefined,
         },
         {
           type: "GROUPS",
           count: scene.groups?.length,
           tooltipContent: groupsTooltip,
-          onClick: scene.groups?.length > 0 ? () => {
-            navigate(`/collections?sceneId=${scene.id}`);
-          } : undefined,
+          onClick: getIndicatorBehavior('scene', 'groups') === 'nav' && scene.groups?.length > 0
+            ? () => navigate(`/collections?sceneId=${scene.id}`)
+            : undefined,
         },
         {
           type: "GALLERIES",
           count: scene.galleries?.length,
           tooltipContent: galleriesTooltip,
-          onClick: scene.galleries?.length > 0 ? () => {
-            navigate(`/galleries?sceneId=${scene.id}`);
-          } : undefined,
+          onClick: getIndicatorBehavior('scene', 'galleries') === 'nav' && scene.galleries?.length > 0
+            ? () => navigate(`/galleries?sceneId=${scene.id}`)
+            : undefined,
         },
         {
           type: "TAGS",
           count: allTags?.length,
           tooltipContent: tagsTooltip,
-          onClick: allTags?.length > 0 ? () => {
-            navigate(`/tags?sceneId=${scene.id}`);
-          } : undefined,
+          onClick: getIndicatorBehavior('scene', 'tags') === 'nav' && allTags?.length > 0
+            ? () => navigate(`/tags?sceneId=${scene.id}`)
+            : undefined,
         },
       ];
     }, [scene, allTags, navigate]);


### PR DESCRIPTION
## Summary

- SceneCard indicators now use `getIndicatorBehavior()` instead of hardcoded behavior with conflicting `onClick` handlers
- GalleryCard now correctly uses 'nav' behavior for scenes/images indicators (was incorrectly showing rich tooltips)
- ImageCard updated to use centralized config for consistency and future-proofing

## Problem

PR #262 unified card architecture but SceneCard indicators had **both** `tooltipContent` AND `onClick` on the same indicators. When clicking a 'rich' indicator (like Performers), the `onClick` fired immediately and navigated away instead of opening the popover.

## Solution

All three cards now consistently check `getIndicatorBehavior()`:
- **'rich'** → `tooltipContent` only (users navigate via entities inside the popover)
- **'nav'** → `onClick` only (navigates to filtered list)
- **'count'** → display only

## Test plan

- [ ] Click performer indicator on SceneCard - should open popover, not navigate
- [ ] Click tags indicator on SceneCard - should open popover
- [ ] Click scenes indicator on GalleryCard - should navigate to `/scenes?galleryId=...`
- [ ] Click images indicator on GalleryCard - should navigate to `/images?galleryId=...`
- [ ] Verify all other cards still work as expected