### PR TITLE
fix: Add studio name hydration to playlist detail endpoint

### DIFF
--- a/server/services/StashEntityService.ts
+++ b/server/services/StashEntityService.ts
@@ -510,8 +510,12 @@ class StashEntityService {
     if (!cached) return null;
     const scene = this.transformSceneWithRelations(cached);
 
-    // Hydrate inherited tags
-    const tagNames = await this.getTagNameMap();
+    // Hydrate studio names and inherited tags
+    const [studioNames, tagNames] = await Promise.all([
+      this.getStudioNameMap(),
+      this.getTagNameMap(),
+    ]);
+    this.hydrateStudioNames([scene], studioNames);
     this.hydrateInheritedTags([scene], tagNames);
 
     return scene;
@@ -554,8 +558,12 @@ class StashEntityService {
 
     const scenes = cached.map((c) => this.transformSceneWithRelations(c));
 
-    // Hydrate inherited tags
-    const tagNames = await this.getTagNameMap();
+    // Hydrate studio names and inherited tags
+    const [studioNames, tagNames] = await Promise.all([
+      this.getStudioNameMap(),
+      this.getTagNameMap(),
+    ]);
+    this.hydrateStudioNames(scenes, studioNames);
     this.hydrateInheritedTags(scenes, tagNames);
 
     return scenes;


### PR DESCRIPTION
## Summary
- Fixed bug where playlist detail endpoint returned studio objects without `name` field
- Added `hydrateStudioNames` call to `getScenesByIdsWithRelations` method to match other scene query methods

## Root Cause
The `getScenesByIdsWithRelations` method in `StashEntityService` only hydrated inherited tags but not studio names, unlike `getAllScenes` and `getScenesPaginated` which hydrate both.

## Test plan
- [ ] Verify playlist detail endpoint returns studio name in scene objects
- [ ] Confirm all 505 existing tests pass