### PR TITLE
fix: prevent navigation when clicking scene card checkbox

### DIFF
--- a/client/tests/hooks/useCardSelection.test.js
+++ b/client/tests/hooks/useCardSelection.test.js
@@ -107,7 +107,7 @@ describe("useCardSelection", () => {
     expect(result.current.handleNavigationClick).toBeDefined();
   });
 
-  it("returns undefined handleNavigationClick when not in selectionMode", () => {
+  it("always returns handleNavigationClick even when not in selectionMode", () => {
     const onToggleSelect = vi.fn();
     const entity = { id: "1" };
 
@@ -115,7 +115,67 @@ describe("useCardSelection", () => {
       useCardSelection({ entity, selectionMode: false, onToggleSelect })
     );
 
-    expect(result.current.handleNavigationClick).toBeUndefined();
+    // Should always be defined so it can intercept clicks from interactive elements
+    expect(result.current.handleNavigationClick).toBeDefined();
+  });
+
+  it("handleNavigationClick prevents default when click originated from interactive element (checkbox)", () => {
+    const onToggleSelect = vi.fn();
+    const entity = { id: "1" };
+    const preventDefault = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCardSelection({ entity, selectionMode: false, onToggleSelect })
+    );
+
+    // Create a mock button element that simulates the checkbox
+    const button = document.createElement("button");
+    const link = document.createElement("a");
+    link.appendChild(button);
+    document.body.appendChild(link);
+
+    act(() => {
+      result.current.handleNavigationClick({
+        preventDefault,
+        target: button,
+        currentTarget: link,
+      });
+    });
+
+    // Should prevent navigation when click came from button inside link
+    expect(preventDefault).toHaveBeenCalled();
+    // Should NOT call onToggleSelect - checkbox handles its own selection
+    expect(onToggleSelect).not.toHaveBeenCalled();
+
+    document.body.removeChild(link);
+  });
+
+  it("handleNavigationClick allows navigation when click is directly on link (not from interactive element)", () => {
+    const onToggleSelect = vi.fn();
+    const entity = { id: "1" };
+    const preventDefault = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCardSelection({ entity, selectionMode: false, onToggleSelect })
+    );
+
+    // Click directly on the link, not on an interactive child
+    const link = document.createElement("a");
+    document.body.appendChild(link);
+
+    act(() => {
+      result.current.handleNavigationClick({
+        preventDefault,
+        target: link,
+        currentTarget: link,
+      });
+    });
+
+    // Should NOT prevent navigation - this is a normal link click
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onToggleSelect).not.toHaveBeenCalled();
+
+    document.body.removeChild(link);
   });
 
   it("handleNavigationClick prevents default and toggles in selection mode", () => {
@@ -133,5 +193,40 @@ describe("useCardSelection", () => {
 
     expect(preventDefault).toHaveBeenCalled();
     expect(onToggleSelect).toHaveBeenCalledWith(entity);
+  });
+
+  it("long-press selection does not trigger navigation - click after long-press is blocked", () => {
+    const onToggleSelect = vi.fn();
+    const entity = { id: "1" };
+    const preventDefault = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCardSelection({ entity, selectionMode: false, onToggleSelect })
+    );
+
+    // Simulate long-press: mousedown, wait 500ms for selection to fire
+    act(() => {
+      result.current.selectionHandlers.onMouseDown({ target: document.body });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // Long-press fired, isLongPressing should be true
+    expect(result.current.isLongPressing).toBe(true);
+    expect(onToggleSelect).toHaveBeenCalledWith(entity);
+
+    // Now the click event fires (browser behavior after mouseup)
+    // This should be blocked to prevent navigation
+    act(() => {
+      result.current.handleNavigationClick({ preventDefault });
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    // onToggleSelect should only have been called once (from long-press, not from click)
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    // isLongPressing should be reset
+    expect(result.current.isLongPressing).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fixed bug where clicking the checkbox on a scene card triggered navigation to the scene page
- The selection correctly worked (card was selected when going back), but navigation should not occur
- Root cause: `handleNavigationClick` was only returned when `selectionMode` was true, leaving the Link with no click handler on the first selection

## Test plan
- [x] Added test: `always returns handleNavigationClick even when not in selectionMode`
- [x] Added test: `handleNavigationClick prevents default when click originated from interactive element (checkbox)`
- [x] Added test: `handleNavigationClick allows navigation when click is directly on link`
- [x] Added test: `long-press selection does not trigger navigation - click after long-press is blocked`
- [x] All 575 client tests pass
- [ ] Manual test: click checkbox on scene card, verify no navigation occurs
- [ ] Manual test: long-press to select, verify no navigation occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)