### PR TITLE
feat: add grid density control for folder and timeline views

### DIFF
--- a/client/src/components/ui/SearchControls.jsx
+++ b/client/src/components/ui/SearchControls.jsx
@@ -895,8 +895,8 @@ const SearchControls = ({
           </div>
         )}
 
-        {/* Grid Density Slider - Only shown in grid mode */}
-        {viewMode === "grid" && (
+        {/* Grid Density Slider - Shown in grid, folder, and timeline modes */}
+        {(viewMode === "grid" || viewMode === "folder" || viewMode === "timeline") && (
           <div
             data-tv-search-item="grid-density"
             ref={(el) => searchZoneNav.setItemRef(6, el)}


### PR DESCRIPTION
## Summary
- The grid density slider (S/M/L) now appears for folder and timeline views, not just grid view
- All three view modes use CSS grids and already accepted the `gridDensity` prop, but lacked the UI control to change it

## Test plan
- [x] Client tests pass (1004 tests)
- [x] Client lint passes (no errors)
- [x] Client build succeeds
- [ ] Manual: Switch to folder view on Scenes page, verify zoom slider appears
- [ ] Manual: Switch to timeline view, verify zoom slider appears
- [ ] Manual: Changing density resizes cards in both views