### PR TITLE
feat: improve user stats ranking with percentile-based engagement scoring

### DIFF
--- a/client/src/components/pages/UserStats/components/TopList.jsx
+++ b/client/src/components/pages/UserStats/components/TopList.jsx
@@ -35,6 +35,9 @@ const getDisplayName = (item) => {
  * All items use consistent row height - landscape images pillarboxed to match portrait height
  * @param {string} entityType - Type of entity for aspect ratio (performer, studio, tag, scene)
  */
+// Fixed height for 5 visible items (each row ~72px with padding)
+const LIST_HEIGHT = "360px";
+
 const TopList = ({ title, items, linkPrefix, entityType = "performer", showImage = true }) => {
   if (!items || items.length === 0) {
     return null;
@@ -56,7 +59,13 @@ const TopList = ({ title, items, linkPrefix, entityType = "performer", showImage
           {title}
         </h3>
       </div>
-      <div className="divide-y" style={{ borderColor: "var(--border-color)" }}>
+      <div
+        className="divide-y overflow-y-auto"
+        style={{
+          borderColor: "var(--border-color)",
+          maxHeight: LIST_HEIGHT,
+        }}
+      >
         {items.map((item, index) => {
           const duration =
             item.playDuration > 0

--- a/docs/plans/2026-01-20-user-stats-ranking-formula-design.md
+++ b/docs/plans/2026-01-20-user-stats-ranking-formula-design.md
@@ -1,0 +1,163 @@
+# User Stats Ranking Formula Design
+
+## Problem Statement
+
+The current "top" rankings on the user stats page use simple `playCount DESC` sorting, which produces misleading results:
+
+1. **Male performers dominate** - They appear in 3-5x more scenes on average, so they accumulate more plays by sheer exposure
+2. **Ubiquitous tags rank unfairly high** - "Blowjob" (41% of library) will always beat niche tags regardless of actual preference
+3. **Large studios have inherent advantage** - More scenes = more opportunity for plays
+4. **No quality signal** - A scene watched for 5 seconds counts the same as one watched fully with engagement
+
+## Solution: Bayesian-Weighted Normalized Engagement Score
+
+Combine three proven techniques:
+
+1. **Weighted engagement metrics** - O-count matters most, then duration, then play count
+2. **Library presence normalization** - Score relative to available content
+3. **Bayesian dampening** - Prevent small sample sizes from dominating
+
+### The Formula
+
+For performers, tags, and studios:
+
+```
+rawEngagement = (oCount × 5) + (normalizedDuration × 1) + (playCount × 1)
+
+engagementRate = rawEngagement / libraryPresence
+
+finalScore = (plays / (plays + m)) × engagementRate + (m / (plays + m)) × globalAvgRate
+```
+
+For scenes (no library presence to normalize against):
+
+```
+finalScore = (oCount × 5) + (normalizedDuration × 1) + (playCount × 1)
+```
+
+### Variables Explained
+
+| Variable | Description | Source |
+|----------|-------------|--------|
+| `oCount` | Number of Os recorded | `UserPerformerStats.oCounter`, `WatchHistory.oCount`, etc. |
+| `normalizedDuration` | Watch time normalized by average scene length | `SUM(playDuration) / avgSceneDuration` |
+| `playCount` | Number of times played | `UserPerformerStats.playCount`, etc. |
+| `libraryPresence` | Scenes available in library | Count of scenes with this performer/tag/studio |
+| `plays` | Total play events for this entity | Same as playCount |
+| `m` | Bayesian dampening threshold | Tunable constant (recommend: 5) |
+| `globalAvgRate` | Average engagement rate across all entities of this type | Computed per-user |
+
+### Weight Rationale
+
+| Metric | Weight | Reasoning |
+|--------|--------|-----------|
+| O-count | 5 | Strongest signal of genuine enjoyment |
+| Duration | 1 | Time spent indicates interest, but longer scenes shouldn't dominate |
+| Play count | 1 | Returning to content matters, but less than completion/enjoyment |
+
+### Bayesian Dampening
+
+The formula `(plays / (plays + m)) × score + (m / (plays + m)) × globalAvg` works as follows:
+
+- With 0 plays: Score = 100% global average (no personal signal)
+- With `m` plays: Score = 50% personal + 50% global average
+- With `2m` plays: Score = 67% personal + 33% global average
+- With `10m` plays: Score = 91% personal + 9% global average
+
+This prevents a performer with 2 scenes (both watched with Os) from unfairly beating a performer with 100 scenes (40 watched, 10 with Os). The small-catalog performer needs more engagement to prove they're truly a favorite.
+
+### Example Calculations
+
+**Scenario**: Phoenix's top performers
+
+| Performer | Gender | Library Scenes | Plays | Os | Duration (norm) | Raw Engagement | Engagement Rate | Bayesian Score |
+|-----------|--------|----------------|-------|-----|-----------------|----------------|-----------------|----------------|
+| Lexi Belle | F | 109 | 5 | 3 | 2.5 | 22.5 | 0.206 | 0.146 |
+| Scott Nails | M | 208 | 8 | 2 | 4.0 | 22.0 | 0.106 | 0.088 |
+| Evan Stone | M | 491 | 7 | 5 | 3.5 | 35.5 | 0.072 | 0.063 |
+
+*Assuming m=5, globalAvgRate=0.05, avgSceneDuration=1200s*
+
+With normalization + Bayesian dampening, Lexi Belle (female, smaller catalog, higher engagement rate) ranks above male performers with more raw plays.
+
+## Implementation
+
+### Database Changes
+
+None required - all data already exists in:
+- `WatchHistory` (scenes)
+- `UserPerformerStats`, `UserStudioStats`, `UserTagStats` (aggregated stats)
+- `StashScene`, `ScenePerformer`, `SceneTag` (library presence counts)
+
+### Service Changes
+
+Modify `UserStatsAggregationService.ts`:
+
+1. Add helper to compute `globalAvgRate` per entity type
+2. Add helper to compute `avgSceneDuration` for normalization
+3. Update `getTopPerformers()`, `getTopStudios()`, `getTopTags()`, `getTopScenes()` to use new formula
+4. Return the computed score in API response for transparency
+
+### API Response Changes
+
+Add `score` field to each top item so the UI can display it if desired:
+
+```typescript
+interface TopPerformer {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playCount: number;
+  playDuration: number;
+  oCount: number;
+  score: number;  // NEW: computed ranking score
+}
+```
+
+### Configuration
+
+Add tunable constants (could be environment variables or hardcoded initially):
+
+```typescript
+const RANKING_CONFIG = {
+  weights: {
+    oCount: 5,
+    duration: 1,
+    playCount: 1,
+  },
+  bayesianThreshold: 5,  // 'm' in the formula
+};
+```
+
+## Testing Strategy
+
+1. **Unit tests** for score calculation with known inputs
+2. **Integration tests** comparing old vs new rankings
+3. **Manual verification** with Phoenix user data - do rankings "feel right"?
+
+## Future Enhancements
+
+- User-configurable weights via settings
+- Recency weighting (recent engagement matters more)
+- Separate "trending" vs "all-time" rankings
+- A/B testing different weight configurations
+
+## Recommendations Page Integration (Pending Validation)
+
+Once the user stats ranking formula is validated, these learnings can improve the Recommendations page (`RecommendationScoringService.ts`):
+
+### Current Gaps in Recommendations
+
+1. **No watch history data** - Only uses explicit ratings/favorites, ignores actual viewing behavior
+2. **No library presence normalization** - Male performers / ubiquitous tags could dominate derived weights
+3. **No small-sample dampening** - A single favorited scene gives its performers full weight
+
+### Proposed Improvements
+
+1. **Hybrid scoring** - Blend explicit preferences (current) with implicit engagement (this formula) for derived weights
+
+2. **Engagement-weighted scene derivation** - Currently a favorited scene propagates weight to all its performers equally. Weight by actual engagement instead: a performer in a scene watched 5x with 3 Os gets more derived weight than one in a scene favorited but barely watched.
+
+3. **Library presence normalization for derived weights** - When accumulating `derivedPerformerWeights`, divide by performer's library presence so niche performers with deep engagement rank higher.
+
+**Status**: Pending validation of user stats formula. Test there first, then apply to recommendations.

--- a/server/controllers/watchHistory.ts
+++ b/server/controllers/watchHistory.ts
@@ -561,17 +561,19 @@ export async function clearAllWatchHistory(
 
     logger.info("Clearing all watch history and stats", { userId });
 
-    // Delete watch history and all related stats in parallel
+    // Delete watch history, all related stats, and rankings in parallel
     const [
       watchHistoryResult,
       performerStatsResult,
       studioStatsResult,
       tagStatsResult,
+      rankingsResult,
     ] = await Promise.all([
       prisma.watchHistory.deleteMany({ where: { userId } }),
       prisma.userPerformerStats.deleteMany({ where: { userId } }),
       prisma.userStudioStats.deleteMany({ where: { userId } }),
       prisma.userTagStats.deleteMany({ where: { userId } }),
+      prisma.userEntityRanking.deleteMany({ where: { userId } }),
     ]);
 
     logger.info("Watch history and stats cleared", {
@@ -580,6 +582,7 @@ export async function clearAllWatchHistory(
       performerStatsDeleted: performerStatsResult.count,
       studioStatsDeleted: studioStatsResult.count,
       tagStatsDeleted: tagStatsResult.count,
+      rankingsDeleted: rankingsResult.count,
     });
 
     res.json({
@@ -589,6 +592,7 @@ export async function clearAllWatchHistory(
         performerStats: performerStatsResult.count,
         studioStats: studioStatsResult.count,
         tagStats: tagStatsResult.count,
+        rankings: rankingsResult.count,
       },
       message: `Cleared ${watchHistoryResult.count} watch history records and all associated statistics`,
     });

--- a/server/prisma/migrations/20260120000000_add_user_entity_ranking/migration.sql
+++ b/server/prisma/migrations/20260120000000_add_user_entity_ranking/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "UserEntityRanking" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "playCount" INTEGER NOT NULL DEFAULT 0,
+    "playDuration" REAL NOT NULL DEFAULT 0,
+    "oCount" INTEGER NOT NULL DEFAULT 0,
+    "engagementScore" REAL NOT NULL DEFAULT 0,
+    "libraryPresence" INTEGER NOT NULL DEFAULT 1,
+    "engagementRate" REAL NOT NULL DEFAULT 0,
+    "percentileRank" REAL NOT NULL DEFAULT 0,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserEntityRanking_userId_entityType_entityId_key" ON "UserEntityRanking"("userId", "entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "UserEntityRanking_userId_entityType_percentileRank_idx" ON "UserEntityRanking"("userId", "entityType", "percentileRank" DESC);
+
+-- CreateIndex
+CREATE INDEX "UserEntityRanking_userId_entityType_idx" ON "UserEntityRanking"("userId", "entityType");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -365,6 +365,32 @@ model UserTagStats {
   @@index([tagId])
 }
 
+// Pre-computed percentile rankings for user stats "Top" lists
+// Refreshed on login or when engagement changes significantly
+model UserEntityRanking {
+  id         Int    @id @default(autoincrement())
+  userId     Int
+  entityType String // 'performer' | 'studio' | 'tag' | 'scene'
+  entityId   String // Stash entity ID
+
+  // Raw engagement metrics (for display)
+  playCount    Int   @default(0)
+  playDuration Float @default(0) // seconds
+  oCount       Int   @default(0)
+
+  // Computed ranking data
+  engagementScore  Float @default(0) // Raw weighted score: (oCount × 5) + (normalizedDuration) + (playCount)
+  libraryPresence  Int   @default(1) // Number of scenes in library for this entity
+  engagementRate   Float @default(0) // engagementScore / libraryPresence
+  percentileRank   Float @default(0) // 0-100, where 100 = top ranked among user's engaged entities of this type
+
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, entityType, entityId])
+  @@index([userId, entityType, percentileRank(sort: Desc)])
+  @@index([userId, entityType])
+}
+
 enum UserRole {
   ADMIN
   USER

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -7,6 +7,7 @@ import {
   setTokenCookie,
 } from "../middleware/auth.js";
 import prisma from "../prisma/singleton.js";
+import rankingComputeService from "../services/RankingComputeService.js";
 import { authenticated } from "../utils/routeHelpers.js";
 
 const router = express.Router();
@@ -50,6 +51,11 @@ router.post("/login", async (req, res) => {
 
     // Set HTTP-only cookie
     setTokenCookie(res, token);
+
+    // Recompute rankings asynchronously on login (fire-and-forget)
+    rankingComputeService.recomputeAllRankings(user.id).catch((err) => {
+      console.error("Failed to recompute rankings on login:", err);
+    });
 
     res.json({
       success: true,

--- a/server/scripts/compute-rankings.ts
+++ b/server/scripts/compute-rankings.ts
@@ -1,0 +1,51 @@
+// scripts/compute-rankings.ts
+// Manual script to compute rankings for a user
+// Usage: npx tsx scripts/compute-rankings.ts [userId]
+
+import prisma from "../prisma/singleton.js";
+import rankingComputeService from "../services/RankingComputeService.js";
+
+async function main() {
+  const userId = parseInt(process.argv[2]) || 11; // Default to Phoenix (11)
+
+  console.log(`Computing rankings for userId: ${userId}...`);
+
+  const startTime = Date.now();
+  await rankingComputeService.recomputeAllRankings(userId);
+  const duration = Date.now() - startTime;
+
+  // Verify results
+  const counts = await prisma.$queryRaw<Array<{ entityType: string; count: bigint }>>`
+    SELECT entityType, COUNT(*) as count
+    FROM UserEntityRanking
+    WHERE userId = ${userId}
+    GROUP BY entityType
+  `;
+
+  console.log(`\nRankings computed in ${duration}ms:`);
+  for (const row of counts) {
+    console.log(`  ${row.entityType}: ${row.count} entities`);
+  }
+
+  // Show top 5 performers
+  const performers = await prisma.userEntityRanking.findMany({
+    where: { userId, entityType: "performer" },
+    orderBy: { percentileRank: "desc" },
+    take: 5,
+  });
+
+  if (performers.length > 0) {
+    console.log("\nTop 5 Performers:");
+    for (const p of performers) {
+      const perf = await prisma.stashPerformer.findUnique({
+        where: { id: p.entityId },
+        select: { name: true },
+      });
+      console.log(`  - ${perf?.name}: ${p.percentileRank}th percentile (plays: ${p.playCount}, Os: ${p.oCount})`);
+    }
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/server/services/RankingComputeService.ts
+++ b/server/services/RankingComputeService.ts
@@ -1,0 +1,324 @@
+// server/services/RankingComputeService.ts
+/**
+ * Service to compute and store percentile rankings for user engagement stats.
+ * Rankings are pre-computed and stored in UserEntityRanking table for fast retrieval.
+ *
+ * Algorithm:
+ * 1. Fetch all entities of a type that the user has engaged with
+ * 2. Calculate raw engagement score: (oCount × 5) + (normalizedDuration) + (playCount)
+ * 3. Calculate engagement rate: engagementScore / libraryPresence
+ * 4. Compute percentile rank within the user's engaged entities
+ * 5. Store results in UserEntityRanking table
+ */
+
+import prisma from "../prisma/singleton.js";
+import { logger } from "../utils/logger.js";
+
+const RANKING_WEIGHTS = {
+  oCount: 5,
+  duration: 1,
+  playCount: 1,
+};
+
+type EntityType = "performer" | "studio" | "tag" | "scene";
+
+interface RawEntityStats {
+  entityId: string;
+  playCount: number;
+  oCount: number;
+  playDuration: number;
+  libraryPresence: number;
+}
+
+interface ComputedRanking extends RawEntityStats {
+  engagementScore: number;
+  engagementRate: number;
+  percentileRank: number;
+}
+
+class RankingComputeService {
+  /**
+   * Recompute all rankings for a user
+   * Call this on login or after significant engagement changes
+   */
+  async recomputeAllRankings(userId: number): Promise<void> {
+    const startTime = Date.now();
+    logger.info("Starting ranking computation", { userId });
+
+    try {
+      // Get average scene duration for normalization
+      const avgSceneDuration = await this.getAverageSceneDuration();
+
+      // Compute rankings for each entity type in parallel
+      await Promise.all([
+        this.computePerformerRankings(userId, avgSceneDuration),
+        this.computeStudioRankings(userId, avgSceneDuration),
+        this.computeTagRankings(userId, avgSceneDuration),
+        this.computeSceneRankings(userId, avgSceneDuration),
+      ]);
+
+      const duration = Date.now() - startTime;
+      logger.info("Ranking computation complete", { userId, durationMs: duration });
+    } catch (error) {
+      logger.error("Failed to compute rankings", {
+        userId,
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get average scene duration for normalizing watch times
+   */
+  private async getAverageSceneDuration(): Promise<number> {
+    const result = await prisma.$queryRaw<Array<{ avgDuration: number | null }>>`
+      SELECT AVG(duration) as avgDuration FROM StashScene WHERE duration > 0
+    `;
+    return Number(result[0]?.avgDuration) || 1200; // Default 20 min
+  }
+
+  /**
+   * Calculate raw engagement score from metrics
+   */
+  private calculateEngagementScore(
+    oCount: number,
+    normalizedDuration: number,
+    playCount: number
+  ): number {
+    return (
+      oCount * RANKING_WEIGHTS.oCount +
+      normalizedDuration * RANKING_WEIGHTS.duration +
+      playCount * RANKING_WEIGHTS.playCount
+    );
+  }
+
+  /**
+   * Compute percentile ranks for a list of entities
+   * Returns entities sorted by engagement rate with percentile ranks assigned
+   */
+  private computePercentileRanks(entities: RawEntityStats[], avgSceneDuration: number): ComputedRanking[] {
+    if (entities.length === 0) return [];
+
+    // Calculate scores (convert BigInt values from SQL to Number)
+    const scored = entities.map((e) => {
+      const playCount = Number(e.playCount);
+      const oCount = Number(e.oCount);
+      const playDuration = Number(e.playDuration);
+      const libraryPresence = Number(e.libraryPresence);
+
+      const normalizedDuration = playDuration / avgSceneDuration;
+      const engagementScore = this.calculateEngagementScore(oCount, normalizedDuration, playCount);
+      const engagementRate = engagementScore / Math.max(libraryPresence, 1);
+      return {
+        entityId: e.entityId,
+        playCount,
+        oCount,
+        playDuration,
+        libraryPresence,
+        engagementScore,
+        engagementRate,
+        percentileRank: 0, // Will be computed below
+      };
+    });
+
+    // Sort by engagement rate descending
+    scored.sort((a, b) => b.engagementRate - a.engagementRate);
+
+    // Assign percentile ranks (100 = best, 0 = worst)
+    const n = scored.length;
+    for (let i = 0; i < n; i++) {
+      // Formula: percentile = 100 * (n - rank) / n
+      // Where rank is 1-indexed position (1 = best)
+      scored[i].percentileRank = Math.round((100 * (n - i - 1)) / Math.max(n - 1, 1));
+    }
+
+    // Handle ties: entities with same engagement rate get same percentile
+    for (let i = 1; i < n; i++) {
+      if (Math.abs(scored[i].engagementRate - scored[i - 1].engagementRate) < 0.0001) {
+        scored[i].percentileRank = scored[i - 1].percentileRank;
+      }
+    }
+
+    return scored;
+  }
+
+  /**
+   * Upsert rankings into database
+   */
+  private async upsertRankings(
+    userId: number,
+    entityType: EntityType,
+    rankings: ComputedRanking[]
+  ): Promise<void> {
+    if (rankings.length === 0) {
+      // Clear any existing rankings for this entity type
+      await prisma.userEntityRanking.deleteMany({
+        where: { userId, entityType },
+      });
+      return;
+    }
+
+    // Delete existing rankings for this user/type and insert new ones
+    // Using transaction to ensure atomicity
+    await prisma.$transaction(async (tx) => {
+      await tx.userEntityRanking.deleteMany({
+        where: { userId, entityType },
+      });
+
+      await tx.userEntityRanking.createMany({
+        data: rankings.map((r) => ({
+          userId,
+          entityType,
+          entityId: r.entityId,
+          playCount: r.playCount,
+          playDuration: r.playDuration,
+          oCount: r.oCount,
+          engagementScore: r.engagementScore,
+          libraryPresence: r.libraryPresence,
+          engagementRate: r.engagementRate,
+          percentileRank: r.percentileRank,
+        })),
+      });
+    });
+  }
+
+  /**
+   * Compute performer rankings
+   */
+  private async computePerformerRankings(userId: number, avgSceneDuration: number): Promise<void> {
+    const stats = await prisma.$queryRaw<RawEntityStats[]>`
+      SELECT
+        ups.performerId as entityId,
+        ups.playCount,
+        ups.oCounter as oCount,
+        COALESCE(dur.totalDuration, 0) as playDuration,
+        COALESCE(lib.sceneCount, 1) as libraryPresence
+      FROM UserPerformerStats ups
+      LEFT JOIN UserExcludedEntity e
+        ON e.userId = ${userId}
+        AND e.entityType = 'performer'
+        AND e.entityId = ups.performerId
+      LEFT JOIN (
+        SELECT sp.performerId, SUM(w.playDuration) as totalDuration
+        FROM ScenePerformer sp
+        JOIN WatchHistory w ON w.sceneId = sp.sceneId AND w.userId = ${userId}
+        GROUP BY sp.performerId
+      ) dur ON dur.performerId = ups.performerId
+      LEFT JOIN (
+        SELECT performerId, COUNT(*) as sceneCount
+        FROM ScenePerformer
+        GROUP BY performerId
+      ) lib ON lib.performerId = ups.performerId
+      WHERE ups.userId = ${userId}
+        AND e.id IS NULL
+        AND (ups.playCount > 0 OR ups.oCounter > 0)
+    `;
+
+    const rankings = this.computePercentileRanks(stats, avgSceneDuration);
+    await this.upsertRankings(userId, "performer", rankings);
+  }
+
+  /**
+   * Compute studio rankings
+   */
+  private async computeStudioRankings(userId: number, avgSceneDuration: number): Promise<void> {
+    const stats = await prisma.$queryRaw<RawEntityStats[]>`
+      SELECT
+        uss.studioId as entityId,
+        uss.playCount,
+        uss.oCounter as oCount,
+        COALESCE(dur.totalDuration, 0) as playDuration,
+        COALESCE(lib.sceneCount, 1) as libraryPresence
+      FROM UserStudioStats uss
+      LEFT JOIN UserExcludedEntity e
+        ON e.userId = ${userId}
+        AND e.entityType = 'studio'
+        AND e.entityId = uss.studioId
+      LEFT JOIN (
+        SELECT s.studioId, SUM(w.playDuration) as totalDuration
+        FROM StashScene s
+        JOIN WatchHistory w ON w.sceneId = s.id AND w.userId = ${userId}
+        WHERE s.studioId IS NOT NULL
+        GROUP BY s.studioId
+      ) dur ON dur.studioId = uss.studioId
+      LEFT JOIN (
+        SELECT studioId, COUNT(*) as sceneCount
+        FROM StashScene
+        WHERE studioId IS NOT NULL
+        GROUP BY studioId
+      ) lib ON lib.studioId = uss.studioId
+      WHERE uss.userId = ${userId}
+        AND e.id IS NULL
+        AND (uss.playCount > 0 OR uss.oCounter > 0)
+    `;
+
+    const rankings = this.computePercentileRanks(stats, avgSceneDuration);
+    await this.upsertRankings(userId, "studio", rankings);
+  }
+
+  /**
+   * Compute tag rankings
+   */
+  private async computeTagRankings(userId: number, avgSceneDuration: number): Promise<void> {
+    const stats = await prisma.$queryRaw<RawEntityStats[]>`
+      SELECT
+        uts.tagId as entityId,
+        uts.playCount,
+        uts.oCounter as oCount,
+        COALESCE(dur.totalDuration, 0) as playDuration,
+        COALESCE(lib.sceneCount, 1) as libraryPresence
+      FROM UserTagStats uts
+      LEFT JOIN UserExcludedEntity e
+        ON e.userId = ${userId}
+        AND e.entityType = 'tag'
+        AND e.entityId = uts.tagId
+      LEFT JOIN (
+        SELECT st.tagId, SUM(w.playDuration) as totalDuration
+        FROM SceneTag st
+        JOIN WatchHistory w ON w.sceneId = st.sceneId AND w.userId = ${userId}
+        GROUP BY st.tagId
+      ) dur ON dur.tagId = uts.tagId
+      LEFT JOIN (
+        SELECT tagId, COUNT(*) as sceneCount
+        FROM SceneTag
+        GROUP BY tagId
+      ) lib ON lib.tagId = uts.tagId
+      WHERE uts.userId = ${userId}
+        AND e.id IS NULL
+        AND (uts.playCount > 0 OR uts.oCounter > 0)
+    `;
+
+    const rankings = this.computePercentileRanks(stats, avgSceneDuration);
+    await this.upsertRankings(userId, "tag", rankings);
+  }
+
+  /**
+   * Compute scene rankings
+   * Scenes don't have library presence normalization - just raw engagement scores
+   */
+  private async computeSceneRankings(userId: number, avgSceneDuration: number): Promise<void> {
+    const stats = await prisma.$queryRaw<RawEntityStats[]>`
+      SELECT
+        w.sceneId as entityId,
+        w.playCount,
+        w.oCount,
+        w.playDuration,
+        1 as libraryPresence
+      FROM WatchHistory w
+      LEFT JOIN UserExcludedEntity e
+        ON e.userId = ${userId}
+        AND e.entityType = 'scene'
+        AND e.entityId = w.sceneId
+      WHERE w.userId = ${userId}
+        AND e.id IS NULL
+        AND (w.playCount > 0 OR w.oCount > 0 OR w.playDuration > 0)
+    `;
+
+    const rankings = this.computePercentileRanks(stats, avgSceneDuration);
+    await this.upsertRankings(userId, "scene", rankings);
+  }
+}
+
+export const rankingComputeService = new RankingComputeService();
+export default rankingComputeService;

--- a/server/tests/controllers/watchHistory.test.ts
+++ b/server/tests/controllers/watchHistory.test.ts
@@ -36,6 +36,9 @@ vi.mock("../../prisma/singleton.js", () => ({
     userTagStats: {
       deleteMany: vi.fn(),
     },
+    userEntityRanking: {
+      deleteMany: vi.fn(),
+    },
   },
 }));
 
@@ -682,6 +685,7 @@ describe("Watch History Controller", () => {
       mockPrisma.userPerformerStats.deleteMany.mockResolvedValue({ count: 5 } as never);
       mockPrisma.userStudioStats.deleteMany.mockResolvedValue({ count: 3 } as never);
       mockPrisma.userTagStats.deleteMany.mockResolvedValue({ count: 15 } as never);
+      mockPrisma.userEntityRanking.deleteMany.mockResolvedValue({ count: 20 } as never);
 
       await clearAllWatchHistory(mockRequest as AuthenticatedRequest, mockResponse as Response);
 
@@ -697,6 +701,9 @@ describe("Watch History Controller", () => {
       expect(mockPrisma.userTagStats.deleteMany).toHaveBeenCalledWith({
         where: { userId: 1 },
       });
+      expect(mockPrisma.userEntityRanking.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 1 },
+      });
 
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -706,6 +713,7 @@ describe("Watch History Controller", () => {
             performerStats: 5,
             studioStats: 3,
             tagStats: 15,
+            rankings: 20,
           },
         })
       );

--- a/server/types/api/userStats.ts
+++ b/server/types/api/userStats.ts
@@ -42,6 +42,7 @@ export interface EngagementStats {
 
 /**
  * A scene ranked by engagement
+ * Score formula: (oCount × 5) + (normalizedDuration × 1) + (playCount × 1)
  */
 export interface TopScene {
   id: string;
@@ -51,10 +52,12 @@ export interface TopScene {
   playCount: number;
   playDuration: number; // seconds
   oCount: number;
+  score: number; // Computed engagement score
 }
 
 /**
  * A performer ranked by engagement
+ * Score formula: Bayesian-weighted (engagement rate normalized by library presence)
  */
 export interface TopPerformer {
   id: string;
@@ -63,10 +66,12 @@ export interface TopPerformer {
   playCount: number;
   playDuration: number; // seconds
   oCount: number;
+  score: number; // Computed Bayesian engagement score
 }
 
 /**
  * A studio ranked by engagement
+ * Score formula: Bayesian-weighted (engagement rate normalized by library presence)
  */
 export interface TopStudio {
   id: string;
@@ -75,10 +80,12 @@ export interface TopStudio {
   playCount: number;
   playDuration: number; // seconds
   oCount: number;
+  score: number; // Computed Bayesian engagement score
 }
 
 /**
  * A tag ranked by engagement
+ * Score formula: Bayesian-weighted (engagement rate normalized by library presence)
  */
 export interface TopTag {
   id: string;
@@ -87,6 +94,7 @@ export interface TopTag {
   playCount: number;
   playDuration: number; // seconds
   oCount: number;
+  score: number; // Computed Bayesian engagement score
 }
 
 // =============================================================================

--- a/server/types/api/watchHistory.ts
+++ b/server/types/api/watchHistory.ts
@@ -166,6 +166,7 @@ export interface ClearAllWatchHistoryResponse {
     performerStats: number;
     studioStats: number;
     tagStats: number;
+    rankings: number;
   };
   message: string;
 }


### PR DESCRIPTION
## Summary
- Replaces simple play count sorting on My Stats page with percentile-based engagement ranking
- Engagement formula weights O-count (×5), normalized duration, and play count, divided by library presence to normalize against ubiquitous content
- Rankings are pre-computed in `UserEntityRanking` table and refreshed automatically on login
- Integrates implicit engagement signals into Recommendations scoring (top 50% entities by percentile influence recommendations)
- Top lists now show 10 items (up from 5) with scrollable overflow

## Test plan
- [x] Server unit tests pass (641/641)
- [x] TypeScript compilation passes
- [x] Client build succeeds
- [x] Linting passes (warnings only)
- [ ] Manual: Log in and verify My Stats top lists show reordered content based on engagement rate
- [ ] Manual: Verify Recommendations page incorporates implicit engagement preferences