### PR TITLE
fix: studio detail parent name display and remove redundant collections card

### DIFF
--- a/client/src/components/pages/StudioDetail.jsx
+++ b/client/src/components/pages/StudioDetail.jsx
@@ -539,7 +539,7 @@ const StudioDetails = ({ studio, settings }) => {
         </Card>
       )}
 
-      {studio?.parent_studio && (
+      {studio?.parent_studio?.id && (
         <Card title="Parent Studio">
           <Link
             to={`/studio/${studio.parent_studio.id}`}
@@ -548,7 +548,7 @@ const StudioDetails = ({ studio, settings }) => {
               backgroundColor: "var(--accent-primary)",
               color: "white" }}
           >
-            {studio.parent_studio.name}
+            {studio.parent_studio.name || `Studio ${studio.parent_studio.id}`}
           </Link>
         </Card>
       )}
@@ -587,22 +587,6 @@ const StudioDetails = ({ studio, settings }) => {
                 style={{ color: "var(--text-primary)" }}
               >
                 {movie.name}
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {studio?.groups && studio.groups.length > 0 && (
-        <Card title="Collections">
-          <div className="space-y-1">
-            {studio.groups.map((group) => (
-              <div
-                key={group.id}
-                className="text-sm"
-                style={{ color: "var(--text-primary)" }}
-              >
-                {group.name}
               </div>
             ))}
           </div>

--- a/server/controllers/library/studios.ts
+++ b/server/controllers/library/studios.ts
@@ -142,10 +142,20 @@ export const findStudios = async (
       const allStudios = await stashEntityService.getAllStudios();
       const allHydrated = await hydrateStudioRelationships(allStudios);
       hydratedStudios = allHydrated.filter((s) => resultStudios.some((r) => r.id === s.id));
-      // Merge the computed counts back
+      // Merge the computed counts back (preserving hydrated parent_studio and child_studios)
       hydratedStudios = hydratedStudios.map((h) => {
         const result = resultStudios.find((r) => r.id === h.id);
-        return result ? { ...h, ...result } : h;
+        if (!result) return h;
+        return {
+          ...result,
+          ...h,
+          // Override counts from result (which has freshly computed values)
+          scene_count: result.scene_count,
+          image_count: result.image_count,
+          gallery_count: result.gallery_count,
+          performer_count: result.performer_count,
+          group_count: result.group_count,
+        };
       });
     } else {
       hydratedStudios = await hydrateStudioRelationships(resultStudios);


### PR DESCRIPTION
## Summary
- Fix parent studio name not displaying on StudioDetail page (showed empty badge instead of parent studio name)
- Remove redundant "Collections" text-only list from StudioDetail since there's already a Collections tab with proper GroupGrid

## Root cause
The parent studio name hydration was working correctly, but the merge logic for single-studio requests was overwriting the hydrated `parent_studio` with the un-hydrated version from StudioQueryBuilder (which had `name: ""`). Fixed by changing merge order to preserve hydrated values.

## Test plan
- [x] Server tests pass (641 tests)
- [x] Client tests pass (1004 tests)
- [x] Lint and TypeScript checks pass
- [ ] Manual: Visit a studio detail page with a parent studio and verify the parent name displays correctly
- [ ] Manual: Verify the "Collections" text card no longer appears (Collections tab still works)