### PR TITLE
Fix clips P2029 parameter limit error

### DIFF
--- a/server/controllers/proxy.ts
+++ b/server/controllers/proxy.ts
@@ -70,7 +70,8 @@ function getAgentForUrl(urlObj: URL): http.Agent | https.Agent {
  * @returns Object with baseUrl and apiKey
  */
 function getInstanceCredentials(instanceId?: string): { baseUrl: string; apiKey: string } {
-  if (instanceId) {
+  // Treat "default" the same as undefined - use the default instance
+  if (instanceId && instanceId !== "default") {
     const instance = stashInstanceManager.get(instanceId);
     if (!instance) {
       throw new Error(`Stash instance not found: ${instanceId}`);

--- a/server/services/ClipQueryBuilder.ts
+++ b/server/services/ClipQueryBuilder.ts
@@ -1,0 +1,518 @@
+/**
+ * ClipQueryBuilder - SQL-native clip querying
+ *
+ * Builds parameterized SQL queries for clip filtering, sorting, and pagination.
+ * Uses JOIN-based exclusions to avoid SQLite parameter limits (P2029 error).
+ */
+import prisma from "../prisma/singleton.js";
+import { logger } from "../utils/logger.js";
+
+// Filter clause builder result
+interface FilterClause {
+  sql: string;
+  params: (string | number | boolean)[];
+}
+
+// Query builder options
+export interface ClipQueryOptions {
+  userId: number;
+  page?: number;
+  perPage?: number;
+  sortBy?: string;
+  sortDir?: "asc" | "desc";
+  isGenerated?: boolean;
+  sceneId?: string;
+  tagIds?: string[];
+  sceneTagIds?: string[];
+  performerIds?: string[];
+  studioId?: string;
+  q?: string;
+  allowedInstanceIds?: string[];
+}
+
+// Clip with relations (matches ClipService interface)
+export interface ClipWithRelations {
+  id: string;
+  sceneId: string;
+  title: string | null;
+  seconds: number;
+  endSeconds: number | null;
+  primaryTagId: string | null;
+  isGenerated: boolean;
+  stashCreatedAt: Date | null;
+  stashUpdatedAt: Date | null;
+  primaryTag: { id: string; name: string; color: string | null } | null;
+  tags: Array<{ id: string; name: string; color: string | null }>;
+  scene: {
+    id: string;
+    title: string | null;
+    pathScreenshot: string | null;
+    studioId: string | null;
+    stashInstanceId: string | null;
+  };
+}
+
+// Raw query result row
+interface ClipRow {
+  id: string;
+  stashInstanceId: string;
+  sceneId: string;
+  sceneInstanceId: string;
+  title: string | null;
+  seconds: number;
+  endSeconds: number | null;
+  primaryTagId: string | null;
+  primaryTagInstanceId: string | null;
+  isGenerated: number; // SQLite returns 0/1
+  stashCreatedAt: string | null;
+  stashUpdatedAt: string | null;
+  // Scene fields
+  sceneTitle: string | null;
+  scenePathScreenshot: string | null;
+  sceneStudioId: string | null;
+  // Primary tag fields
+  primaryTagName: string | null;
+  primaryTagColor: string | null;
+}
+
+/**
+ * Builds and executes SQL queries for clip filtering
+ */
+class ClipQueryBuilder {
+  private readonly SELECT_COLUMNS = `
+    c.id, c.stashInstanceId, c.sceneId, c.sceneInstanceId,
+    c.title, c.seconds, c.endSeconds,
+    c.primaryTagId, c.primaryTagInstanceId,
+    c.isGenerated, c.stashCreatedAt, c.stashUpdatedAt,
+    s.title AS sceneTitle, s.pathScreenshot AS scenePathScreenshot,
+    s.studioId AS sceneStudioId,
+    pt.name AS primaryTagName, pt.color AS primaryTagColor
+  `.trim();
+
+  /**
+   * Build FROM clause with exclusion JOIN
+   */
+  private buildFromClause(userId: number): { sql: string; params: number[] } {
+    return {
+      sql: `
+        FROM StashClip c
+        INNER JOIN StashScene s ON c.sceneId = s.id AND c.sceneInstanceId = s.stashInstanceId
+        LEFT JOIN StashTag pt ON c.primaryTagId = pt.id AND c.primaryTagInstanceId = pt.stashInstanceId
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'scene' AND e.entityId = c.sceneId
+      `.trim(),
+      params: [userId],
+    };
+  }
+
+  /**
+   * Build base WHERE clause (always filter deleted and excluded)
+   */
+  private buildBaseWhere(): FilterClause {
+    return {
+      sql: "c.deletedAt IS NULL AND s.deletedAt IS NULL AND e.id IS NULL",
+      params: [],
+    };
+  }
+
+  /**
+   * Build instance filter clause
+   */
+  private buildInstanceFilter(allowedInstanceIds: string[] | undefined): FilterClause {
+    if (!allowedInstanceIds || allowedInstanceIds.length === 0) {
+      return { sql: "", params: [] };
+    }
+
+    const placeholders = allowedInstanceIds.map(() => "?").join(", ");
+    return {
+      sql: `(c.stashInstanceId IN (${placeholders}) OR c.stashInstanceId IS NULL)`,
+      params: allowedInstanceIds,
+    };
+  }
+
+  /**
+   * Build isGenerated filter
+   */
+  private buildGeneratedFilter(isGenerated: boolean | undefined): FilterClause {
+    if (isGenerated === undefined) {
+      return { sql: "", params: [] };
+    }
+    return {
+      sql: "c.isGenerated = ?",
+      params: [isGenerated ? 1 : 0],
+    };
+  }
+
+  /**
+   * Build scene ID filter
+   */
+  private buildSceneIdFilter(sceneId: string | undefined): FilterClause {
+    if (!sceneId) {
+      return { sql: "", params: [] };
+    }
+    return {
+      sql: "c.sceneId = ?",
+      params: [sceneId],
+    };
+  }
+
+  /**
+   * Build text search filter
+   */
+  private buildSearchFilter(q: string | undefined): FilterClause {
+    if (!q) {
+      return { sql: "", params: [] };
+    }
+    return {
+      sql: "c.title LIKE ?",
+      params: [`%${q}%`],
+    };
+  }
+
+  /**
+   * Build clip tag filter (matches clips with ANY of these tags on the clip itself)
+   */
+  private buildTagFilter(tagIds: string[] | undefined): FilterClause {
+    if (!tagIds || tagIds.length === 0) {
+      return { sql: "", params: [] };
+    }
+
+    const placeholders = tagIds.map(() => "?").join(", ");
+    return {
+      sql: `(c.primaryTagId IN (${placeholders}) OR EXISTS (
+        SELECT 1 FROM ClipTag ct WHERE ct.clipId = c.id AND ct.clipInstanceId = c.stashInstanceId AND ct.tagId IN (${placeholders})
+      ))`,
+      params: [...tagIds, ...tagIds],
+    };
+  }
+
+  /**
+   * Build scene tag filter (matches clips from scenes with ANY of these tags)
+   */
+  private buildSceneTagFilter(sceneTagIds: string[] | undefined): FilterClause {
+    if (!sceneTagIds || sceneTagIds.length === 0) {
+      return { sql: "", params: [] };
+    }
+
+    const placeholders = sceneTagIds.map(() => "?").join(", ");
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM SceneTag st
+        WHERE st.sceneId = c.sceneId AND st.sceneInstanceId = c.sceneInstanceId
+        AND st.tagId IN (${placeholders})
+      )`,
+      params: sceneTagIds,
+    };
+  }
+
+  /**
+   * Build performer filter (matches clips from scenes with ANY of these performers)
+   */
+  private buildPerformerFilter(performerIds: string[] | undefined): FilterClause {
+    if (!performerIds || performerIds.length === 0) {
+      return { sql: "", params: [] };
+    }
+
+    const placeholders = performerIds.map(() => "?").join(", ");
+    return {
+      sql: `EXISTS (
+        SELECT 1 FROM ScenePerformer sp
+        WHERE sp.sceneId = c.sceneId AND sp.sceneInstanceId = c.sceneInstanceId
+        AND sp.performerId IN (${placeholders})
+      )`,
+      params: performerIds,
+    };
+  }
+
+  /**
+   * Build studio filter
+   */
+  private buildStudioFilter(studioId: string | undefined): FilterClause {
+    if (!studioId) {
+      return { sql: "", params: [] };
+    }
+    return {
+      sql: "s.studioId = ?",
+      params: [studioId],
+    };
+  }
+
+  /**
+   * Build ORDER BY clause
+   */
+  private buildOrderBy(sortBy: string, sortDir: "asc" | "desc"): string {
+    const validColumns: Record<string, string> = {
+      stashCreatedAt: "c.stashCreatedAt",
+      stashUpdatedAt: "c.stashUpdatedAt",
+      title: "c.title",
+      seconds: "c.seconds",
+      sceneTitle: "s.title",
+    };
+
+    const column = validColumns[sortBy] || "c.stashCreatedAt";
+    const direction = sortDir.toUpperCase();
+
+    return `ORDER BY ${column} ${direction}`;
+  }
+
+  /**
+   * Combine filter clauses
+   */
+  private combineFilters(filters: FilterClause[]): FilterClause {
+    const validFilters = filters.filter((f) => f.sql.length > 0);
+    if (validFilters.length === 0) {
+      return { sql: "", params: [] };
+    }
+
+    return {
+      sql: validFilters.map((f) => `(${f.sql})`).join(" AND "),
+      params: validFilters.flatMap((f) => f.params),
+    };
+  }
+
+  /**
+   * Fetch tags for clips
+   */
+  private async fetchClipTags(clipIds: Array<{ id: string; instanceId: string }>): Promise<Map<string, Array<{ id: string; name: string; color: string | null }>>> {
+    if (clipIds.length === 0) {
+      return new Map();
+    }
+
+    // Build query to get all tags for these clips
+    const conditions = clipIds.map(() => "(ct.clipId = ? AND ct.clipInstanceId = ?)").join(" OR ");
+    const params = clipIds.flatMap((c) => [c.id, c.instanceId]);
+
+    const tags = await prisma.$queryRawUnsafe<Array<{
+      clipId: string;
+      clipInstanceId: string;
+      tagId: string;
+      tagName: string;
+      tagColor: string | null;
+    }>>(
+      `SELECT ct.clipId, ct.clipInstanceId, t.id AS tagId, t.name AS tagName, t.color AS tagColor
+       FROM ClipTag ct
+       INNER JOIN StashTag t ON ct.tagId = t.id AND ct.tagInstanceId = t.stashInstanceId
+       WHERE ${conditions}`,
+      ...params
+    );
+
+    const tagMap = new Map<string, Array<{ id: string; name: string; color: string | null }>>();
+    for (const tag of tags) {
+      const key = `${tag.clipId}:${tag.clipInstanceId}`;
+      if (!tagMap.has(key)) {
+        tagMap.set(key, []);
+      }
+      tagMap.get(key)!.push({
+        id: tag.tagId,
+        name: tag.tagName,
+        color: tag.tagColor,
+      });
+    }
+
+    return tagMap;
+  }
+
+  /**
+   * Transform raw rows to ClipWithRelations
+   */
+  private transformRows(
+    rows: ClipRow[],
+    tagMap: Map<string, Array<{ id: string; name: string; color: string | null }>>
+  ): ClipWithRelations[] {
+    return rows.map((row) => {
+      const key = `${row.id}:${row.stashInstanceId}`;
+      return {
+        id: row.id,
+        sceneId: row.sceneId,
+        title: row.title,
+        seconds: row.seconds,
+        endSeconds: row.endSeconds,
+        primaryTagId: row.primaryTagId,
+        // SQLite via Prisma raw queries may return number or string for boolean columns
+        isGenerated: Number(row.isGenerated) === 1,
+        stashCreatedAt: row.stashCreatedAt ? new Date(row.stashCreatedAt) : null,
+        stashUpdatedAt: row.stashUpdatedAt ? new Date(row.stashUpdatedAt) : null,
+        primaryTag: row.primaryTagId
+          ? { id: row.primaryTagId, name: row.primaryTagName || "", color: row.primaryTagColor }
+          : null,
+        tags: tagMap.get(key) || [],
+        scene: {
+          id: row.sceneId,
+          title: row.sceneTitle,
+          pathScreenshot: row.scenePathScreenshot,
+          studioId: row.sceneStudioId,
+          stashInstanceId: row.sceneInstanceId,
+        },
+      };
+    });
+  }
+
+  /**
+   * Execute query and return clips with pagination
+   */
+  async getClips(options: ClipQueryOptions): Promise<{ clips: ClipWithRelations[]; total: number }> {
+    const {
+      userId,
+      page = 1,
+      perPage = 24,
+      sortBy = "stashCreatedAt",
+      sortDir = "desc",
+      isGenerated,
+      sceneId,
+      tagIds,
+      sceneTagIds,
+      performerIds,
+      studioId,
+      q,
+      allowedInstanceIds,
+    } = options;
+
+    // Build query components
+    const fromClause = this.buildFromClause(userId);
+    const baseWhere = this.buildBaseWhere();
+
+    const filters = this.combineFilters([
+      baseWhere,
+      this.buildInstanceFilter(allowedInstanceIds),
+      this.buildGeneratedFilter(isGenerated),
+      this.buildSceneIdFilter(sceneId),
+      this.buildSearchFilter(q),
+      this.buildTagFilter(tagIds),
+      this.buildSceneTagFilter(sceneTagIds),
+      this.buildPerformerFilter(performerIds),
+      this.buildStudioFilter(studioId),
+    ]);
+
+    const whereClause = filters.sql ? `WHERE ${filters.sql}` : "";
+    const orderBy = this.buildOrderBy(sortBy, sortDir);
+    const offset = (page - 1) * perPage;
+
+    // Build full queries
+    const dataQuery = `
+      SELECT ${this.SELECT_COLUMNS}
+      ${fromClause.sql}
+      ${whereClause}
+      ${orderBy}
+      LIMIT ? OFFSET ?
+    `;
+
+    const countQuery = `
+      SELECT COUNT(*) as total
+      ${fromClause.sql}
+      ${whereClause}
+    `;
+
+    const queryParams = [...fromClause.params, ...filters.params];
+
+    try {
+      // Execute queries in parallel
+      const [rows, countResult] = await Promise.all([
+        prisma.$queryRawUnsafe<ClipRow[]>(dataQuery, ...queryParams, perPage, offset),
+        prisma.$queryRawUnsafe<[{ total: bigint }]>(countQuery, ...queryParams),
+      ]);
+
+      // Fetch tags for all clips
+      const clipIds = rows.map((r) => ({ id: r.id, instanceId: r.stashInstanceId }));
+      const tagMap = await this.fetchClipTags(clipIds);
+
+      return {
+        clips: this.transformRows(rows, tagMap),
+        total: Number(countResult[0]?.total || 0),
+      };
+    } catch (error) {
+      logger.error("ClipQueryBuilder.getClips failed", { error, options });
+      throw error;
+    }
+  }
+
+  /**
+   * Get clips for a specific scene (simpler query, no pagination)
+   */
+  async getClipsForScene(
+    sceneId: string,
+    userId: number,
+    includeUngenerated = false,
+    allowedInstanceIds?: string[]
+  ): Promise<ClipWithRelations[]> {
+    const fromClause = this.buildFromClause(userId);
+    const baseWhere = this.buildBaseWhere();
+
+    const filters = this.combineFilters([
+      baseWhere,
+      this.buildInstanceFilter(allowedInstanceIds),
+      { sql: "c.sceneId = ?", params: [sceneId] },
+      includeUngenerated ? { sql: "", params: [] } : this.buildGeneratedFilter(true),
+    ]);
+
+    const whereClause = filters.sql ? `WHERE ${filters.sql}` : "";
+
+    const query = `
+      SELECT ${this.SELECT_COLUMNS}
+      ${fromClause.sql}
+      ${whereClause}
+      ORDER BY c.seconds ASC
+    `;
+
+    const queryParams = [...fromClause.params, ...filters.params];
+
+    try {
+      const rows = await prisma.$queryRawUnsafe<ClipRow[]>(query, ...queryParams);
+
+      // Fetch tags for all clips
+      const clipIds = rows.map((r) => ({ id: r.id, instanceId: r.stashInstanceId }));
+      const tagMap = await this.fetchClipTags(clipIds);
+
+      return this.transformRows(rows, tagMap);
+    } catch (error) {
+      logger.error("ClipQueryBuilder.getClipsForScene failed", { error, sceneId, userId });
+      throw error;
+    }
+  }
+
+  /**
+   * Get a single clip by ID
+   */
+  async getClipById(
+    clipId: string,
+    userId: number,
+    allowedInstanceIds?: string[]
+  ): Promise<ClipWithRelations | null> {
+    const fromClause = this.buildFromClause(userId);
+    const baseWhere = this.buildBaseWhere();
+
+    const filters = this.combineFilters([
+      baseWhere,
+      this.buildInstanceFilter(allowedInstanceIds),
+      { sql: "c.id = ?", params: [clipId] },
+    ]);
+
+    const whereClause = filters.sql ? `WHERE ${filters.sql}` : "";
+
+    const query = `
+      SELECT ${this.SELECT_COLUMNS}
+      ${fromClause.sql}
+      ${whereClause}
+      LIMIT 1
+    `;
+
+    const queryParams = [...fromClause.params, ...filters.params];
+
+    try {
+      const rows = await prisma.$queryRawUnsafe<ClipRow[]>(query, ...queryParams);
+
+      if (rows.length === 0) {
+        return null;
+      }
+
+      // Fetch tags for this clip
+      const clipIds = [{ id: rows[0].id, instanceId: rows[0].stashInstanceId }];
+      const tagMap = await this.fetchClipTags(clipIds);
+
+      return this.transformRows(rows, tagMap)[0];
+    } catch (error) {
+      logger.error("ClipQueryBuilder.getClipById failed", { error, clipId, userId });
+      throw error;
+    }
+  }
+}
+
+export const clipQueryBuilder = new ClipQueryBuilder();

--- a/server/services/ClipService.ts
+++ b/server/services/ClipService.ts
@@ -1,5 +1,4 @@
-import prisma from "../prisma/singleton.js";
-import { Prisma } from "@prisma/client";
+import { clipQueryBuilder, ClipQueryOptions as QueryBuilderOptions, ClipWithRelations as RawClipWithRelations } from "./ClipQueryBuilder.js";
 
 export interface ClipQueryOptions {
   page?: number;
@@ -72,8 +71,8 @@ export class ClipService {
       proxyPath = `/api/proxy/stash?path=${encodeURIComponent(urlOrPath)}`;
     }
 
-    // Add instanceId for multi-instance routing
-    if (instanceId) {
+    // Add instanceId for multi-instance routing (skip "default" - proxy handles that automatically)
+    if (instanceId && instanceId !== "default") {
       proxyPath += `&instanceId=${encodeURIComponent(instanceId)}`;
     }
 
@@ -81,48 +80,17 @@ export class ClipService {
   }
 
   /**
-   * Transform clip scene data to use proxy URLs
+   * Transform clip from query builder to client-safe format with proxy URLs
    */
-  private transformClipScene(scene: { id: string; title: string | null; pathScreenshot: string | null; studioId: string | null; stashInstanceId?: string | null }) {
+  private transformClip(clip: RawClipWithRelations): ClipWithRelations {
     return {
-      ...scene,
-      pathScreenshot: this.transformUrl(scene.pathScreenshot, scene.stashInstanceId),
-    };
-  }
-
-  /**
-   * Transform a clip database record to the client-safe format.
-   * Strips raw Stash URLs and only includes fields the client needs.
-   */
-  private transformClip(
-    clip: {
-      id: string;
-      sceneId: string;
-      title: string | null;
-      seconds: number;
-      endSeconds: number | null;
-      primaryTagId: string | null;
-      isGenerated: boolean;
-      stashCreatedAt: Date | null;
-      stashUpdatedAt: Date | null;
-      primaryTag: { id: string; name: string; color: string | null } | null;
-      tags: Array<{ tag: { id: string; name: string; color: string | null } }>;
-      scene: { id: string; title: string | null; pathScreenshot: string | null; studioId: string | null };
-    }
-  ): ClipWithRelations {
-    return {
-      id: clip.id,
-      sceneId: clip.sceneId,
-      title: clip.title,
-      seconds: clip.seconds,
-      endSeconds: clip.endSeconds,
-      primaryTagId: clip.primaryTagId,
-      isGenerated: clip.isGenerated,
-      stashCreatedAt: clip.stashCreatedAt,
-      stashUpdatedAt: clip.stashUpdatedAt,
-      primaryTag: clip.primaryTag,
-      tags: clip.tags.map((ct) => ct.tag),
-      scene: this.transformClipScene(clip.scene),
+      ...clip,
+      scene: {
+        id: clip.scene.id,
+        title: clip.scene.title,
+        pathScreenshot: this.transformUrl(clip.scene.pathScreenshot, clip.scene.stashInstanceId),
+        studioId: clip.scene.studioId,
+      },
     };
   }
 
@@ -134,143 +102,28 @@ export class ClipService {
     userId: number,
     includeUngenerated = false
   ): Promise<ClipWithRelations[]> {
-    const whereClause: Prisma.StashClipWhereInput = {
-      sceneId,
-      deletedAt: null,
-    };
-
-    if (!includeUngenerated) {
-      whereClause.isGenerated = true;
-    }
-
-    // Check if scene is excluded for this user
-    const isExcluded = await prisma.userExcludedEntity.findFirst({
-      where: { userId, entityType: "scene", entityId: sceneId },
-    });
-
-    if (isExcluded) {
-      return [];
-    }
-
-    const clips = await prisma.stashClip.findMany({
-      where: whereClause,
-      include: {
-        primaryTag: { select: { id: true, name: true, color: true } },
-        tags: {
-          include: {
-            tag: { select: { id: true, name: true, color: true } },
-          },
-        },
-        scene: {
-          select: { id: true, title: true, pathScreenshot: true, studioId: true },
-        },
-      },
-      orderBy: { seconds: "asc" },
-    });
-
+    const clips = await clipQueryBuilder.getClipsForScene(sceneId, userId, includeUngenerated);
     return clips.map((clip) => this.transformClip(clip));
   }
 
   /**
    * Get clips with filtering and pagination
+   * Uses SQL-native query builder with JOIN-based exclusions to avoid P2029 parameter limit errors
    */
   async getClips(
     userId: number,
     options: ClipQueryOptions = {}
   ): Promise<{ clips: ClipWithRelations[]; total: number }> {
-    const {
-      page = 1,
-      perPage = 24,
-      sortBy = "stashCreatedAt",
-      sortDir = "desc",
-      isGenerated,
-      sceneId,
-      tagIds,
-      sceneTagIds,
-      performerIds,
-      studioId,
-      q,
-    } = options;
-
-    const whereClause: Prisma.StashClipWhereInput = {
-      deletedAt: null,
+    const queryOptions: QueryBuilderOptions = {
+      userId,
+      ...options,
     };
 
-    if (isGenerated !== undefined) {
-      whereClause.isGenerated = isGenerated;
-    }
-
-    if (sceneId) {
-      whereClause.sceneId = sceneId;
-    }
-
-    if (q) {
-      whereClause.title = { contains: q };
-    }
-
-    if (tagIds && tagIds.length > 0) {
-      whereClause.OR = [
-        { primaryTagId: { in: tagIds } },
-        { tags: { some: { tagId: { in: tagIds } } } },
-      ];
-    }
-
-    // Scene-level filters
-    const sceneFilters: Prisma.StashSceneWhereInput = {};
-
-    if (sceneTagIds && sceneTagIds.length > 0) {
-      sceneFilters.tags = { some: { tagId: { in: sceneTagIds } } };
-    }
-
-    if (performerIds && performerIds.length > 0) {
-      sceneFilters.performers = { some: { performerId: { in: performerIds } } };
-    }
-
-    if (studioId) {
-      sceneFilters.studioId = studioId;
-    }
-
-    if (Object.keys(sceneFilters).length > 0) {
-      whereClause.scene = sceneFilters;
-    }
-
-    // Exclude clips from excluded scenes
-    const excludedSceneIds = await prisma.userExcludedEntity.findMany({
-      where: { userId, entityType: "scene" },
-      select: { entityId: true },
-    });
-
-    if (excludedSceneIds.length > 0) {
-      whereClause.sceneId = {
-        ...((typeof whereClause.sceneId === 'object' ? whereClause.sceneId : {}) as object),
-        notIn: excludedSceneIds.map((e) => e.entityId),
-      };
-    }
-
-    const [clips, total] = await Promise.all([
-      prisma.stashClip.findMany({
-        where: whereClause,
-        include: {
-          primaryTag: { select: { id: true, name: true, color: true } },
-          tags: {
-            include: {
-              tag: { select: { id: true, name: true, color: true } },
-            },
-          },
-          scene: {
-            select: { id: true, title: true, pathScreenshot: true, studioId: true },
-          },
-        },
-        orderBy: { [sortBy]: sortDir },
-        skip: (page - 1) * perPage,
-        take: perPage,
-      }),
-      prisma.stashClip.count({ where: whereClause }),
-    ]);
+    const result = await clipQueryBuilder.getClips(queryOptions);
 
     return {
-      clips: clips.map((clip) => this.transformClip(clip)),
-      total,
+      clips: result.clips.map((clip) => this.transformClip(clip)),
+      total: result.total,
     };
   }
 
@@ -278,30 +131,8 @@ export class ClipService {
    * Get a single clip by ID
    */
   async getClipById(clipId: string, userId: number): Promise<ClipWithRelations | null> {
-    const clip = await prisma.stashClip.findFirst({
-      where: { id: clipId, deletedAt: null },
-      include: {
-        primaryTag: { select: { id: true, name: true, color: true } },
-        tags: {
-          include: {
-            tag: { select: { id: true, name: true, color: true } },
-          },
-        },
-        scene: {
-          select: { id: true, title: true, pathScreenshot: true, studioId: true },
-        },
-      },
-    });
-
+    const clip = await clipQueryBuilder.getClipById(clipId, userId);
     if (!clip) return null;
-
-    // Check if scene is excluded
-    const isExcluded = await prisma.userExcludedEntity.findFirst({
-      where: { userId, entityType: "scene", entityId: clip.sceneId },
-    });
-
-    if (isExcluded) return null;
-
     return this.transformClip(clip);
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Prisma P2029 error when loading clips for users with many excluded scenes
- Replaces `notIn` clause with JOIN-based exclusion pattern (matches SceneQueryBuilder approach)
- Handles "default" instanceId correctly for pre-multi-instance data

## Technical Details
- New `ClipQueryBuilder` uses raw SQL with `LEFT JOIN UserExcludedEntity` to filter exclusions
- Avoids SQLite's ~999 parameter limit that caused the P2029 error
- Fixed boolean conversion for SQLite raw query results

## Test plan
- [x] Server unit tests pass (751/751)
- [x] Server lint passes (0 errors)
- [x] Server type check passes
- [x] Manual testing: clips page loads correctly, previews display