### PR TITLE
Fix multi-instance scene relations and enable search via SQL query builder

### DIFF
--- a/server/controllers/library/scenes.ts
+++ b/server/controllers/library/scenes.ts
@@ -936,9 +936,9 @@ export const findScenes = async (
     const mergedFilter: PeekSceneFilter = { ...scene_filter, ids: normalizedIds };
     const _requestingUser = req.user;
 
-    // NEW: Use SQL query builder if enabled
-    if (USE_SQL_QUERY_BUILDER && !searchQuery) {
-      logger.info("findScenes: using SQL query builder path");
+    // NEW: Use SQL query builder if enabled (now supports text search too)
+    if (USE_SQL_QUERY_BUILDER) {
+      logger.info("findScenes: using SQL query builder path", { hasSearchQuery: !!searchQuery });
 
       // Get user's allowed instance IDs for multi-instance filtering
       const allowedInstanceIds = await getUserAllowedInstanceIds(userId);
@@ -959,6 +959,7 @@ export const findScenes = async (
         page,
         perPage,
         randomSeed: sortField === 'random' ? randomSeed : userId,
+        searchQuery: searchQuery || undefined,
       });
 
       // Add streamability info


### PR DESCRIPTION
## Summary
- Fix performer, tag, studio, group, and gallery indicators not showing on scene cards when using multi-instance Stash setup
- Scene search now uses the SQL query builder path, fixing missing performer indicators on search results
- Text search now correctly searches across title, details, file path, performer names, studio name, and tag names

## Test plan
- [x] Server unit tests pass (751 tests)
- [x] Client unit tests pass (1064 tests) 
- [x] TypeScript compiles without errors
- [x] Client build succeeds
- [ ] Manual: Search for a scene by title - performers should show on card
- [ ] Manual: Search for a scene by performer name - scene should appear in results