### PR TITLE
fix: Remove default instance fallbacks for multi-stash support

### DIFF
--- a/server/controllers/playlist.ts
+++ b/server/controllers/playlist.ts
@@ -719,7 +719,7 @@ export const reorderPlaylist = async (
           where: {
             playlistId_instanceId_sceneId: {
               playlistId,
-              instanceId: instanceIdMap.get(item.sceneId) || 'default',
+              instanceId: instanceIdMap.get(item.sceneId)!,
               sceneId: item.sceneId,
             },
           },

--- a/server/controllers/video.ts
+++ b/server/controllers/video.ts
@@ -262,7 +262,7 @@ export const getCaption = async (req: Request, res: Response) => {
       return res.status(400).send("Missing lang or type parameter");
     }
 
-    logger.info(`[CAPTION] Request: scene=${sceneId}, lang=${lang}, type=${type}, instanceId=${instanceId || 'default'}`);
+    logger.info(`[CAPTION] Request: scene=${sceneId}, lang=${lang}, type=${type}, instanceId=${instanceId || '(not specified)'}`);
 
     // Get Stash instance configuration
     let stashUrl: string;

--- a/server/controllers/watchHistory.ts
+++ b/server/controllers/watchHistory.ts
@@ -73,7 +73,7 @@ export async function pingWatchHistory(
 
     // Get scene duration from cache
     let sceneDuration = 0;
-    let instanceId = 'default';
+    let instanceId: string;
     try {
       // Use findFirst since composite primary key [id, stashInstanceId] requires both fields for findUnique
       const scene = await prisma.stashScene.findFirst({
@@ -81,13 +81,16 @@ export async function pingWatchHistory(
         select: { duration: true, stashInstanceId: true },
       });
       sceneDuration = scene?.duration || 0;
-      instanceId = scene?.stashInstanceId || 'default';
+      // Get instanceId from scene, or fall back to looking it up
+      instanceId = scene?.stashInstanceId || await getEntityInstanceId('scene', sceneId);
     } catch (error) {
       logger.error("Failed to fetch scene duration from cache", {
         sceneId,
         error,
       });
       // Continue without duration - won't be able to calculate percentages
+      // Still need to get instanceId for watch history
+      instanceId = await getEntityInstanceId('scene', sceneId);
     }
 
     // Get or create watch history record

--- a/server/prisma/migrations/20260127000000_remove_default_instance_fallbacks/migration.sql
+++ b/server/prisma/migrations/20260127000000_remove_default_instance_fallbacks/migration.sql
@@ -1,0 +1,385 @@
+-- Migration: Remove 'default' Instance ID Fallbacks
+--
+-- This migration fixes any entities that have stashInstanceId = 'default' or NULL by
+-- updating them to use the actual StashInstance UUID. This is a data repair for the
+-- legacy fallback pattern that has been removed from the codebase.
+--
+-- Handles two cases:
+-- 1. stashInstanceId = 'default' (from legacy fallback code)
+-- 2. stashInstanceId IS NULL (from pre-multi-instance data)
+--
+-- After this migration:
+-- - All entities will have valid UUID stashInstanceId values
+-- - The schema defaults are removed (handled by Prisma schema change)
+-- - A full sync runs on startup to ensure all data is correct
+
+-- ============================================================================
+-- STEP 1: Update entity tables - replace 'default' with actual StashInstance ID
+-- ============================================================================
+
+-- Use the primary instance (lowest priority) as the target for 'default' values
+-- This handles upgrading users who had entities created before multi-instance support
+
+UPDATE "StashScene"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashPerformer"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashStudio"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashTag"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashGroup"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashGallery"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashImage"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashClip"
+SET "stashInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("stashInstanceId" = 'default' OR "stashInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 2: Update StashClip foreign key fields
+-- ============================================================================
+
+UPDATE "StashClip"
+SET "sceneInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("sceneInstanceId" = 'default' OR "sceneInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StashClip"
+SET "primaryTagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("primaryTagInstanceId" = 'default' OR "primaryTagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 3: Update junction tables - ScenePerformer
+-- ============================================================================
+
+UPDATE "ScenePerformer"
+SET "sceneInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("sceneInstanceId" = 'default' OR "sceneInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "ScenePerformer"
+SET "performerInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("performerInstanceId" = 'default' OR "performerInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 4: Update junction tables - SceneTag
+-- ============================================================================
+
+UPDATE "SceneTag"
+SET "sceneInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("sceneInstanceId" = 'default' OR "sceneInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "SceneTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 5: Update junction tables - SceneGroup
+-- ============================================================================
+
+UPDATE "SceneGroup"
+SET "sceneInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("sceneInstanceId" = 'default' OR "sceneInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "SceneGroup"
+SET "groupInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("groupInstanceId" = 'default' OR "groupInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 6: Update junction tables - SceneGallery
+-- ============================================================================
+
+UPDATE "SceneGallery"
+SET "sceneInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("sceneInstanceId" = 'default' OR "sceneInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "SceneGallery"
+SET "galleryInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("galleryInstanceId" = 'default' OR "galleryInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 7: Update junction tables - ImagePerformer
+-- ============================================================================
+
+UPDATE "ImagePerformer"
+SET "imageInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("imageInstanceId" = 'default' OR "imageInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "ImagePerformer"
+SET "performerInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("performerInstanceId" = 'default' OR "performerInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 8: Update junction tables - ImageTag
+-- ============================================================================
+
+UPDATE "ImageTag"
+SET "imageInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("imageInstanceId" = 'default' OR "imageInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "ImageTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 9: Update junction tables - ImageGallery
+-- ============================================================================
+
+UPDATE "ImageGallery"
+SET "imageInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("imageInstanceId" = 'default' OR "imageInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "ImageGallery"
+SET "galleryInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("galleryInstanceId" = 'default' OR "galleryInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 10: Update junction tables - GalleryPerformer
+-- ============================================================================
+
+UPDATE "GalleryPerformer"
+SET "galleryInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("galleryInstanceId" = 'default' OR "galleryInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "GalleryPerformer"
+SET "performerInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("performerInstanceId" = 'default' OR "performerInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 11: Update junction tables - GalleryTag
+-- ============================================================================
+
+UPDATE "GalleryTag"
+SET "galleryInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("galleryInstanceId" = 'default' OR "galleryInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "GalleryTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 12: Update junction tables - PerformerTag
+-- ============================================================================
+
+UPDATE "PerformerTag"
+SET "performerInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("performerInstanceId" = 'default' OR "performerInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "PerformerTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 13: Update junction tables - StudioTag
+-- ============================================================================
+
+UPDATE "StudioTag"
+SET "studioInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("studioInstanceId" = 'default' OR "studioInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "StudioTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 14: Update junction tables - GroupTag
+-- ============================================================================
+
+UPDATE "GroupTag"
+SET "groupInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("groupInstanceId" = 'default' OR "groupInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "GroupTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 15: Update junction tables - ClipTag
+-- ============================================================================
+
+UPDATE "ClipTag"
+SET "clipInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("clipInstanceId" = 'default' OR "clipInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+UPDATE "ClipTag"
+SET "tagInstanceId" = (SELECT "id" FROM "StashInstance" ORDER BY "priority" ASC LIMIT 1)
+WHERE ("tagInstanceId" = 'default' OR "tagInstanceId" IS NULL)
+  AND EXISTS (SELECT 1 FROM "StashInstance");
+
+-- ============================================================================
+-- STEP 16: Clean up orphaned junction table records
+-- Delete any junction records where the FK relationship doesn't resolve
+-- ============================================================================
+
+-- ImageTag: delete records where the tag doesn't exist with matching instanceId
+DELETE FROM "ImageTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "ImageTag".tagId
+    AND t.stashInstanceId = "ImageTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- ImagePerformer: delete records where the performer doesn't exist
+DELETE FROM "ImagePerformer"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashPerformer" p
+  WHERE p.id = "ImagePerformer".performerId
+    AND p.stashInstanceId = "ImagePerformer".performerInstanceId
+    AND p.deletedAt IS NULL
+);
+
+-- ImageGallery: delete records where the gallery doesn't exist
+DELETE FROM "ImageGallery"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashGallery" g
+  WHERE g.id = "ImageGallery".galleryId
+    AND g.stashInstanceId = "ImageGallery".galleryInstanceId
+    AND g.deletedAt IS NULL
+);
+
+-- ScenePerformer: delete records where the performer doesn't exist
+DELETE FROM "ScenePerformer"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashPerformer" p
+  WHERE p.id = "ScenePerformer".performerId
+    AND p.stashInstanceId = "ScenePerformer".performerInstanceId
+    AND p.deletedAt IS NULL
+);
+
+-- SceneTag: delete records where the tag doesn't exist
+DELETE FROM "SceneTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "SceneTag".tagId
+    AND t.stashInstanceId = "SceneTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- SceneGroup: delete records where the group doesn't exist
+DELETE FROM "SceneGroup"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashGroup" g
+  WHERE g.id = "SceneGroup".groupId
+    AND g.stashInstanceId = "SceneGroup".groupInstanceId
+    AND g.deletedAt IS NULL
+);
+
+-- SceneGallery: delete records where the gallery doesn't exist
+DELETE FROM "SceneGallery"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashGallery" g
+  WHERE g.id = "SceneGallery".galleryId
+    AND g.stashInstanceId = "SceneGallery".galleryInstanceId
+    AND g.deletedAt IS NULL
+);
+
+-- GalleryPerformer: delete records where the performer doesn't exist
+DELETE FROM "GalleryPerformer"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashPerformer" p
+  WHERE p.id = "GalleryPerformer".performerId
+    AND p.stashInstanceId = "GalleryPerformer".performerInstanceId
+    AND p.deletedAt IS NULL
+);
+
+-- GalleryTag: delete records where the tag doesn't exist
+DELETE FROM "GalleryTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "GalleryTag".tagId
+    AND t.stashInstanceId = "GalleryTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- PerformerTag: delete records where the tag doesn't exist
+DELETE FROM "PerformerTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "PerformerTag".tagId
+    AND t.stashInstanceId = "PerformerTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- StudioTag: delete records where the tag doesn't exist
+DELETE FROM "StudioTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "StudioTag".tagId
+    AND t.stashInstanceId = "StudioTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- GroupTag: delete records where the tag doesn't exist
+DELETE FROM "GroupTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "GroupTag".tagId
+    AND t.stashInstanceId = "GroupTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- ClipTag: delete records where the tag doesn't exist
+DELETE FROM "ClipTag"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "StashTag" t
+  WHERE t.id = "ClipTag".tagId
+    AND t.stashInstanceId = "ClipTag".tagInstanceId
+    AND t.deletedAt IS NULL
+);
+
+-- ============================================================================
+-- NOTE: Schema default removal is handled by Prisma schema changes
+-- A full sync will run automatically after this migration to ensure all
+-- data is correct with proper instance IDs from the sync code.
+-- ============================================================================

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -632,7 +632,7 @@ model UserCarousel {
 
 model StashScene {
   id              String  // Stash scene ID
-  stashInstanceId String  @default("default") // Which Stash server
+  stashInstanceId String // Which Stash server
 
   // === Core fields (indexed) ===
   title     String?
@@ -716,8 +716,7 @@ model StashScene {
 
 model StashPerformer {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Deduplication (StashDB IDs) ===
   stashIds String? // JSON array of {endpoint, stash_id} pairs
 
@@ -778,8 +777,7 @@ model StashPerformer {
 
 model StashStudio {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Deduplication (StashDB IDs) ===
   stashIds String? // JSON array of {endpoint, stash_id} pairs
 
@@ -825,8 +823,7 @@ model StashStudio {
 
 model StashTag {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Deduplication (StashDB IDs) ===
   stashIds String? // JSON array of {endpoint, stash_id} pairs
 
@@ -882,8 +879,7 @@ model StashTag {
 
 model StashGroup {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Core fields ===
   name      String
   date      String?
@@ -925,13 +921,12 @@ model StashGroup {
 
 model StashGallery {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Core fields ===
   title            String?
   date             String?
   studioId         String?
-  studioInstanceId String? @default("default")
+  studioInstanceId String?
   rating100        Int?
   coverImageId     String? // Stash image ID of the cover image (for dimension lookup)
 
@@ -977,8 +972,7 @@ model StashGallery {
 
 model StashImage {
   id              String
-  stashInstanceId String  @default("default")
-
+  stashInstanceId String 
   // === Core fields ===
   title            String?
   code             String?
@@ -987,7 +981,7 @@ model StashImage {
   urls             String? // JSON array of URLs
   date             String?
   studioId         String?
-  studioInstanceId String? @default("default")
+  studioInstanceId String?
   rating100        Int?
   oCounter         Int     @default(0)
   organized        Boolean @default(false)
@@ -1027,10 +1021,11 @@ model StashImage {
 
 model StashClip {
   id              String   // Stash marker ID
-  stashInstanceId String   @default("default")
+  stashInstanceId String
   sceneId         String
-  sceneInstanceId String   @default("default")
-  scene           StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  sceneInstanceId String
+
+  scene StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   // === Core fields ===
   title           String?
@@ -1039,9 +1034,10 @@ model StashClip {
 
   // === Tag relations ===
   primaryTagId         String?
-  primaryTagInstanceId String?  @default("default")
-  primaryTag           StashTag? @relation("ClipPrimaryTag", fields: [primaryTagId, primaryTagInstanceId], references: [id, stashInstanceId])
-  tags                 ClipTag[]
+  primaryTagInstanceId String?
+
+  primaryTag StashTag? @relation("ClipPrimaryTag", fields: [primaryTagId, primaryTagInstanceId], references: [id, stashInstanceId])
+  tags       ClipTag[]
 
   // === Preview generation status ===
   previewPath     String?  // Stash preview URL path
@@ -1064,12 +1060,13 @@ model StashClip {
 }
 
 model ClipTag {
-  clipId             String
-  clipInstanceId     String @default("default")
-  tagId              String
-  tagInstanceId      String @default("default")
-  clip               StashClip @relation(fields: [clipId, clipInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag                StashTag  @relation("ClipTags", fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  clipId         String
+  clipInstanceId String
+  tagId          String
+  tagInstanceId  String
+
+  clip StashClip @relation(fields: [clipId, clipInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag  StashTag  @relation("ClipTags", fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([clipId, clipInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
@@ -1079,11 +1076,12 @@ model ClipTag {
 
 model ScenePerformer {
   sceneId             String
-  sceneInstanceId     String @default("default")
+  sceneInstanceId     String
   performerId         String
-  performerInstanceId String @default("default")
-  scene               StashScene     @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  performer           StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performerInstanceId String
+
+  scene     StashScene     @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performer StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([sceneId, sceneInstanceId, performerId, performerInstanceId])
   @@index([performerId, performerInstanceId])
@@ -1091,11 +1089,12 @@ model ScenePerformer {
 
 model SceneTag {
   sceneId         String
-  sceneInstanceId String @default("default")
+  sceneInstanceId String
   tagId           String
-  tagInstanceId   String @default("default")
-  scene           StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag             StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId   String
+
+  scene StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag   StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([sceneId, sceneInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
@@ -1103,12 +1102,13 @@ model SceneTag {
 
 model SceneGroup {
   sceneId         String
-  sceneInstanceId String @default("default")
+  sceneInstanceId String
   groupId         String
-  groupInstanceId String @default("default")
+  groupInstanceId String
   sceneIndex      Int?
-  scene           StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  group           StashGroup @relation(fields: [groupId, groupInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+
+  scene StashScene @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  group StashGroup @relation(fields: [groupId, groupInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([sceneId, sceneInstanceId, groupId, groupInstanceId])
   @@index([groupId, groupInstanceId])
@@ -1116,11 +1116,12 @@ model SceneGroup {
 
 model SceneGallery {
   sceneId           String
-  sceneInstanceId   String @default("default")
+  sceneInstanceId   String
   galleryId         String
-  galleryInstanceId String @default("default")
-  scene             StashScene   @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  gallery           StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  galleryInstanceId String
+
+  scene   StashScene   @relation(fields: [sceneId, sceneInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  gallery StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([sceneId, sceneInstanceId, galleryId, galleryInstanceId])
   @@index([galleryId, galleryInstanceId])
@@ -1128,11 +1129,12 @@ model SceneGallery {
 
 model ImagePerformer {
   imageId             String
-  imageInstanceId     String @default("default")
+  imageInstanceId     String
   performerId         String
-  performerInstanceId String @default("default")
-  image               StashImage     @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  performer           StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performerInstanceId String
+
+  image     StashImage     @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performer StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([imageId, imageInstanceId, performerId, performerInstanceId])
   @@index([performerId, performerInstanceId])
@@ -1141,11 +1143,12 @@ model ImagePerformer {
 
 model ImageTag {
   imageId         String
-  imageInstanceId String @default("default")
+  imageInstanceId String
   tagId           String
-  tagInstanceId   String @default("default")
-  image           StashImage @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag             StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId   String
+
+  image StashImage @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag   StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([imageId, imageInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
@@ -1154,11 +1157,12 @@ model ImageTag {
 
 model ImageGallery {
   imageId           String
-  imageInstanceId   String @default("default")
+  imageInstanceId   String
   galleryId         String
-  galleryInstanceId String @default("default")
-  image             StashImage   @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  gallery           StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  galleryInstanceId String
+
+  image   StashImage   @relation(fields: [imageId, imageInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  gallery StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([imageId, imageInstanceId, galleryId, galleryInstanceId])
   @@index([galleryId, galleryInstanceId])
@@ -1166,11 +1170,12 @@ model ImageGallery {
 
 model GalleryPerformer {
   galleryId           String
-  galleryInstanceId   String @default("default")
+  galleryInstanceId   String
   performerId         String
-  performerInstanceId String @default("default")
-  gallery             StashGallery   @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  performer           StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performerInstanceId String
+
+  gallery   StashGallery   @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  performer StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([galleryId, galleryInstanceId, performerId, performerInstanceId])
   @@index([performerId, performerInstanceId])
@@ -1178,11 +1183,12 @@ model GalleryPerformer {
 
 model PerformerTag {
   performerId         String
-  performerInstanceId String @default("default")
+  performerInstanceId String
   tagId               String
-  tagInstanceId       String @default("default")
-  performer           StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag                 StashTag       @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId       String
+
+  performer StashPerformer @relation(fields: [performerId, performerInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag       StashTag       @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([performerId, performerInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
@@ -1190,10 +1196,11 @@ model PerformerTag {
 
 model StudioTag {
   studioId         String
-  studioInstanceId String @default("default")
+  studioInstanceId String
   tagId            String
-  tagInstanceId    String @default("default")
-  studio           StashStudio @relation(fields: [studioId, studioInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId    String
+
+  studio StashStudio @relation(fields: [studioId, studioInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
   tag              StashTag    @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([studioId, studioInstanceId, tagId, tagInstanceId])
@@ -1202,11 +1209,12 @@ model StudioTag {
 
 model GalleryTag {
   galleryId         String
-  galleryInstanceId String @default("default")
+  galleryInstanceId String
   tagId             String
-  tagInstanceId     String @default("default")
-  gallery           StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag               StashTag     @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId     String
+
+  gallery StashGallery @relation(fields: [galleryId, galleryInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag     StashTag     @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([galleryId, galleryInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
@@ -1214,11 +1222,12 @@ model GalleryTag {
 
 model GroupTag {
   groupId         String
-  groupInstanceId String @default("default")
+  groupInstanceId String
   tagId           String
-  tagInstanceId   String @default("default")
-  group           StashGroup @relation(fields: [groupId, groupInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
-  tag             StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tagInstanceId   String
+
+  group StashGroup @relation(fields: [groupId, groupInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
+  tag   StashTag   @relation(fields: [tagId, tagInstanceId], references: [id, stashInstanceId], onDelete: Cascade)
 
   @@id([groupId, groupInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])

--- a/server/services/StashSyncService.ts
+++ b/server/services/StashSyncService.ts
@@ -592,7 +592,7 @@ class StashSyncService extends EventEmitter {
    * Get sync state for a specific entity type
    */
   private async getEntitySyncState(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     entityType: EntityType
   ): Promise<{
     lastFullSyncTimestamp: string | null;
@@ -709,7 +709,7 @@ class StashSyncService extends EventEmitter {
    */
   private async syncEntityType(
     entityType: EntityType,
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -747,11 +747,61 @@ class StashSyncService extends EventEmitter {
 
     this.syncInProgress = true;
     this.abortController = new AbortController();
+
+    try {
+      // If no instance specified, sync all enabled instances
+      if (!stashInstanceId) {
+        return await this.incrementalSyncAllInstances();
+      }
+      return await this.incrementalSyncInstance(stashInstanceId);
+    } finally {
+      this.syncInProgress = false;
+      this.abortController = null;
+    }
+  }
+
+  /**
+   * Incremental sync all enabled instances
+   * Note: Assumes syncInProgress is already set by caller
+   */
+  private async incrementalSyncAllInstances(): Promise<SyncResult[]> {
+    const enabledInstances = stashInstanceManager.getAllEnabled();
+
+    if (enabledInstances.length === 0) {
+      logger.warn("No enabled Stash instances to sync");
+      return [];
+    }
+
+    logger.info(`Starting incremental sync for ${enabledInstances.length} instance(s)...`);
+    const allResults: SyncResult[] = [];
+
+    for (const instance of enabledInstances) {
+      logger.info(`Incremental sync instance: ${instance.name} (${instance.id})`);
+      try {
+        const results = await this.incrementalSyncInstance(instance.id);
+        allResults.push(...results);
+      } catch (error) {
+        logger.error(`Failed to incremental sync instance ${instance.name}`, {
+          instanceId: instance.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Continue with other instances
+      }
+    }
+
+    return allResults;
+  }
+
+  /**
+   * Incremental sync a single instance
+   * Note: Assumes syncInProgress is already set by caller
+   */
+  private async incrementalSyncInstance(stashInstanceId: string): Promise<SyncResult[]> {
     const startTime = Date.now();
     const results: SyncResult[] = [];
 
     try {
-      logger.info("Starting incremental sync with per-entity timestamps...");
+      logger.info("Starting incremental sync with per-entity timestamps...", { stashInstanceId });
 
       // Entity types in dependency order (tags first since others reference them)
       const entityTypes: EntityType[] = [
@@ -857,9 +907,6 @@ class StashSyncService extends EventEmitter {
       }
 
       throw error;
-    } finally {
-      this.syncInProgress = false;
-      this.abortController = null;
     }
   }
 
@@ -873,23 +920,30 @@ class StashSyncService extends EventEmitter {
     action: "create" | "update" | "delete",
     stashInstanceId?: string
   ): Promise<void> {
-    logger.info("Single entity sync", { entityType, entityId, action });
+    // Resolve instance ID - use first enabled instance if not specified
+    const instanceId = stashInstanceId ?? this.getFirstEnabledInstanceId();
+    if (!instanceId) {
+      logger.warn("Cannot sync single entity: no enabled Stash instances");
+      return;
+    }
+
+    logger.info("Single entity sync", { entityType, entityId, action, instanceId });
 
     if (action === "delete") {
       // Soft delete the entity
-      await this.softDeleteEntity(entityType, entityId, stashInstanceId);
+      await this.softDeleteEntity(entityType, entityId, instanceId);
       return;
     }
 
     // Fetch and upsert the entity
-    const stash = this.getStashClient(stashInstanceId);
+    const stash = this.getStashClient(instanceId);
 
     switch (entityType) {
       case "scene": {
         // Use findScenes with ids filter for single scene
         const result = await stash.findScenes({ ids: [entityId] });
         if (result.findScenes.scenes.length > 0) {
-          await this.processScenesBatch(result.findScenes.scenes as Scene[], stashInstanceId, 0, 1);
+          await this.processScenesBatch(result.findScenes.scenes as Scene[], instanceId, 0, 1);
         }
         break;
       }
@@ -898,7 +952,7 @@ class StashSyncService extends EventEmitter {
         if (result.findPerformers.performers.length > 0) {
           await this.processPerformersBatch(
             result.findPerformers.performers as Performer[],
-            stashInstanceId
+            instanceId
           );
         }
         break;
@@ -906,45 +960,53 @@ class StashSyncService extends EventEmitter {
       case "studio": {
         const result = await stash.findStudios({ ids: [entityId] });
         if (result.findStudios.studios.length > 0) {
-          await this.processStudiosBatch(result.findStudios.studios as Studio[], stashInstanceId);
+          await this.processStudiosBatch(result.findStudios.studios as Studio[], instanceId);
         }
         break;
       }
       case "tag": {
         const result = await stash.findTags({ ids: [entityId] });
         if (result.findTags.tags.length > 0) {
-          await this.processTagsBatch(result.findTags.tags as Tag[], stashInstanceId);
+          await this.processTagsBatch(result.findTags.tags as Tag[], instanceId);
         }
         break;
       }
       case "group": {
         const result = await stash.findGroup({ id: entityId });
         if (result.findGroup) {
-          await this.processGroupsBatch([result.findGroup as Group], stashInstanceId);
+          await this.processGroupsBatch([result.findGroup as Group], instanceId);
         }
         break;
       }
       case "gallery": {
         const result = await stash.findGallery({ id: entityId });
         if (result.findGallery) {
-          await this.processGalleriesBatch([result.findGallery as Gallery], stashInstanceId);
+          await this.processGalleriesBatch([result.findGallery as Gallery], instanceId);
         }
         break;
       }
       case "image": {
         const result = await stash.findImages({ image_ids: [parseInt(entityId, 10)] });
         if (result.findImages.images.length > 0) {
-          await this.processImagesBatch(result.findImages.images, stashInstanceId);
+          await this.processImagesBatch(result.findImages.images, instanceId);
         }
         break;
       }
     }
   }
 
+  /**
+   * Get the ID of the first enabled Stash instance
+   */
+  private getFirstEnabledInstanceId(): string | undefined {
+    const enabledInstances = stashInstanceManager.getAllEnabled();
+    return enabledInstances.length > 0 ? enabledInstances[0].id : undefined;
+  }
+
   // ==================== Scene Sync ====================
 
   private async syncScenes(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -1041,7 +1103,7 @@ class StashSyncService extends EventEmitter {
 
   private async processScenesBatch(
     scenes: Scene[],
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     _batchStart: number,
     _totalCount: number
   ): Promise<void> {
@@ -1057,7 +1119,7 @@ class StashSyncService extends EventEmitter {
     if (validScenes.length === 0) return;
 
     const sceneIds = validScenes.map((s) => s.id);
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
 
     // Bulk delete all junction records for this batch
     await Promise.all([
@@ -1246,7 +1308,7 @@ class StashSyncService extends EventEmitter {
    * Fetches all entity IDs from Stash using pagination and soft-deletes any
    * entities in Peek that are not present in Stash (due to deletion or merge).
    */
-  private async cleanupDeletedEntities(entityType: EntityType, stashInstanceId?: string): Promise<number> {
+  private async cleanupDeletedEntities(entityType: EntityType, stashInstanceId: string): Promise<number> {
     const plural = ENTITY_PLURALS[entityType];
     logger.info(`Checking for deleted ${plural}...`);
     const startTime = Date.now();
@@ -1397,7 +1459,7 @@ class StashSyncService extends EventEmitter {
 
             // Soft-delete in batches
             const deleteIds = scenesToDelete.map((s) => s.id);
-            const instanceId = stashInstanceId || 'default';
+            const instanceId = stashInstanceId;
             for (let i = 0; i < deleteIds.length; i += BATCH_SIZE) {
               const batch = deleteIds.slice(i, i + BATCH_SIZE);
               await prisma.stashScene.updateMany({
@@ -1413,7 +1475,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "performer": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashPerformer.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1421,7 +1483,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "studio": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashStudio.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1429,7 +1491,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "tag": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashTag.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1437,7 +1499,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "group": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashGroup.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1445,7 +1507,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "gallery": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashGallery.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1453,7 +1515,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "image": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashImage.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1461,7 +1523,7 @@ class StashSyncService extends EventEmitter {
           break;
         }
         case "clip": {
-          const cleanupInstanceId = stashInstanceId || 'default';
+          const cleanupInstanceId = stashInstanceId;
           deletedCount = (await prisma.stashClip.updateMany({
             where: { deletedAt: null, stashInstanceId: cleanupInstanceId, id: { notIn: stashIds } },
             data: { deletedAt: now },
@@ -1493,7 +1555,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Performer Sync ====================
 
   private async syncPerformers(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -1583,7 +1645,7 @@ class StashSyncService extends EventEmitter {
 
   private async processPerformersBatch(
     performers: Performer[],
-    stashInstanceId?: string
+    stashInstanceId: string
   ): Promise<void> {
     // Skip empty batches
     if (performers.length === 0) return;
@@ -1685,7 +1747,7 @@ class StashSyncService extends EventEmitter {
   `);
 
     // Sync performer tags to PerformerTag junction table
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
     for (const performer of validPerformers) {
       const performerTags = (performer as any).tags;
       if (performerTags && Array.isArray(performerTags) && performerTags.length > 0) {
@@ -1714,7 +1776,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Studio Sync ====================
 
   private async syncStudios(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -1804,7 +1866,7 @@ class StashSyncService extends EventEmitter {
 
   private async processStudiosBatch(
     studios: Studio[],
-    stashInstanceId?: string
+    stashInstanceId: string
   ): Promise<void> {
     // Skip empty batches
     if (studios.length === 0) return;
@@ -1876,7 +1938,7 @@ class StashSyncService extends EventEmitter {
   `);
 
     // Sync studio tags to StudioTag junction table
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
     for (const studio of validStudios) {
       const studioTags = (studio as any).tags;
       if (studioTags && Array.isArray(studioTags) && studioTags.length > 0) {
@@ -1905,7 +1967,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Tag Sync ====================
 
   private async syncTags(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -1993,7 +2055,7 @@ class StashSyncService extends EventEmitter {
     }
   }
 
-  private async processTagsBatch(tags: Tag[], stashInstanceId?: string): Promise<void> {
+  private async processTagsBatch(tags: Tag[], stashInstanceId: string): Promise<void> {
     // Skip empty batches
     if (tags.length === 0) return;
 
@@ -2072,7 +2134,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Group Sync ====================
 
   private async syncGroups(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -2160,7 +2222,7 @@ class StashSyncService extends EventEmitter {
     }
   }
 
-  private async processGroupsBatch(groups: Group[], stashInstanceId?: string): Promise<void> {
+  private async processGroupsBatch(groups: Group[], stashInstanceId: string): Promise<void> {
     // Skip empty batches
     if (groups.length === 0) return;
 
@@ -2222,7 +2284,7 @@ class StashSyncService extends EventEmitter {
   `);
 
     // Sync group tags to GroupTag junction table
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
     for (const group of validGroups) {
       const groupTags = (group as any).tags;
       if (groupTags && Array.isArray(groupTags) && groupTags.length > 0) {
@@ -2251,7 +2313,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Gallery Sync ====================
 
   private async syncGalleries(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -2341,7 +2403,7 @@ class StashSyncService extends EventEmitter {
 
   private async processGalleriesBatch(
     galleries: Gallery[],
-    stashInstanceId?: string
+    stashInstanceId: string
   ): Promise<void> {
     // Skip empty batches
     if (galleries.length === 0) return;
@@ -2410,7 +2472,7 @@ class StashSyncService extends EventEmitter {
   `);
 
     // Sync gallery performers (junction table)
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
     const performerInserts: { galleryId: string; performerId: string }[] = [];
     for (const gallery of validGalleries) {
       if (gallery.performers && gallery.performers.length > 0) {
@@ -2480,7 +2542,7 @@ class StashSyncService extends EventEmitter {
   // ==================== Image Sync ====================
 
   private async syncImages(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     isFullSync: boolean,
     lastSyncTime?: string
   ): Promise<SyncResult> {
@@ -2571,7 +2633,7 @@ class StashSyncService extends EventEmitter {
   /**
    * Sync clips (scene markers) from Stash
    */
-  async syncClips(stashInstanceId?: string, isFullSync = false, since?: string): Promise<SyncResult> {
+  async syncClips(stashInstanceId: string, isFullSync = false, since?: string): Promise<SyncResult> {
     logger.info("Syncing clips...");
     const startTime = Date.now();
     const client = this.getStashClient(stashInstanceId);
@@ -2636,17 +2698,19 @@ class StashSyncService extends EventEmitter {
         const probeResults = await clipPreviewProber.probeBatch(previewUrls);
 
         // Upsert clips
-        const instanceId = stashInstanceId || 'default';
+        const instanceId = stashInstanceId;
         for (let i = 0; i < markers.length; i++) {
           const marker = markers[i];
           const previewUrl = previewUrls[i];
 
           const clipData = {
             sceneId: marker.scene.id,
+            sceneInstanceId: instanceId,
             title: marker.title || null,
             seconds: marker.seconds,
             endSeconds: marker.end_seconds || null,
             primaryTagId: marker.primary_tag.id,
+            primaryTagInstanceId: instanceId,
             previewPath: marker.preview,
             screenshotPath: marker.screenshot,
             streamPath: marker.stream,
@@ -2732,7 +2796,7 @@ class StashSyncService extends EventEmitter {
     }
   }
 
-  private async processImagesBatch(images: any[], stashInstanceId?: string): Promise<void> {
+  private async processImagesBatch(images: any[], stashInstanceId: string): Promise<void> {
     // Skip empty batches
     if (images.length === 0) return;
 
@@ -2741,7 +2805,7 @@ class StashSyncService extends EventEmitter {
     if (validImages.length === 0) return;
 
     const imageIds = validImages.map((i: any) => i.id);
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
 
     // Bulk delete junction records
     await Promise.all([
@@ -2864,9 +2928,9 @@ class StashSyncService extends EventEmitter {
     }
   }
 
-  private async softDeleteEntity(entityType: EntityType, entityId: string, stashInstanceId?: string): Promise<void> {
+  private async softDeleteEntity(entityType: EntityType, entityId: string, stashInstanceId: string): Promise<void> {
     const now = new Date();
-    const instanceId = stashInstanceId || 'default';
+    const instanceId = stashInstanceId;
 
     switch (entityType) {
       case "scene":
@@ -2933,11 +2997,11 @@ class StashSyncService extends EventEmitter {
    * Without maxUpdatedAt from synced entities, we have no reliable timestamp to store.
    */
   private async saveSyncState(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     syncType: "full" | "incremental",
     result: SyncResult
   ): Promise<void> {
-    const instanceId = stashInstanceId ?? null;
+    const instanceId = stashInstanceId;
 
     // Actual time (real UTC) for display purposes
     const actualTime = new Date();
@@ -2998,12 +3062,12 @@ class StashSyncService extends EventEmitter {
   }
 
   private async updateAllSyncStates(
-    stashInstanceId: string | undefined,
+    stashInstanceId: string,
     syncType: "full" | "incremental",
     results: SyncResult[],
     _totalDurationMs: number
   ): Promise<void> {
-    const instanceId = stashInstanceId ?? null;
+    const instanceId = stashInstanceId;
 
     for (const result of results) {
       // Actual time (real UTC) for display purposes

--- a/server/tests/controllers/watchHistory.test.ts
+++ b/server/tests/controllers/watchHistory.test.ts
@@ -27,6 +27,12 @@ vi.mock("../../prisma/singleton.js", () => ({
     user: {
       findUnique: vi.fn(),
     },
+    stashScene: {
+      findFirst: vi.fn().mockResolvedValue({
+        duration: 600,
+        stashInstanceId: "test-instance",
+      }),
+    },
     userPerformerStats: {
       deleteMany: vi.fn(),
     },
@@ -53,6 +59,7 @@ vi.mock("../../services/StashInstanceManager.js", () => ({
       sceneAddPlay: vi.fn().mockResolvedValue({ sceneAddPlay: { count: 1, history: [] } }),
       sceneIncrementO: vi.fn().mockResolvedValue({ sceneIncrementO: 1 }),
     })),
+    getAllConfigs: vi.fn(() => [{ id: "test-instance", name: "Test", priority: 0 }]),
   },
 }));
 
@@ -161,10 +168,10 @@ describe("Watch History Controller", () => {
 
       expect(mockPrisma.watchHistory.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { userId_instanceId_sceneId: { userId: 1, instanceId: "default", sceneId: "123" } },
+          where: { userId_instanceId_sceneId: { userId: 1, instanceId: "test-instance", sceneId: "123" } },
           create: expect.objectContaining({
             userId: 1,
-            instanceId: "default",
+            instanceId: "test-instance",
             sceneId: "123",
             playDuration: 10,
             resumeTime: 60,

--- a/server/tests/services/MergeReconciliationService.test.ts
+++ b/server/tests/services/MergeReconciliationService.test.ts
@@ -3,6 +3,21 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// Mock stashInstanceManager to provide a default instance for entityInstanceId lookups
+vi.mock("../../services/StashInstanceManager.js", () => ({
+  stashInstanceManager: {
+    getDefault: vi.fn().mockReturnValue({
+      id: "test-instance",
+      name: "Test",
+      url: "http://localhost:9999/graphql",
+      apiKey: "test-key",
+    }),
+    getAllConfigs: vi.fn().mockReturnValue([{ id: "test-instance", name: "Test", priority: 0 }]),
+    getAllEnabled: vi.fn().mockReturnValue([]),
+    hasInstances: vi.fn().mockReturnValue(true),
+  },
+}));
+
 // Mock prisma
 vi.mock("../../prisma/singleton.js", () => ({
   default: {

--- a/server/tests/services/StashSyncService.cleanup.test.ts
+++ b/server/tests/services/StashSyncService.cleanup.test.ts
@@ -86,6 +86,15 @@ vi.mock("../../services/StashInstanceManager.js", () => ({
       findGalleryIDs: mockFindGalleryIDs,
       findImageIDs: mockFindImageIDs,
     })),
+    get: vi.fn(() => ({
+      findSceneIDs: mockFindSceneIDs,
+      findPerformerIDs: mockFindPerformerIDs,
+      findStudioIDs: mockFindStudioIDs,
+      findTagIDs: mockFindTagIDs,
+      findGroupIDs: mockFindGroupIDs,
+      findGalleryIDs: mockFindGalleryIDs,
+      findImageIDs: mockFindImageIDs,
+    })),
     initialize: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -254,12 +263,12 @@ describe("StashSyncService Cleanup", () => {
       ]);
       vi.mocked(prisma.stashScene.updateMany).mockResolvedValue({ count: 2 });
 
-      const result = await (stashSyncService as any).cleanupDeletedEntities("scene");
+      const result = await (stashSyncService as any).cleanupDeletedEntities("scene", "test-instance");
 
       expect(result).toBe(2);
       // New implementation uses batched IN clauses for scenes to delete
       expect(prisma.stashScene.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: ["4", "5"] }, stashInstanceId: "default" },
+        where: { id: { in: ["4", "5"] }, stashInstanceId: "test-instance" },
         data: { deletedAt: expect.any(Date) },
       });
     });
@@ -270,11 +279,11 @@ describe("StashSyncService Cleanup", () => {
       });
       vi.mocked(prisma.stashPerformer.updateMany).mockResolvedValue({ count: 5 });
 
-      const result = await (stashSyncService as any).cleanupDeletedEntities("performer");
+      const result = await (stashSyncService as any).cleanupDeletedEntities("performer", "test-instance");
 
       expect(result).toBe(5);
       expect(prisma.stashPerformer.updateMany).toHaveBeenCalledWith({
-        where: { deletedAt: null, stashInstanceId: "default", id: { notIn: ["p1", "p2"] } },
+        where: { deletedAt: null, stashInstanceId: "test-instance", id: { notIn: ["p1", "p2"] } },
         data: { deletedAt: expect.any(Date) },
       });
     });
@@ -352,13 +361,13 @@ describe("StashSyncService Cleanup", () => {
       vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue(localScenes);
       vi.mocked(prisma.stashScene.updateMany).mockResolvedValue({ count: 100 });
 
-      const result = await (stashSyncService as any).cleanupDeletedEntities("scene");
+      const result = await (stashSyncService as any).cleanupDeletedEntities("scene", "test-instance");
 
       expect(result).toBe(100);
       // New implementation uses batched IN clauses - first batch has IDs 1-100
       const expectedIds = Array.from({ length: 100 }, (_, i) => String(i + 1));
       expect(prisma.stashScene.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: expectedIds }, stashInstanceId: "default" },
+        where: { id: { in: expectedIds }, stashInstanceId: "test-instance" },
         data: { deletedAt: expect.any(Date) },
       });
     });

--- a/server/tests/services/StashSyncService.unit.test.ts
+++ b/server/tests/services/StashSyncService.unit.test.ts
@@ -54,18 +54,22 @@ vi.mock("../../prisma/singleton.js", () => ({
 }));
 
 // Mock the stash instance manager
+const mockStashClient = {
+  findTags: vi.fn().mockResolvedValue({ findTags: { tags: [], count: 0 } }),
+  findStudios: vi.fn().mockResolvedValue({ findStudios: { studios: [], count: 0 } }),
+  findPerformers: vi.fn().mockResolvedValue({ findPerformers: { performers: [], count: 0 } }),
+  findGroups: vi.fn().mockResolvedValue({ findGroups: { groups: [], count: 0 } }),
+  findGalleries: vi.fn().mockResolvedValue({ findGalleries: { galleries: [], count: 0 } }),
+  findScenesCompact: vi.fn().mockResolvedValue({ findScenes: { scenes: [], count: 0 } }),
+  findSceneMarkers: vi.fn().mockResolvedValue({ findSceneMarkers: { scene_markers: [], count: 0 } }),
+  findImages: vi.fn().mockResolvedValue({ findImages: { images: [], count: 0 } }),
+};
+
 vi.mock("../../services/StashInstanceManager.js", () => ({
   stashInstanceManager: {
-    getDefault: vi.fn(() => ({
-      findTags: vi.fn().mockResolvedValue({ findTags: { tags: [], count: 0 } }),
-      findStudios: vi.fn().mockResolvedValue({ findStudios: { studios: [], count: 0 } }),
-      findPerformers: vi.fn().mockResolvedValue({ findPerformers: { performers: [], count: 0 } }),
-      findGroups: vi.fn().mockResolvedValue({ findGroups: { groups: [], count: 0 } }),
-      findGalleries: vi.fn().mockResolvedValue({ findGalleries: { galleries: [], count: 0 } }),
-      findScenesCompact: vi.fn().mockResolvedValue({ findScenes: { scenes: [], count: 0 } }),
-      findSceneMarkers: vi.fn().mockResolvedValue({ findSceneMarkers: { scene_markers: [], count: 0 } }),
-      findImages: vi.fn().mockResolvedValue({ findImages: { images: [], count: 0 } }),
-    })),
+    getDefault: vi.fn(() => mockStashClient),
+    get: vi.fn(() => mockStashClient),
+    getAllEnabled: vi.fn(() => [{ id: "test-instance-uuid", name: "Test Instance" }]),
     hasInstances: vi.fn(() => true),
     getBaseUrl: vi.fn(() => "http://localhost:9999"),
     getApiKey: vi.fn(() => "test-api-key"),


### PR DESCRIPTION
## Summary
- Fixes FK constraint errors and missing clips reported by KiritoP in multi-stash instance setups
- Removes all legacy 'default' fallbacks that don't match any real StashInstance UUID
- Adds migration to fix existing 'default' and NULL values in database
- Ensures all entities and junction tables use proper instance IDs throughout the sync process

## Test plan
- [x] Server unit tests pass (751 tests)
- [x] Server lint passes (0 errors)
- [x] Server TypeScript check passes
- [x] Integration tests pass (602 tests)
- [x] Client tests pass (1064 tests)
- [x] Client lint passes (0 errors)
- [x] Client build succeeds