### PR TITLE
UI: Clickable description text and responsive O counter sizing

### DIFF
--- a/client/src/components/ui/ExpandableDescription.jsx
+++ b/client/src/components/ui/ExpandableDescription.jsx
@@ -12,7 +12,7 @@ import { useTruncationDetection } from "../../hooks/useTruncationDetection";
  * - This ensures "more" appears at the end of the text regardless of line count
  */
 export const ExpandableDescription = ({ description, maxLines = 3 }) => {
-  const [ref, isTruncated] = useTruncationDetection();
+  const [ref] = useTruncationDetection();
   const [isExpanded, setIsExpanded] = useState(false);
   const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
 

--- a/client/src/components/ui/OCounterButton.jsx
+++ b/client/src/components/ui/OCounterButton.jsx
@@ -129,7 +129,7 @@ const OCounterButton = ({
 
       {/* Count with scale animation */}
       <span
-        className={`${config.text} font-medium transition-all ${
+        className={`card-counter-text ${config.text} font-medium transition-all ${
           isAnimating ? "scale-110 font-bold" : "scale-100"
         }`}
         style={{

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -251,6 +251,11 @@ a:focus-visible,
   height: var(--card-rating-icon-size) !important;
 }
 
+/* Scale counter text (O counter, play count) within rating row */
+.card-grid-responsive .card-rating-icons .card-counter-text {
+  font-size: var(--card-indicator-size);
+}
+
 /* Scale rating badge text */
 .card-grid-responsive .card-rating-row button:first-child {
   font-size: var(--card-indicator-size);


### PR DESCRIPTION
## Summary
- Make truncated description text clickable to expand, removing the separate "More" button
- Scale O counter text with grid density to match icon scaling behavior

## Test plan
- [ ] Verify clicking truncated description text opens the expanded popover
- [ ] Change grid density (small/medium/large) and confirm O counter text scales with icons
- [ ] All client tests pass (1061 tests)
- [ ] Client build succeeds