### PR TITLE
fix: Sync timeout scalability for large libraries

### DIFF
--- a/server/prisma/migrations/20260128000000_add_junction_sync_indexes/migration.sql
+++ b/server/prisma/migrations/20260128000000_add_junction_sync_indexes/migration.sql
@@ -1,0 +1,22 @@
+-- Add indexes for sync delete operations
+-- These indexes allow efficient lookups when deleting junction records by entity ID
+-- Without these, SQLite does full table scans causing timeouts on large libraries
+
+-- Scene junction tables
+CREATE INDEX "ScenePerformer_scene_idx" ON "ScenePerformer"("sceneId", "sceneInstanceId");
+CREATE INDEX "SceneTag_scene_idx" ON "SceneTag"("sceneId", "sceneInstanceId");
+CREATE INDEX "SceneGroup_scene_idx" ON "SceneGroup"("sceneId", "sceneInstanceId");
+CREATE INDEX "SceneGallery_scene_idx" ON "SceneGallery"("sceneId", "sceneInstanceId");
+
+-- Image junction table (ImagePerformer and ImageTag already have this index)
+CREATE INDEX "ImageGallery_image_idx" ON "ImageGallery"("imageId", "imageInstanceId");
+
+-- Gallery junction tables
+CREATE INDEX "GalleryPerformer_gallery_idx" ON "GalleryPerformer"("galleryId", "galleryInstanceId");
+CREATE INDEX "GalleryTag_gallery_idx" ON "GalleryTag"("galleryId", "galleryInstanceId");
+
+-- Other junction tables
+CREATE INDEX "PerformerTag_performer_idx" ON "PerformerTag"("performerId", "performerInstanceId");
+CREATE INDEX "StudioTag_studio_idx" ON "StudioTag"("studioId", "studioInstanceId");
+CREATE INDEX "GroupTag_group_idx" ON "GroupTag"("groupId", "groupInstanceId");
+CREATE INDEX "ClipTag_clip_idx" ON "ClipTag"("clipId", "clipInstanceId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1070,6 +1070,7 @@ model ClipTag {
 
   @@id([clipId, clipInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([clipId, clipInstanceId])
 }
 
 // Junction tables for efficient many-to-many queries
@@ -1085,6 +1086,7 @@ model ScenePerformer {
 
   @@id([sceneId, sceneInstanceId, performerId, performerInstanceId])
   @@index([performerId, performerInstanceId])
+  @@index([sceneId, sceneInstanceId])
 }
 
 model SceneTag {
@@ -1098,6 +1100,7 @@ model SceneTag {
 
   @@id([sceneId, sceneInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([sceneId, sceneInstanceId])
 }
 
 model SceneGroup {
@@ -1112,6 +1115,7 @@ model SceneGroup {
 
   @@id([sceneId, sceneInstanceId, groupId, groupInstanceId])
   @@index([groupId, groupInstanceId])
+  @@index([sceneId, sceneInstanceId])
 }
 
 model SceneGallery {
@@ -1125,6 +1129,7 @@ model SceneGallery {
 
   @@id([sceneId, sceneInstanceId, galleryId, galleryInstanceId])
   @@index([galleryId, galleryInstanceId])
+  @@index([sceneId, sceneInstanceId])
 }
 
 model ImagePerformer {
@@ -1166,6 +1171,7 @@ model ImageGallery {
 
   @@id([imageId, imageInstanceId, galleryId, galleryInstanceId])
   @@index([galleryId, galleryInstanceId])
+  @@index([imageId, imageInstanceId])
 }
 
 model GalleryPerformer {
@@ -1179,6 +1185,7 @@ model GalleryPerformer {
 
   @@id([galleryId, galleryInstanceId, performerId, performerInstanceId])
   @@index([performerId, performerInstanceId])
+  @@index([galleryId, galleryInstanceId])
 }
 
 model PerformerTag {
@@ -1192,6 +1199,7 @@ model PerformerTag {
 
   @@id([performerId, performerInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([performerId, performerInstanceId])
 }
 
 model StudioTag {
@@ -1205,6 +1213,7 @@ model StudioTag {
 
   @@id([studioId, studioInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([studioId, studioInstanceId])
 }
 
 model GalleryTag {
@@ -1218,6 +1227,7 @@ model GalleryTag {
 
   @@id([galleryId, galleryInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([galleryId, galleryInstanceId])
 }
 
 model GroupTag {
@@ -1231,6 +1241,7 @@ model GroupTag {
 
   @@id([groupId, groupInstanceId, tagId, tagInstanceId])
   @@index([tagId, tagInstanceId])
+  @@index([groupId, groupInstanceId])
 }
 
 // Sync state tracking per entity type


### PR DESCRIPTION
## Summary
- Fixes sync timeout errors for users with large libraries (2k+ tags, thousands of scenes)
- Adds 11 missing indexes on junction tables for O(log n) delete operations instead of O(n)
- Refactors batch sync to use sequential transactions (avoids SQLite single-writer lock contention)
- Adds extended timeouts (60s for batches, 120s for clearInstanceData)

## Root Cause
The `sceneGallery.deleteMany()` was timing out because:
1. Four parallel `deleteMany` operations competed for SQLite write locks
2. Missing indexes on the "scene side" of junction tables caused full table scans
3. Default 5-second Prisma timeout was too short for large batches

## Changes
- **Schema**: Add indexes to 11 junction tables (ScenePerformer, SceneTag, SceneGroup, SceneGallery, ImageGallery, GalleryPerformer, GalleryTag, PerformerTag, StudioTag, GroupTag, ClipTag)
- **StashSyncService**: 
  - `processScenesBatch`: Sequential raw SQL in transaction with 60s timeout
  - `processImagesBatch`: Same pattern
  - `clearInstanceData`: Interactive transaction with 120s timeout, also cleans SceneGallery and ClipTag

## Test plan
- [x] All 751 unit tests pass
- [x] All 602 integration tests pass (including fresh sync with 24k scenes, 53k images)
- [x] TypeScript compiles without errors
- [x] Linting passes (no errors)