### PR TITLE
Fix gallery wall view, lightbox navigation bug, and scroll restoration

### DIFF
--- a/client/src/components/pages/GalleryDetail.jsx
+++ b/client/src/components/pages/GalleryDetail.jsx
@@ -9,13 +9,12 @@ import { useCardDisplaySettings } from "../../contexts/CardDisplaySettingsContex
 import { useConfig } from "../../contexts/ConfigContext.jsx";
 import { libraryApi } from "../../services/api.js";
 import { galleryTitle } from "../../utils/gallery.js";
-import { getImageTitle } from "../../utils/imageGalleryInheritance.js";
 import { getEntityPath } from "../../utils/entityLinks.js";
 import SceneSearch from "../scene-search/SceneSearch.jsx";
+import WallView from "../wall/WallView.jsx";
 import {
   Button,
   FavoriteButton,
-  LazyImage,
   Lightbox,
   LoadingSpinner,
   PageHeader,
@@ -382,44 +381,17 @@ const GalleryDetail = () => {
                 </div>
               )}
 
-              {imagesLoading ? (
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-3">
-                  {[...Array(Math.min(PER_PAGE, gallery.image_count || 12))].map(
-                    (_, index) => (
-                      <div
-                        key={index}
-                        className="aspect-square rounded-lg animate-pulse"
-                        style={{
-                          backgroundColor: "var(--bg-tertiary)",
-                        }}
-                      />
-                    )
-                  )}
-                </div>
-              ) : images.length > 0 ? (
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-3">
-                  {images.map((image, index) => (
-                    <LazyImage
-                      key={image.id}
-                      src={image.paths?.thumbnail}
-                      alt={getImageTitle(image)}
-                      className="aspect-square rounded-lg overflow-hidden cursor-pointer hover:opacity-80 hover:scale-105 transition-all border"
-                      style={{
-                        backgroundColor: "var(--bg-secondary)",
-                        borderColor: "var(--border-color)",
-                      }}
-                      onClick={() => lightbox.openLightbox(index)}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div
-                  className="text-center py-12"
-                  style={{ color: "var(--text-muted)" }}
-                >
-                  No images found in this gallery
-                </div>
-              )}
+              <WallView
+                items={images}
+                entityType="image"
+                zoomLevel="medium"
+                onItemClick={(image) => {
+                  const index = images.findIndex((img) => img.id === image.id);
+                  lightbox.openLightbox(index >= 0 ? index : 0);
+                }}
+                loading={imagesLoading}
+                emptyMessage="No images found in this gallery"
+              />
 
               {/* Pagination - Bottom */}
               {lightbox.totalPages > 1 && (

--- a/client/src/components/ui/GlobalLayout.jsx
+++ b/client/src/components/ui/GlobalLayout.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { migrateNavPreferences } from "../../constants/navigation.js";
 import { useGlobalNavigation } from "../../hooks/useGlobalNavigation.js";
+import useScrollRestoration from "../../hooks/useScrollRestoration.js";
 import { apiGet } from "../../services/api.js";
 import Sidebar from "./Sidebar.jsx";
 import TopBar from "./TopBar.jsx";
@@ -34,6 +35,7 @@ const GlobalLayout = ({ children }) => {
   }, []);
 
   useGlobalNavigation();
+  useScrollRestoration();
 
   return (
     <div className="layout-container min-h-screen">

--- a/client/src/components/ui/Lightbox.jsx
+++ b/client/src/components/ui/Lightbox.jsx
@@ -47,11 +47,13 @@ const Lightbox = ({
   });
   const controlsTimeoutRef = useRef(null);
 
-  // Reset index when initialIndex changes
+  // Reset index when initialIndex changes OR when lightbox opens
   useEffect(() => {
-    setCurrentIndex(initialIndex);
-    setImageLoaded(false);
-  }, [initialIndex]);
+    if (isOpen) {
+      setCurrentIndex(initialIndex);
+      setImageLoaded(false);
+    }
+  }, [initialIndex, isOpen]);
 
   // Track the current image ID to detect when images array changes during page transitions
   const currentImageId = images[currentIndex]?.id;

--- a/client/src/hooks/useScrollRestoration.js
+++ b/client/src/hooks/useScrollRestoration.js
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+import { useLocation, useNavigationType } from "react-router-dom";
+
+/**
+ * Saves and restores scroll position across route navigations.
+ * - On POP (back/forward): restores saved scroll position
+ * - On PUSH/REPLACE: scrolls to top
+ */
+const useScrollRestoration = () => {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const scrollYRef = useRef(0);
+  const prevKeyRef = useRef("");
+
+  // Track current scroll position via passive listener
+  useEffect(() => {
+    const handleScroll = () => {
+      scrollYRef.current = window.scrollY;
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  // Save/restore on route changes
+  useEffect(() => {
+    const key = location.pathname + location.search;
+
+    // Save the scroll position of the route we're leaving
+    if (prevKeyRef.current && prevKeyRef.current !== key) {
+      try {
+        sessionStorage.setItem(
+          `scrollPos:${prevKeyRef.current}`,
+          String(scrollYRef.current)
+        );
+      } catch {
+        // sessionStorage full or unavailable
+      }
+    }
+
+    prevKeyRef.current = key;
+
+    if (navigationType === "POP") {
+      // Back/forward navigation — restore saved position
+      const saved = sessionStorage.getItem(`scrollPos:${key}`);
+      if (saved) {
+        const y = parseInt(saved, 10);
+        // Try immediately, then retry for lazy-loaded content
+        window.scrollTo(0, y);
+        requestAnimationFrame(() => window.scrollTo(0, y));
+        const timer = setTimeout(() => window.scrollTo(0, y), 100);
+        return () => clearTimeout(timer);
+      }
+    } else {
+      // PUSH or REPLACE — scroll to top
+      window.scrollTo(0, 0);
+    }
+  }, [location.pathname, location.search, navigationType]);
+};
+
+export default useScrollRestoration;


### PR DESCRIPTION
## Summary
- Gallery detail pages now use WallView (masonry layout) instead of a rigid CSS grid, preserving image aspect ratios instead of cropping everything to squares
- Fix lightbox reopening the wrong image after navigating and closing — `currentIndex` now resyncs every time the lightbox opens, not just when `initialIndex` changes
- Add scroll position restoration on back/forward navigation so pressing back returns to the previous scroll position instead of the top of the page

## Test plan
- [ ] Open a gallery detail page — images should display in masonry wall layout respecting aspect ratios
- [ ] Click an image to open lightbox, navigate forward a few images, close, then re-click the original image — should open the correct image
- [ ] Scroll down on a list page, click into a detail page, press back — should return to previous scroll position
- [ ] Forward navigation (clicking links) should still scroll to top
- [ ] Verify lightbox slideshow, cross-page navigation, and keyboard shortcuts still work
- [ ] `cd client && npm run lint` — no new errors
- [ ] `cd client && npm test` — all 1063 tests pass
- [ ] `cd client && npm run build` — builds successfully