### PR TITLE
docs: refresh CLAUDE.md and track project skills

### DIFF
--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: release-workflow
+description: Use when preparing or executing a release of peek-stash-browser. Covers the full release lifecycle from validation through Docker image publishing.
+---
+
+# Release Workflow
+
+## Overview
+
+Releases are triggered by pushing git tags. GitHub Actions builds and publishes Docker images automatically.
+
+```
+Pre-release validation → Version bump → Commit → Tag → Push → GitHub Actions → Docker Hub
+```
+
+## Version Scheme
+
+- **Stable**: `X.Y.Z` (e.g., `3.3.1`)
+- **Beta**: `X.Y.Z-beta.N` (e.g., `3.3.2-beta.1`)
+- **Tag format**: `vX.Y.Z` or `vX.Y.Z-beta.N`
+
+Both `client/package.json` and `server/package.json` must always have identical versions.
+
+## Step 1: Pre-Release Validation
+
+Run `/pre-release` to execute all checks:
+
+1. Server unit tests: `cd server && npm test`
+2. Server linting: `cd server && npm run lint`
+3. Client unit tests: `cd client && npm test`
+4. Client linting: `cd client && npm run lint`
+5. Integration tests: `cd server && npm run test:integration`
+6. Client build: `cd client && npm run build`
+7. Docker production build: `docker build -f Dockerfile.production -t peek:test .`
+
+All 7 checks must pass before proceeding.
+
+## Step 2: Version Bump & Tag
+
+### Beta Release
+
+Run `/release-beta`:
+
+- Increment beta number: `3.3.2-beta.1` → `3.3.2-beta.2`
+- Or start new beta: `3.3.1` → `3.3.2-beta.1`
+
+### Stable Release
+
+Run `/release-alpha` (the skill name is historical — it creates stable releases):
+
+- Remove beta suffix: `3.3.2-beta.8` → `3.3.2`
+- Or increment: `3.3.2` → `3.3.3` or `3.4.0`
+
+### What the Release Skills Do
+
+1. Verify on `main` branch and up to date
+2. Update version in `client/package.json` and `server/package.json`
+3. Commit: `chore: bump version to X.Y.Z`
+4. Push commit to main
+5. Create tag: `git tag vX.Y.Z`
+6. Push tag: `git push origin vX.Y.Z`
+
+## Step 3: Automated CI/CD
+
+GitHub Actions (`.github/workflows/docker-build.yml`) triggers on `v*` tags:
+
+1. **Build**: Multi-stage Dockerfile.production (frontend → backend → runtime)
+2. **Platforms**: `linux/amd64` + `linux/arm64`
+3. **Push to Docker Hub**: `carrotwaxr/peek-stash-browser`
+4. **Tag strategy**:
+   - Semver: `3.3.2`
+   - Major.minor: `3.3`
+   - `latest` (stable releases only)
+   - `stable` (stable releases only)
+   - `beta` (beta releases only)
+5. **GitHub Release**: Auto-created with generated release notes, marked as prerelease if beta
+
+## Docker Hub Tags After Release
+
+| Release Type | Tags Applied |
+|-------------|-------------|
+| `v3.3.2` (stable) | `3.3.2`, `3.3`, `latest`, `stable` |
+| `v3.3.2-beta.1` | `3.3.2-beta.1`, `beta` |
+
+## Updating on unRAID
+
+After GitHub Actions completes:
+
+```bash
+# SSH to server
+ssh root@10.0.0.4
+
+# Pull new image
+docker pull carrotwaxr/peek-stash-browser:latest  # or :beta
+
+# Restart container via unRAID WebGUI or CLI
+docker stop peek-stash-browser && docker start peek-stash-browser
+```
+
+## Semantic Versioning Guide
+
+- **Patch** (3.3.X): Bug fixes, minor tweaks, no new features
+- **Minor** (3.X.0): New features, backward-compatible changes
+- **Major** (X.0.0): Breaking changes (rare — major UI overhauls, API changes)

--- a/.claude/skills/updating-docs/SKILL.md
+++ b/.claude/skills/updating-docs/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: updating-docs
+description: Use when creating or updating documentation in peek-stash-browser. Covers MkDocs conventions, doc structure, API reference generation, and plan document formatting.
+---
+
+# Updating Documentation
+
+## Documentation Stack
+
+- **Engine**: MkDocs with Material theme
+- **Deployment**: GitHub Pages via GitHub Actions (auto on push to main)
+- **API Reference**: Auto-generated from TypeScript source via `server/scripts/generate-api-docs.ts`
+
+## Directory Structure
+
+```
+docs/
+  index.md                      # Landing page
+  getting-started/              # Installation, config, troubleshooting (6 files)
+  user-guide/                   # Feature documentation (14 files)
+  development/                  # Developer docs (4 files)
+  reference/                    # API reference, entity relationships, Docker basics
+  plans/                        # Design docs and implementation plans (~120 files)
+  audits/                       # Documentation audits
+  assets/                       # Images, logos
+  stylesheets/                  # Custom CSS
+  javascripts/                  # Custom JS
+```
+
+## Writing User-Facing Docs
+
+### Page Structure
+
+```markdown
+# Feature Name
+
+Brief description of what this feature does and why it's useful.
+
+## Section Name
+
+Step-by-step instructions or explanation.
+
+### Subsection
+
+More detail as needed.
+
+!!! tip
+    Helpful hint for the user.
+
+!!! warning
+    Important caution about potential issues.
+
+!!! info
+    Additional context or background information.
+```
+
+### Conventions
+
+- **H1**: Page title only (one per page)
+- **H2**: Major sections
+- **H3**: Subsections within a section
+- **Admonitions**: Use `!!! tip`, `!!! warning`, `!!! info`, `!!! note` for callouts
+- **Numbered lists**: For step-by-step procedures
+- **Tables**: For keyboard shortcuts, comparisons, reference data
+- **Cross-links**: Use relative paths: `[Link Text](../user-guide/playlists.md)`
+- **Code blocks**: Always specify language (```bash, ```json, etc.)
+- **Feature location**: Include where to find the feature ("Location: Home page > Settings")
+- **Troubleshooting**: Add a section at the end for common issues
+
+### What Goes Where
+
+| Content | Directory |
+|---------|-----------|
+| How to install/configure | `getting-started/` |
+| How to use a feature | `user-guide/` |
+| How the code works | `development/` |
+| API endpoints, entity models | `reference/` |
+| Feature design before implementation | `plans/` |
+
+## Plan Documents
+
+### Naming Convention
+
+```
+docs/plans/YYYY-MM-DD-feature-name-type.md
+```
+
+Types:
+- `-design.md` — Problem statement, proposed solution, architecture decisions
+- `-plan.md` — Task-by-task implementation steps
+- `-impl.md` or `-implementation.md` — Detailed implementation notes
+
+### Design Document Template
+
+```markdown
+# Feature Name
+
+## Objective
+Brief statement of what we're building and why.
+
+## Current State
+What exists today, what's missing or broken.
+
+## Solution
+
+### Approach
+High-level description of the solution.
+
+### Changes
+#### File: `path/to/file.ts`
+- Description of changes with code context
+
+## Files Affected
+- `path/to/file.ts` — description
+```
+
+### Implementation Plan Template
+
+```markdown
+# Feature Name — Implementation Plan
+
+## Goal
+One-line goal.
+
+## Architecture
+Brief architecture summary.
+
+---
+
+### Task 1: Task Title
+
+**Files:**
+- Modify: `path/to/file.ts`
+- Create: `path/to/new-file.ts`
+
+**Steps:**
+1. Step description
+2. Step description
+
+**Verification:** `npm test` or manual check description.
+
+---
+
+### Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Task title | file.ts |
+```
+
+## API Reference
+
+The API reference at `docs/reference/api-reference.md` is **auto-generated**. Do not edit it manually.
+
+### Regenerating
+
+```bash
+cd server && npm run generate-api-docs
+```
+
+This parses route files, controller implementations, and TypeScript type definitions to generate the reference. It runs automatically in CI when relevant source files change.
+
+### Triggers for Auto-Rebuild
+
+The docs GitHub Action rebuilds when these paths change:
+- `docs/**`
+- `mkdocs.yml`
+- `server/routes/**`
+- `server/types/api/**`
+- `server/controllers/**`
+- `server/scripts/**`
+
+## Redirects
+
+When moving a doc to a new path, add a redirect in `mkdocs.yml`:
+
+```yaml
+plugins:
+  - redirects:
+      redirect_maps:
+        'old/path.md': 'new/path.md'
+```
+
+## Local Preview
+
+```bash
+pip install mkdocs-material mkdocs-minify-plugin mkdocs-redirects
+mkdocs serve
+```
+
+Site available at `http://localhost:8000`.

--- a/.claude/skills/visual-style/SKILL.md
+++ b/.claude/skills/visual-style/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: visual-style
+description: Use when creating or modifying UI components, styling, themes, or layouts in peek-stash-browser. Follow these visual conventions exactly.
+---
+
+# Visual Style Guide
+
+## Color System
+
+Colors are defined as CSS custom properties, set by the theme provider. Never use hardcoded colors.
+
+### Core Variables
+
+```css
+--bg-primary          /* Page background (#0a0a0b dark) */
+--bg-secondary        /* Nav, buttons, controls (#1d1d20) */
+--bg-card             /* Cards, modals (#19191b) */
+--bg-tertiary         /* Skeleton loaders, subtle backgrounds */
+--text-primary        /* Main text (white) */
+--text-secondary      /* Secondary text (15% dimmer) */
+--text-muted          /* De-emphasized text (30% dimmer) */
+--accent-primary      /* Primary accent (theme-dependent) */
+--accent-secondary    /* Secondary accent */
+--border-color        /* Borders (#2a2a32) */
+--focus-ring-color    /* Keyboard focus ring */
+--focus-ring-shadow   /* Focus ring shadow */
+--selection-color     /* Hover/selection outlines */
+--selection-bg        /* Selection background (10% accent) */
+```
+
+### Status Colors
+
+```css
+--status-success: #0F7173    /* Teal */
+--status-error: #FD6B86      /* Pink */
+--status-info: #3993DD       /* Blue */
+--status-warning: #FA8C2A    /* Orange */
+/* Each has -bg (10% opacity) and -border (30% opacity) variants */
+```
+
+### Themes
+
+Five built-in themes defined in `client/src/themes/themes.js`. Custom themes supported via API. All themes use the same CSS variable interface, only values change.
+
+## Tailwind Patterns
+
+### Breakpoints
+
+Standard Tailwind plus custom large-screen breakpoints:
+
+| Breakpoint | Width | Use |
+|-----------|-------|-----|
+| `sm` | 640px | Small tablets |
+| `md` | 768px | Tablets |
+| `lg` | 1024px | Desktop |
+| `xl` | 1280px | Large desktop |
+| `2xl` | 1536px | Wide monitors |
+| `3xl` | 1920px | Full HD |
+| `4xl` | 2560px | QHD/1440p |
+| `5xl` | 3840px | 4K UHD |
+
+### Common Class Patterns
+
+```jsx
+// Card container
+"flex flex-col rounded-lg border p-2"
+style={{ backgroundColor: "var(--bg-card)", borderColor: "var(--border-color)" }}
+
+// Hover effects on cards
+"hover:shadow-lg hover:scale-[1.02] transition-all"
+
+// Card outlines on hover
+"hover:outline hover:outline-2 hover:outline-[var(--selection-color)] hover:outline-offset-2"
+
+// Text styling
+"text-primary"  /* var(--text-primary) */
+"text-secondary" /* var(--text-secondary) */
+"text-muted"    /* var(--text-muted) */
+
+// Buttons
+"btn"           /* Base: p-2 px-4 rounded-lg border transition-all 0.2s */
+"btn-primary"   /* Accent bg, white text, opacity hover */
+```
+
+## Grid System
+
+### Grid Densities
+
+Three density levels (small/medium/large) with responsive column counts. Defined in `client/src/constants/grids.js`.
+
+**Standard grid (performers, studios, tags)** — uses `sm:` breakpoint:
+
+| Density | base | sm | lg | xl | 2xl | 3xl | 4xl | 5xl |
+|---------|------|-----|-----|-----|------|------|------|------|
+| Small | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 14 |
+| Medium | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 12 |
+| Large | 1 | 2 | 2 | 3 | 3 | 4 | 5 | 8 |
+
+**Scene grid** (uses `md:` breakpoint, different column counts for 16:9):
+
+| Density | base | md | lg | xl | 2xl | 3xl | 4xl | 5xl |
+|---------|------|-----|-----|-----|------|------|------|------|
+| Small | 2 | 3 | 4 | 5 | 6 | 7 | 9 | 12 |
+| Medium | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 10 |
+| Large | 1 | 2 | 2 | 3 | 3 | 4 | 5 | 6 |
+
+Grid gap is always `gap-4` (1rem).
+
+### Card Density Scaling
+
+CSS custom properties scale text and spacing per density. Applied via `density-{level}` class on the grid container.
+
+| Property | Small | Medium | Large |
+|----------|-------|--------|-------|
+| `--card-title-size` | 13px | 15px | 16px |
+| `--card-subtitle-size` | 12px | 13px | 14px |
+| `--card-padding` | 6px | 8px | 10px |
+| `--card-image-margin` | 8px | 12px | 14px |
+| `--card-rating-icon-size` | 14px | 18px | 20px |
+
+## Card Component Architecture
+
+Cards use a composable primitive system defined in `client/src/components/ui/CardComponents.jsx`:
+
+```
+CardContainer          - Outer wrapper (border, bg, hover effects)
+  CardImage            - Aspect-ratio image with lazy loading
+  CardTitle            - MarqueeText with auto-scroll on overflow
+  CardSubtitle         - Secondary text line
+  CardDescription      - ExpandableDescription (3-line clamp default)
+  CardIndicators       - Relationship counts (performers, tags, etc.)
+  CardRatingRow        - Rating + O-counter + favorite + menu
+  CardMenuRow          - Entity-specific action buttons
+```
+
+`BaseCard` in `client/src/components/ui/BaseCard.jsx` composes these primitives via render slots. Entity-specific cards (SceneCard, PerformerCard, etc.) pass their content to BaseCard.
+
+### Aspect Ratios by Entity
+
+| Entity | Ratio | CSS |
+|--------|-------|-----|
+| Scene | 16:9 | `aspect-[16/9]` |
+| Performer | 2:3 | `aspect-[2/3]` |
+| Gallery | 3:4 | `aspect-[3/4]` |
+| Studio | 16:9 | `aspect-[16/9]` |
+| Tag | 16:9 | `aspect-[16/9]` |
+
+## Animation & Transitions
+
+### Standard Transitions
+
+- Card hover: `transition-all 0.2s ease`
+- Button states: `transition-all 0.15s ease`
+
+### Keyboard Focus
+
+```css
+.keyboard-focus {
+  outline: 3px solid var(--focus-ring-color);
+  box-shadow: var(--focus-ring-shadow), 0 8px 24px rgba(0,0,0,0.4);
+  transform: scale(1.05);
+  z-index: 10;
+}
+```
+
+Pulse animation on focused card (2s infinite, subtle scale 1.0-1.02).
+
+### Mouse vs Keyboard
+
+```css
+.mouse-user *:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+```
+
+Focus rings only show for keyboard/TV navigation, not mouse clicks.
+
+### MarqueeText
+
+Card titles auto-scroll when text overflows on hover. Implementation in `client/src/components/ui/MarqueeText.jsx`:
+- Speed: ~30px/second
+- Pauses at start (15%) and end (25%)
+- Respects `prefers-reduced-motion`
+- GPU-accelerated via `translate3d`
+
+### Loading Skeletons
+
+```jsx
+<div className="animate-pulse rounded-lg" style={{
+  backgroundColor: "var(--bg-tertiary)",
+  height: "20rem"  // scene cards, 24rem for standard
+}} />
+```
+
+## Keyboard Navigation
+
+The app supports full TV/remote navigation with spatial awareness:
+
+- **Zones**: search, topPagination, grid, bottomPagination, mainNav
+- **Focus class**: `keyboard-focus` on the active element
+- **tabIndex**: 0 for focused element, -1 for all others
+- **Arrow keys**: Spatial navigation within grid
+- **Enter/Space**: Select/navigate
+- **Escape**: Move between zones
+
+## Layout Patterns
+
+### Page Structure
+
+```jsx
+<PageLayout>
+  <PageHeader />           {/* Title, search, filter controls */}
+  <GridLayout>             {/* Or BaseGrid */}
+    <EntityCard />          {/* Repeated per item */}
+  </GridLayout>
+  <Pagination />
+</PageLayout>
+```
+
+### Containers
+
+| Class | Behavior |
+|-------|----------|
+| `.layout-container` | Full viewport width |
+| `.container` | 0.25rem padding mobile, 1rem desktop |
+| `.container-fluid` | Full width + responsive padding |
+| `.container-constrained` | Max 1400px + responsive padding |
+
+## Rules
+
+1. **Never hardcode colors** — always use CSS custom properties
+2. **Never skip breakpoints** — always include 3xl/4xl/5xl for large displays
+3. **Use density variables** for text sizing — never hardcode font sizes in cards
+4. **Respect focus patterns** — keyboard-focus class, not custom focus styles
+5. **Use CardComponents primitives** — don't create new card layouts from scratch
+6. **Images lazy load** via IntersectionObserver — never eager-load grid images
+7. **Transitions are 0.2s ease** — don't use longer or different easing
+8. **Status colors are fixed** — success=teal, error=pink, info=blue, warning=orange

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: writing-tests
+description: Use when writing tests for peek-stash-browser. Covers Vitest + React Testing Library (client) and Vitest + integration testing (server). Follow these conventions exactly.
+---
+
+# Writing Tests for Peek
+
+## Stack
+
+- **Framework**: Vitest 3.x (both client and server)
+- **Client**: React Testing Library 16.x, happy-dom, @testing-library/user-event
+- **Server unit**: Vitest in node environment, sequential execution
+- **Server integration**: Real HTTP client against live server + Stash test instance
+
+## Client Tests
+
+### Location & Naming
+
+Tests live in `client/tests/` mirroring the source structure:
+
+```
+client/tests/
+  components/ui/       # UI component tests
+  components/cards/    # Card component tests
+  components/timeline/ # Timeline tests
+  hooks/               # Hook tests
+  utils/               # Utility function tests
+  integration/         # Integration tests
+  mocks/               # Mock providers
+  mockData.js          # Shared test data factories
+  testUtils.jsx        # Shared rendering helpers
+  setup.js             # Global browser API mocks
+```
+
+File naming: `ComponentName.test.jsx` or `hookName.test.js`
+
+### Test Structure
+
+```jsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("ComponentName", () => {
+  const defaultProps = { /* ... */ };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("renders with correct aria-label", () => {
+      render(<Component {...defaultProps} />);
+      expect(screen.getByRole("option")).toHaveAttribute("aria-label", "expected");
+    });
+  });
+
+  describe("Interactions", () => {
+    it("calls onClick when clicked", async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(<Component {...defaultProps} onClick={onClick} />);
+      await user.click(screen.getByRole("button"));
+      expect(onClick).toHaveBeenCalledWith("expected-arg");
+    });
+  });
+});
+```
+
+### Key Conventions
+
+- **Query priority**: `getByRole` > `getByText` > `getByTestId` (accessibility-first)
+- **User events**: Always use `userEvent.setup()`, not `fireEvent`
+- **Async**: Use `await user.click()`, `waitFor()`, and `act()` properly
+- **Mock callbacks**: `vi.fn()` for all callback props
+- **Group by behavior**: Nest `describe()` blocks by "Rendering", "Interactions", "Edge Cases"
+- **Clear mocks**: `vi.clearAllMocks()` in `beforeEach()`
+
+### Test Data Factories (`mockData.js`)
+
+```javascript
+import { createScene, createPerformer, createStudio, resetIdCounter } from "@tests/mockData";
+
+// Factory with overrides
+const scene = createScene({ title: "Custom Title", rating100: 85 });
+const performer = createPerformer({ name: "Jane", gender: "FEMALE" });
+
+// Reset counters between test suites
+beforeEach(() => resetIdCounter());
+```
+
+### Rendering Helpers (`testUtils.jsx`)
+
+```jsx
+import { renderWithProviders, createMockApi, flushPromises } from "@tests/testUtils";
+
+// Render with router context
+renderWithProviders(<Component />, { route: "/scenes/123" });
+
+// Mock API for components that fetch
+const mockApi = createMockApi();
+```
+
+### Hook Tests
+
+```javascript
+import { renderHook, act } from "@testing-library/react";
+
+it("updates when input changes", () => {
+  const { result, rerender } = renderHook(
+    ({ query }) => useMyHook(query),
+    { initialProps: { query: "initial" } }
+  );
+  expect(result.current).toBe(expectedInitial);
+
+  rerender({ query: "updated" });
+  expect(result.current).toBe(expectedUpdated);
+});
+```
+
+### Path Aliases
+
+```javascript
+import Component from "@/components/Component";  // src/
+import { mockData } from "@tests/mockData";       // tests/
+```
+
+### What's Mocked Globally (setup.js)
+
+- `window.matchMedia` - returns `{ matches: false }`
+- `IntersectionObserver` - no-op observe/unobserve
+- `ResizeObserver` - no-op observe/unobserve
+- `Element.scrollIntoView` - no-op
+
+## Server Unit Tests
+
+### Location & Naming
+
+```
+server/tests/
+  services/          # Service logic
+  filters/           # Filter logic
+  controllers/       # Controller tests
+  routes/            # Route tests
+  middleware/        # Middleware tests
+  schemas/           # Schema validation
+  helpers/           # Test utilities
+    mockDataGenerators.ts
+```
+
+File naming: `ServiceName.test.ts`
+
+### Mocking Prisma
+
+```typescript
+// Mock BEFORE importing the service under test
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    user: { findUnique: vi.fn(), findMany: vi.fn() },
+    scene: { findFirst: vi.fn(), count: vi.fn() },
+  },
+}));
+
+import { myService } from "../../services/MyService.js";
+import prisma from "../../prisma/singleton.js";
+const mockPrisma = vi.mocked(prisma);
+```
+
+### Key Conventions
+
+- **Sequential execution**: `fileParallelism: false` prevents DB conflicts
+- **Mock before import**: Always `vi.mock()` before importing the module
+- **Typed mocks**: Use `vi.mocked()` for TypeScript type safety
+- **No real DB**: Unit tests never touch SQLite
+
+## Server Integration Tests
+
+### Location & Naming
+
+```
+server/integration/
+  api/               # API endpoint tests
+  services/          # Service integration tests
+  helpers/
+    globalSetup.ts   # One-time server startup + migration + sync
+    testClient.ts    # HTTP client with auth
+    testSetup.ts     # Ensure admin user exists
+  fixtures/
+    testEntities.ts  # Test instance entity IDs (git-ignored, copy from .example)
+```
+
+File naming: `feature-name.integration.test.ts`
+
+### TestClient Pattern
+
+```typescript
+import { adminClient, TestClient } from "../helpers/testClient.js";
+
+// Admin is pre-authenticated via globalSetup
+const response = await adminClient.get<{ users: User[] }>("/api/user/all");
+expect(response.ok).toBe(true);
+expect(response.status).toBe(200);
+
+// Create per-test user clients
+const userClient = new TestClient();
+await userClient.login("username", "password");
+```
+
+### Integration Test Structure
+
+```typescript
+describe("Feature Integration Tests", () => {
+  let testUserId: number;
+
+  beforeAll(async () => {
+    // Create test data via API
+    const res = await adminClient.post("/api/user/create", { ... });
+    testUserId = res.data.user.id;
+  });
+
+  afterAll(async () => {
+    // Cleanup test data
+    await adminClient.delete(`/api/user/${testUserId}`);
+  });
+
+  it("should return 403 for unauthorized access", async () => {
+    const response = await guestClient.get("/api/admin/endpoint");
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(403);
+  });
+});
+```
+
+### Running Integration Tests
+
+Requires `.env` with `STASH_TEST_URL` and `STASH_TEST_API_KEY` pointing to test instance (port 6971).
+
+```bash
+npm run test:integration          # Standard run
+npm run test:integration:fresh    # Fresh database (FRESH_DB=true)
+npm run test:integration:watch    # Watch mode
+```
+
+## Running Tests
+
+```bash
+# Client
+cd client && npm test             # Watch mode
+cd client && npm run test:run     # Single run
+cd client && npm run test:coverage
+
+# Server unit
+cd server && npm test
+cd server && npm run test:run
+
+# Server integration
+cd server && npm run test:integration
+```


### PR DESCRIPTION
## Summary
- Rewrote CLAUDE.md to reflect current architecture (multi-instance support, StashClient, proxy streaming, correct file paths and model listings)
- Committed 4 previously-untracked project skills (release-workflow, updating-docs, visual-style, writing-tests)
- Removed obsolete `publish-peek` global skill that conflicted with new release workflow

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm skills load in a new Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)