### PR TITLE
Fix lightbox pagination, fullscreen sizing, and drawer positioning

### DIFF
--- a/client/src/components/pages/GalleryDetail.jsx
+++ b/client/src/components/pages/GalleryDetail.jsx
@@ -439,6 +439,7 @@ const GalleryDetail = () => {
         pageOffset={lightbox.pageOffset}
         onIndexChange={lightbox.onIndexChange}
         isPageTransitioning={lightbox.isPageTransitioning}
+        transitionKey={lightbox.transitionKey}
         prefetchImages={lightbox.prefetchImages}
       />
     </div>

--- a/client/src/components/pages/Images.jsx
+++ b/client/src/components/pages/Images.jsx
@@ -389,6 +389,7 @@ const Images = () => {
             pageOffset={pageOffset}
             onIndexChange={lightbox.onIndexChange}
             isPageTransitioning={lightbox.isPageTransitioning}
+            transitionKey={lightbox.transitionKey}
           />
         )}
       </div>

--- a/client/src/components/ui/Lightbox.jsx
+++ b/client/src/components/ui/Lightbox.jsx
@@ -23,6 +23,7 @@ const Lightbox = ({
   pageOffset = 0, // Offset of current page (e.g., page 2 with 100/page = 100)
   onIndexChange, // (index: number) => void - called when current index changes (for syncing with parent)
   isPageTransitioning = false, // Whether we're loading a new page (show loading state, hide current image)
+  transitionKey = 0, // Increments on each page boundary crossing to force index reset
   prefetchImages = [], // Images from adjacent pages to prefetch into browser cache
 }) => {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
@@ -47,13 +48,15 @@ const Lightbox = ({
   });
   const controlsTimeoutRef = useRef(null);
 
-  // Reset index when initialIndex changes OR when lightbox opens
+  // Reset index when initialIndex changes, lightbox opens, or page transition occurs.
+  // transitionKey ensures this fires even when initialIndex is the same value
+  // (e.g., 0 on consecutive forward page boundary crossings).
   useEffect(() => {
     if (isOpen) {
       setCurrentIndex(initialIndex);
       setImageLoaded(false);
     }
-  }, [initialIndex, isOpen]);
+  }, [initialIndex, isOpen, transitionKey]);
 
   // Track the current image ID to detect when images array changes during page transitions
   const currentImageId = images[currentIndex]?.id;
@@ -681,17 +684,17 @@ const Lightbox = ({
       {/* Image container - swipe handlers here so they don't block button taps on letterbox areas */}
       <div
         {...swipeHandlers}
-        className="relative max-w-[90vw] max-h-[90vh] flex items-center justify-center"
+        className="relative w-[90vw] h-[90vh] flex items-center justify-center"
         onClick={(e) => e.stopPropagation()}
         style={{
           visibility: isPageTransitioning || isShowingStaleImage ? "hidden" : "visible",
         }}
       >
-        {/* Image */}
+        {/* Image - scales down to fit but never up beyond native resolution */}
         <img
           src={imageSrc}
           alt={imageTitle}
-          className="max-w-full max-h-[90vh] object-contain"
+          className="max-w-full max-h-full object-contain"
           style={{
             opacity: imageLoaded ? 1 : 0,
             transition: "opacity 0.2s ease-in-out",

--- a/client/src/components/ui/PaginatedImageGrid.jsx
+++ b/client/src/components/ui/PaginatedImageGrid.jsx
@@ -114,6 +114,7 @@ const PaginatedImageGrid = ({
         pageOffset={lightbox.pageOffset}
         onIndexChange={lightbox.onIndexChange}
         isPageTransitioning={lightbox.isPageTransitioning}
+        transitionKey={lightbox.transitionKey}
         prefetchImages={lightbox.prefetchImages}
       />
     </>

--- a/client/src/hooks/usePaginatedLightbox.js
+++ b/client/src/hooks/usePaginatedLightbox.js
@@ -35,6 +35,10 @@ export function usePaginatedLightbox({
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [lightboxAutoPlay, setLightboxAutoPlay] = useState(false);
   const [isPageTransitioning, setIsPageTransitioning] = useState(false);
+  // Counter that increments on each page boundary crossing.
+  // Ensures Lightbox resets currentIndex even when lightboxIndex is the same value
+  // (e.g., 0 on consecutive forward crossings).
+  const [transitionKey, setTransitionKey] = useState(0);
 
   // Prefetch state for adjacent pages
   const [prevPageImages, setPrevPageImages] = useState([]);
@@ -76,6 +80,7 @@ export function usePaginatedLightbox({
         // User navigated past last image on current page - load next page
         const targetIndex = 0; // First image of next page
         setLightboxIndex(targetIndex); // Update immediately to prevent counter flicker
+        setTransitionKey((k) => k + 1); // Force Lightbox to reset even if index unchanged
         setIsPageTransitioning(true); // Show loading state until new data arrives
         pendingLightboxNav.current = targetIndex; // Also store for data callback
         handlePageChange(currentPage + 1);
@@ -84,6 +89,7 @@ export function usePaginatedLightbox({
         // User navigated before first image on current page - load previous page
         const targetIndex = perPage - 1; // Last image of previous page
         setLightboxIndex(targetIndex); // Update immediately to prevent counter flicker
+        setTransitionKey((k) => k + 1); // Force Lightbox to reset even if index unchanged
         setIsPageTransitioning(true); // Show loading state until new data arrives
         pendingLightboxNav.current = targetIndex; // Also store for data callback
         handlePageChange(currentPage - 1);
@@ -194,6 +200,7 @@ export function usePaginatedLightbox({
     lightboxIndex,
     lightboxAutoPlay,
     isPageTransitioning,
+    transitionKey,
 
     // Lightbox handlers
     openLightbox,

--- a/client/tests/components/ui/Lightbox.test.jsx
+++ b/client/tests/components/ui/Lightbox.test.jsx
@@ -229,7 +229,7 @@ describe("Lightbox", () => {
       );
 
       // Find the image container div (has visibility style)
-      const imageContainer = container.querySelector(".max-w-\\[90vw\\]");
+      const imageContainer = container.querySelector(".w-\\[90vw\\]");
       expect(imageContainer.style.visibility).toBe("visible");
 
       // Now transition
@@ -301,7 +301,7 @@ describe("Lightbox", () => {
       expect(getImgSrc()).toBe("http://example.com/page1/image0.jpg");
 
       // Verify container is hidden
-      const imageContainer = container.querySelector(".max-w-\\[90vw\\]");
+      const imageContainer = container.querySelector(".w-\\[90vw\\]");
       expect(imageContainer.style.visibility).toBe("hidden");
     });
 
@@ -332,7 +332,7 @@ describe("Lightbox", () => {
 
       const getImgSrc = () => container.querySelector("img")?.getAttribute("src");
       const getVisibility = () =>
-        container.querySelector(".max-w-\\[90vw\\]")?.style.visibility;
+        container.querySelector(".w-\\[90vw\\]")?.style.visibility;
 
       expect(getImgSrc()).toBe("http://example.com/page1/image9.jpg");
 


### PR DESCRIPTION
## Summary
- Fix lightbox skipping entire pages when crossing multiple page boundaries during image browsing
- Make images fill available viewport space in fullscreen mode (large images scale to fit, small images stay sharp at native resolution)
- Info drawer now opens on the right side on landscape/desktop screens and from the bottom on portrait/mobile

## Notes
Pagination fix uses a transition counter to force React state sync when the target index value is unchanged across consecutive page crossings. Drawer orientation uses `matchMedia` for efficient change detection, consistent with existing hover detection pattern.