### PR TITLE
feat: improve stats freshness and add info tooltips

### DIFF
--- a/client/src/components/pages/Recommended.jsx
+++ b/client/src/components/pages/Recommended.jsx
@@ -5,12 +5,43 @@ import { useInitialFocus } from "../../hooks/useFocusTrap.js";
 import { usePageTitle } from "../../hooks/usePageTitle.js";
 import { useTVMode } from "../../hooks/useTVMode.js";
 import SceneGrid from "../scene-search/SceneGrid.jsx";
+import { Info } from "lucide-react";
 import {
   SyncProgressBanner,
   PageHeader,
   PageLayout,
   Pagination,
+  Tooltip,
 } from "../ui/index.js";
+
+const RecommendationInfoContent = () => (
+  <div className="text-sm max-w-sm">
+    <p className="mb-2">
+      Scenes are scored based on your ratings, favorites, and watch history.
+    </p>
+    <p className="mb-1">
+      <span className="font-medium">Explicit signals</span> &mdash; Performers,
+      studios, and tags you&apos;ve rated 80+ or favorited contribute the most
+      weight. Performers are weighted heaviest (5&times;), then studios
+      (3&times;), then tags (1&times;).
+    </p>
+    <p className="mb-1">
+      <span className="font-medium">Implicit signals</span> &mdash; Your
+      top-engaged entities (top 50% by engagement rank) also contribute, weighted
+      by how strongly you engage with them.
+    </p>
+    <p className="mb-1">
+      <span className="font-medium">Freshness</span> &mdash; Unwatched scenes
+      get a +30 boost. Scenes watched over 14 days ago get +20. Recently watched
+      scenes are deprioritized.
+    </p>
+    <p>
+      <span className="font-medium">Diversity</span> &mdash; Scores are grouped
+      into tiers and shuffled within each tier daily, so you see variety even
+      among similarly-scored scenes.
+    </p>
+  </div>
+);
 
 const Recommended = () => {
   usePageTitle("Recommended");
@@ -200,10 +231,20 @@ const Recommended = () => {
   return (
     <PageLayout>
       <div ref={pageRef}>
-        <PageHeader
-          title="Recommended"
-          subtitle="Personalized recommendations based on your favorites and ratings"
-        />
+        <div className="flex items-start gap-2">
+          <PageHeader
+            title="Recommended"
+            subtitle="Personalized recommendations based on your favorites and ratings"
+          />
+          <Tooltip content={<RecommendationInfoContent />} position="bottom">
+            <button
+              className="p-1 mt-1 rounded-full hover:bg-[var(--bg-secondary)] transition-colors"
+              aria-label="How recommendations work"
+            >
+              <Info size={18} style={{ color: "var(--text-muted)" }} />
+            </button>
+          </Tooltip>
+        </div>
 
         {initMessage && <SyncProgressBanner message={initMessage} />}
 

--- a/client/src/components/pages/UserStats/UserStats.jsx
+++ b/client/src/components/pages/UserStats/UserStats.jsx
@@ -1,7 +1,7 @@
 // client/src/components/pages/UserStats/UserStats.jsx
 
 import { useState } from "react";
-import { BarChart3, Info } from "lucide-react";
+import { BarChart3, Info, RefreshCw } from "lucide-react";
 import { usePageTitle } from "../../../hooks/usePageTitle.js";
 import { useUserStats } from "../../../hooks/useUserStats.js";
 import { PageHeader, PageLayout, LoadingSpinner, Tooltip } from "../../ui/index.js";
@@ -13,22 +13,75 @@ import {
 } from "./components/index.js";
 
 /**
- * Info content explaining sort options
+ * Section info tooltip: wraps content with consistent sizing
  */
-const SortInfoContent = () => (
+const SectionInfo = ({ children, position = "right" }) => (
+  <Tooltip content={children} position={position}>
+    <button
+      className="p-1 rounded-full hover:bg-[var(--bg-secondary)] transition-colors"
+      aria-label="Info"
+    >
+      <Info size={16} style={{ color: "var(--text-muted)" }} />
+    </button>
+  </Tooltip>
+);
+
+const LibraryInfoContent = () => (
   <div className="text-sm max-w-xs">
-    <p className="font-semibold mb-2">Sort Options</p>
-    <ul className="space-y-2">
+    <p>
+      Total counts of each entity type cached from your connected Stash
+      instances. Updated when Peek syncs with Stash (default: every 60 minutes).
+    </p>
+  </div>
+);
+
+const EngagementInfoContent = () => (
+  <div className="text-sm max-w-xs">
+    <p>
+      Aggregated from your watch and browsing history across all instances.
+      Watch time and play counts update in real-time as you watch. O-count
+      updates when you tap the O button.
+    </p>
+  </div>
+);
+
+const TopContentInfoContent = () => (
+  <div className="text-sm max-w-xs">
+    <p className="mb-2">
+      Entities ranked by your personal engagement. Engagement score = (O-count
+      &times; 5) + watch duration + play count, divided by how often the entity
+      appears in your library.
+    </p>
+    <p className="mb-2">
+      Percentile rank shows where each entity falls among all your engaged
+      entities (100 = top, 0 = bottom). Rankings refresh on login and
+      periodically while browsing.
+    </p>
+    <p className="font-semibold mb-1">Sort Options</p>
+    <ul className="space-y-1">
       <li>
-        <span className="font-medium">Engagement:</span> Percentile rank combining O-count (weighted 5x), watch duration, and play count, normalized by how often you see this content.
+        <span className="font-medium">Engagement:</span> Percentile rank as
+        described above.
       </li>
       <li>
-        <span className="font-medium">O-Count:</span> Total Os recorded for scenes featuring this entity.
+        <span className="font-medium">O-Count:</span> Total Os for scenes
+        featuring this entity.
       </li>
       <li>
-        <span className="font-medium">Play Count:</span> Total times scenes featuring this entity were played.
+        <span className="font-medium">Play Count:</span> Total plays for scenes
+        featuring this entity.
       </li>
     </ul>
+  </div>
+);
+
+const HighlightsInfoContent = () => (
+  <div className="text-sm max-w-xs">
+    <p>
+      Your single highest-engagement entity in each category, based on raw
+      counts (most plays, most O&apos;s, most views). These update in real-time
+      with your activity.
+    </p>
   </div>
 );
 
@@ -38,7 +91,17 @@ const UserStats = () => {
   // Sort state for top lists - shared across all lists
   const [sortBy, setSortBy] = useState("engagement");
 
-  const { data, loading, error } = useUserStats({ sortBy });
+  const { data, loading, error, refresh } = useUserStats({ sortBy });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await refresh(false);
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -74,21 +137,41 @@ const UserStats = () => {
 
   return (
     <PageLayout fullHeight style={{ backgroundColor: "var(--bg-primary)" }}>
-      <PageHeader
-        title="My Stats"
-        subtitle="Your viewing statistics"
-        icon={<BarChart3 className="w-8 h-8" />}
-      />
+      <div className="flex items-start justify-between">
+        <PageHeader
+          title="My Stats"
+          subtitle="Your viewing statistics"
+          icon={<BarChart3 className="w-8 h-8" />}
+        />
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing || loading}
+          className="p-2 rounded-lg hover:bg-[var(--bg-secondary)] transition-colors disabled:opacity-50"
+          aria-label="Refresh stats"
+          title="Refresh stats"
+        >
+          <RefreshCw
+            size={20}
+            className={refreshing ? "animate-spin" : ""}
+            style={{ color: "var(--text-muted)" }}
+          />
+        </button>
+      </div>
 
       <div className="space-y-8 pb-8">
         {/* Library Overview */}
         <section>
-          <h2
-            className="text-lg font-semibold mb-4"
-            style={{ color: "var(--text-primary)" }}
-          >
-            Library
-          </h2>
+          <div className="flex items-center gap-2 mb-4">
+            <h2
+              className="text-lg font-semibold"
+              style={{ color: "var(--text-primary)" }}
+            >
+              Library
+            </h2>
+            <SectionInfo>
+              <LibraryInfoContent />
+            </SectionInfo>
+          </div>
           <LibraryOverview library={data.library} />
         </section>
 
@@ -96,12 +179,17 @@ const UserStats = () => {
         {hasEngagement ? (
           <>
             <section>
-              <h2
-                className="text-lg font-semibold mb-4"
-                style={{ color: "var(--text-primary)" }}
-              >
-                Engagement
-              </h2>
+              <div className="flex items-center gap-2 mb-4">
+                <h2
+                  className="text-lg font-semibold"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  Engagement
+                </h2>
+                <SectionInfo>
+                  <EngagementInfoContent />
+                </SectionInfo>
+              </div>
               <EngagementTotals
                 engagement={data.engagement}
                 librarySceneCount={data.library.sceneCount}
@@ -117,14 +205,9 @@ const UserStats = () => {
                 >
                   Top Content
                 </h2>
-                <Tooltip content={<SortInfoContent />} position="right">
-                  <button
-                    className="p-1 rounded-full hover:bg-[var(--bg-secondary)] transition-colors"
-                    aria-label="Sort options info"
-                  >
-                    <Info size={16} style={{ color: "var(--text-muted)" }} />
-                  </button>
-                </Tooltip>
+                <SectionInfo>
+                  <TopContentInfoContent />
+                </SectionInfo>
               </div>
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <TopList
@@ -168,12 +251,17 @@ const UserStats = () => {
 
             {/* Highlights */}
             <section>
-              <h2
-                className="text-lg font-semibold mb-4"
-                style={{ color: "var(--text-primary)" }}
-              >
-                Highlights
-              </h2>
+              <div className="flex items-center gap-2 mb-4">
+                <h2
+                  className="text-lg font-semibold"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  Highlights
+                </h2>
+                <SectionInfo>
+                  <HighlightsInfoContent />
+                </SectionInfo>
+              </div>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <HighlightCard
                   title="Most Watched Scene"

--- a/server/controllers/userStats.ts
+++ b/server/controllers/userStats.ts
@@ -5,13 +5,38 @@ import type {
   UserStatsResponse,
 } from "../types/api/index.js";
 import { userStatsAggregationService, type TopListSortBy } from "../services/UserStatsAggregationService.js";
+import rankingComputeService from "../services/RankingComputeService.js";
+import prisma from "../prisma/singleton.js";
 import { logger } from "../utils/logger.js";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
 /**
  * Validate sortBy query parameter
  */
 function isValidSortBy(value: unknown): value is TopListSortBy {
   return value === "engagement" || value === "oCount" || value === "playCount";
+}
+
+/**
+ * Ensure rankings are fresh for the given user.
+ * If rankings are stale (>1 hour) or missing, awaits a full recompute.
+ */
+async function ensureFreshRankings(userId: number): Promise<void> {
+  const lastRanking = await prisma.userEntityRanking.findFirst({
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+    select: { updatedAt: true },
+  });
+
+  const isStale =
+    !lastRanking ||
+    Date.now() - lastRanking.updatedAt.getTime() > ONE_HOUR_MS;
+
+  if (isStale) {
+    logger.info("Rankings stale for user stats, recomputing", { userId });
+    await rankingComputeService.recomputeAllRankings(userId);
+  }
 }
 
 /**
@@ -34,6 +59,9 @@ export async function getUserStats(
     // Parse sortBy query parameter
     const sortByParam = req.query.sortBy;
     const sortBy: TopListSortBy = isValidSortBy(sortByParam) ? sortByParam : "engagement";
+
+    // Ensure rankings are fresh before returning stats
+    await ensureFreshRankings(userId);
 
     const stats = await userStatsAggregationService.getUserStats(userId, { sortBy });
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -8,10 +8,11 @@ import { stashEntityService } from "../services/StashEntityService.js";
 const JWT_SECRET =
   process.env.JWT_SECRET || "your-secret-key-change-in-production";
 
-// Token expires after 24 hours, but we refresh it if older than 20 hours
-// This gives users a 4-hour inactivity window before session expires
-const TOKEN_EXPIRY_HOURS = 24;
-const TOKEN_REFRESH_THRESHOLD_HOURS = 20;
+// Token expires after 2 hours, but we refresh it if older than 1 hour
+// This gives users a 1-hour inactivity window before session expires
+// Active users (making API requests) stay logged in seamlessly
+const TOKEN_EXPIRY_HOURS = 2;
+const TOKEN_REFRESH_THRESHOLD_HOURS = 1;
 
 /**
  * User information attached to request by auth middleware


### PR DESCRIPTION
## Summary
- Session expiry reduced from 24h to 2h (auto-refreshes while active) so ranking recomputes on login actually trigger regularly
- User Stats endpoint now awaits ranking recompute if rankings are >1 hour stale, ensuring fresh data on page load
- Added refresh button to User Stats page header for manual data refresh
- Added info icon tooltips to all 4 User Stats sections (Library, Engagement, Top Content, Highlights) explaining what each metric means and how it's calculated
- Added info icon tooltip to Recommendations page explaining the scoring algorithm (explicit/implicit signals, freshness, diversity)

## Test plan
- [ ] Verify session expires after 2 hours of inactivity (stays alive with active use)
- [ ] Visit User Stats with stale rankings — should see fresh data (may take slightly longer on first load)
- [ ] Click refresh button on User Stats — icon spins, data reloads
- [ ] Hover/click info icons on all 4 User Stats sections — tooltips appear with formula explanations
- [ ] Hover/click info icon on Recommendations page — tooltip explains algorithm
- [ ] Verify tooltips position correctly and don't clip on mobile viewports