### PR TITLE
fix: prevent multi-instance stats corruption from ID collisions

### DIFF
--- a/server/controllers/library/galleries.ts
+++ b/server/controllers/library/galleries.ts
@@ -37,9 +37,10 @@ async function mergeGalleriesWithUserData(
 ): Promise<NormalizedGallery[]> {
   const ratings = await prisma.galleryRating.findMany({ where: { userId } });
 
+  const KEY_SEP = "\0";
   const ratingMap = new Map(
     ratings.map((r) => [
-      r.galleryId,
+      `${r.galleryId}${KEY_SEP}${r.instanceId || ""}`,
       {
         rating: r.rating,
         rating100: r.rating,
@@ -53,7 +54,7 @@ async function mergeGalleriesWithUserData(
     rating: null,
     rating100: null,
     favorite: false,
-    ...ratingMap.get(gallery.id),
+    ...ratingMap.get(`${gallery.id}${KEY_SEP}${(gallery as any).instanceId || ""}`),
   }));
 }
 
@@ -66,9 +67,10 @@ async function mergeImagesWithUserData(
 ): Promise<any[]> {
   const ratings = await prisma.imageRating.findMany({ where: { userId } });
 
+  const KEY_SEP = "\0";
   const ratingMap = new Map(
     ratings.map((r) => [
-      r.imageId,
+      `${r.imageId}${KEY_SEP}${r.instanceId || ""}`,
       {
         rating: r.rating,
         rating100: r.rating,
@@ -79,7 +81,7 @@ async function mergeImagesWithUserData(
 
   return images.map((image) => ({
     ...image,
-    ...ratingMap.get(image.id),
+    ...ratingMap.get(`${image.id}${KEY_SEP}${image.instanceId || ""}`),
   }));
 }
 

--- a/server/controllers/library/images.ts
+++ b/server/controllers/library/images.ts
@@ -31,9 +31,10 @@ async function mergeImagesWithUserData(
     prisma.imageViewHistory.findMany({ where: { userId } }),
   ]);
 
+  const KEY_SEP = "\0";
   const ratingMap = new Map(
     ratings.map((r) => [
-      r.imageId,
+      `${r.imageId}${KEY_SEP}${r.instanceId || ""}`,
       {
         rating: r.rating,
         rating100: r.rating,
@@ -44,7 +45,7 @@ async function mergeImagesWithUserData(
 
   const viewHistoryMap = new Map(
     viewHistories.map((vh) => [
-      vh.imageId,
+      `${vh.imageId}${KEY_SEP}${vh.instanceId || ""}`,
       {
         oCounter: vh.oCount,
         viewCount: vh.viewCount,
@@ -59,8 +60,8 @@ async function mergeImagesWithUserData(
     favorite: false,
     oCounter: 0,
     viewCount: 0,
-    ...ratingMap.get(image.id),
-    ...viewHistoryMap.get(image.id),
+    ...ratingMap.get(`${image.id}${KEY_SEP}${image.instanceId || ""}`),
+    ...viewHistoryMap.get(`${image.id}${KEY_SEP}${image.instanceId || ""}`),
   }));
 }
 

--- a/server/services/EntityImageCountService.ts
+++ b/server/services/EntityImageCountService.ts
@@ -68,20 +68,21 @@ class EntityImageCountService {
       SET imageCount = COALESCE((
         SELECT COUNT(DISTINCT imageId) FROM (
           -- Direct: image has performer directly
-          SELECT ip.imageId, ip.performerId
+          SELECT ip.imageId, ip.performerId, ip.performerInstanceId
           FROM ImagePerformer ip
-          JOIN StashImage si ON ip.imageId = si.id AND si.deletedAt IS NULL
+          JOIN StashImage si ON ip.imageId = si.id AND ip.imageInstanceId = si.stashInstanceId AND si.deletedAt IS NULL
 
           UNION
 
           -- Inherited: image is in gallery that has performer
-          SELECT ig.imageId, gp.performerId
+          SELECT ig.imageId, gp.performerId, gp.performerInstanceId
           FROM ImageGallery ig
-          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
-          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL
-          JOIN GalleryPerformer gp ON ig.galleryId = gp.galleryId
+          JOIN StashImage si ON ig.imageId = si.id AND ig.imageInstanceId = si.stashInstanceId AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND ig.galleryInstanceId = sg.stashInstanceId AND sg.deletedAt IS NULL
+          JOIN GalleryPerformer gp ON ig.galleryId = gp.galleryId AND ig.galleryInstanceId = gp.galleryInstanceId
         ) AS combined
         WHERE combined.performerId = StashPerformer.id
+          AND combined.performerInstanceId = StashPerformer.stashInstanceId
       ), 0)
       WHERE StashPerformer.deletedAt IS NULL
     `;
@@ -102,19 +103,20 @@ class EntityImageCountService {
       SET imageCount = COALESCE((
         SELECT COUNT(DISTINCT imageId) FROM (
           -- Direct: image has studio directly
-          SELECT si.id AS imageId, si.studioId
+          SELECT si.id AS imageId, si.studioId, si.stashInstanceId AS studioInstanceId
           FROM StashImage si
           WHERE si.deletedAt IS NULL AND si.studioId IS NOT NULL
 
           UNION
 
           -- Inherited: image is in gallery that has studio
-          SELECT ig.imageId, sg.studioId
+          SELECT ig.imageId, sg.studioId, sg.stashInstanceId AS studioInstanceId
           FROM ImageGallery ig
-          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
-          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL AND sg.studioId IS NOT NULL
+          JOIN StashImage si ON ig.imageId = si.id AND ig.imageInstanceId = si.stashInstanceId AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND ig.galleryInstanceId = sg.stashInstanceId AND sg.deletedAt IS NULL AND sg.studioId IS NOT NULL
         ) AS combined
         WHERE combined.studioId = StashStudio.id
+          AND combined.studioInstanceId = StashStudio.stashInstanceId
       ), 0)
       WHERE StashStudio.deletedAt IS NULL
     `;
@@ -135,20 +137,21 @@ class EntityImageCountService {
       SET imageCount = COALESCE((
         SELECT COUNT(DISTINCT imageId) FROM (
           -- Direct: image has tag directly
-          SELECT it.imageId, it.tagId
+          SELECT it.imageId, it.tagId, it.tagInstanceId
           FROM ImageTag it
-          JOIN StashImage si ON it.imageId = si.id AND si.deletedAt IS NULL
+          JOIN StashImage si ON it.imageId = si.id AND it.imageInstanceId = si.stashInstanceId AND si.deletedAt IS NULL
 
           UNION
 
           -- Inherited: image is in gallery that has tag
-          SELECT ig.imageId, gt.tagId
+          SELECT ig.imageId, gt.tagId, gt.tagInstanceId
           FROM ImageGallery ig
-          JOIN StashImage si ON ig.imageId = si.id AND si.deletedAt IS NULL
-          JOIN StashGallery sg ON ig.galleryId = sg.id AND sg.deletedAt IS NULL
-          JOIN GalleryTag gt ON ig.galleryId = gt.galleryId
+          JOIN StashImage si ON ig.imageId = si.id AND ig.imageInstanceId = si.stashInstanceId AND si.deletedAt IS NULL
+          JOIN StashGallery sg ON ig.galleryId = sg.id AND ig.galleryInstanceId = sg.stashInstanceId AND sg.deletedAt IS NULL
+          JOIN GalleryTag gt ON ig.galleryId = gt.galleryId AND ig.galleryInstanceId = gt.galleryInstanceId
         ) AS combined
         WHERE combined.tagId = StashTag.id
+          AND combined.tagInstanceId = StashTag.stashInstanceId
       ), 0)
       WHERE StashTag.deletedAt IS NULL
     `;

--- a/server/services/ExclusionComputationService.ts
+++ b/server/services/ExclusionComputationService.ts
@@ -518,8 +518,8 @@ class ExclusionComputationService {
       WHERE g.deletedAt IS NULL
       AND NOT EXISTS (
         SELECT 1 FROM ImageGallery ig
-        JOIN StashImage i ON ig.imageId = i.id
-        WHERE ig.galleryId = g.id
+        JOIN StashImage i ON ig.imageId = i.id AND ig.imageInstanceId = i.stashInstanceId
+        WHERE ig.galleryId = g.id AND ig.galleryInstanceId = g.stashInstanceId
           AND i.deletedAt IS NULL
           AND i.id NOT IN (SELECT imageId FROM temp_excluded_images)
       )
@@ -574,15 +574,15 @@ class ExclusionComputationService {
       AND p.id NOT IN (SELECT performerId FROM temp_excluded_performers)
       AND NOT EXISTS (
         SELECT 1 FROM ScenePerformer sp
-        JOIN StashScene s ON sp.sceneId = s.id
-        WHERE sp.performerId = p.id
+        JOIN StashScene s ON sp.sceneId = s.id AND sp.sceneInstanceId = s.stashInstanceId
+        WHERE sp.performerId = p.id AND sp.performerInstanceId = p.stashInstanceId
           AND s.deletedAt IS NULL
           AND s.id NOT IN (SELECT sceneId FROM temp_excluded_scenes)
       )
       AND NOT EXISTS (
         SELECT 1 FROM ImagePerformer ip
-        JOIN StashImage i ON ip.imageId = i.id
-        WHERE ip.performerId = p.id
+        JOIN StashImage i ON ip.imageId = i.id AND ip.imageInstanceId = i.stashInstanceId
+        WHERE ip.performerId = p.id AND ip.performerInstanceId = p.stashInstanceId
           AND i.deletedAt IS NULL
           AND i.id NOT IN (SELECT imageId FROM temp_excluded_images)
       )
@@ -664,8 +664,8 @@ class ExclusionComputationService {
       AND g.id NOT IN (SELECT groupId FROM temp_excluded_groups)
       AND NOT EXISTS (
         SELECT 1 FROM SceneGroup sg
-        JOIN StashScene s ON sg.sceneId = s.id
-        WHERE sg.groupId = g.id
+        JOIN StashScene s ON sg.sceneId = s.id AND sg.sceneInstanceId = s.stashInstanceId
+        WHERE sg.groupId = g.id AND sg.groupInstanceId = g.stashInstanceId
           AND s.deletedAt IS NULL
           AND s.id NOT IN (SELECT sceneId FROM temp_excluded_scenes)
       )
@@ -688,29 +688,29 @@ class ExclusionComputationService {
       WHERE t.deletedAt IS NULL
       AND NOT EXISTS (
         SELECT 1 FROM SceneTag st
-        JOIN StashScene s ON st.sceneId = s.id
-        WHERE st.tagId = t.id
+        JOIN StashScene s ON st.sceneId = s.id AND st.sceneInstanceId = s.stashInstanceId
+        WHERE st.tagId = t.id AND st.tagInstanceId = t.stashInstanceId
           AND s.deletedAt IS NULL
           AND s.id NOT IN (SELECT sceneId FROM temp_excluded_scenes)
       )
       AND NOT EXISTS (
         SELECT 1 FROM PerformerTag pt
-        JOIN StashPerformer p ON pt.performerId = p.id
-        WHERE pt.tagId = t.id
+        JOIN StashPerformer p ON pt.performerId = p.id AND pt.performerInstanceId = p.stashInstanceId
+        WHERE pt.tagId = t.id AND pt.tagInstanceId = t.stashInstanceId
           AND p.deletedAt IS NULL
           AND p.id NOT IN (SELECT performerId FROM temp_excluded_performers)
       )
       AND NOT EXISTS (
         SELECT 1 FROM StudioTag stt
-        JOIN StashStudio stu ON stt.studioId = stu.id
-        WHERE stt.tagId = t.id
+        JOIN StashStudio stu ON stt.studioId = stu.id AND stt.studioInstanceId = stu.stashInstanceId
+        WHERE stt.tagId = t.id AND stt.tagInstanceId = t.stashInstanceId
           AND stu.deletedAt IS NULL
           AND stu.id NOT IN (SELECT studioId FROM temp_excluded_studios)
       )
       AND NOT EXISTS (
         SELECT 1 FROM GroupTag gt
-        JOIN StashGroup g ON gt.groupId = g.id
-        WHERE gt.tagId = t.id
+        JOIN StashGroup g ON gt.groupId = g.id AND gt.groupInstanceId = g.stashInstanceId
+        WHERE gt.tagId = t.id AND gt.tagInstanceId = t.stashInstanceId
           AND g.deletedAt IS NULL
           AND g.id NOT IN (SELECT groupId FROM temp_excluded_groups)
       )

--- a/server/services/ImageQueryBuilder.ts
+++ b/server/services/ImageQueryBuilder.ts
@@ -289,12 +289,12 @@ class ImageQueryBuilder {
     switch (modifier) {
       case "INCLUDES":
         return {
-          sql: `i.id IN (SELECT imageId FROM ImageGallery WHERE galleryId IN (${placeholders}))`,
+          sql: `i.id IN (SELECT imageId FROM ImageGallery WHERE galleryId IN (${placeholders}) AND imageInstanceId = i.stashInstanceId)`,
           params: ids,
         };
       case "EXCLUDES":
         return {
-          sql: `i.id NOT IN (SELECT imageId FROM ImageGallery WHERE galleryId IN (${placeholders}))`,
+          sql: `i.id NOT IN (SELECT imageId FROM ImageGallery WHERE galleryId IN (${placeholders}) AND imageInstanceId = i.stashInstanceId)`,
           params: ids,
         };
       default:

--- a/server/services/RankingComputeService.ts
+++ b/server/services/RankingComputeService.ts
@@ -204,16 +204,16 @@ class RankingComputeService {
         AND e.entityType = 'performer'
         AND e.entityId = ups.performerId
       LEFT JOIN (
-        SELECT sp.performerId, SUM(w.playDuration) as totalDuration
+        SELECT sp.performerId, sp.performerInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM ScenePerformer sp
-        JOIN WatchHistory w ON w.sceneId = sp.sceneId AND w.userId = ${userId}
-        GROUP BY sp.performerId
-      ) dur ON dur.performerId = ups.performerId
+        JOIN WatchHistory w ON w.sceneId = sp.sceneId AND w.instanceId = sp.sceneInstanceId AND w.userId = ${userId}
+        GROUP BY sp.performerId, sp.performerInstanceId
+      ) dur ON dur.performerId = ups.performerId AND dur.instanceId = ups.instanceId
       LEFT JOIN (
-        SELECT performerId, COUNT(*) as sceneCount
+        SELECT performerId, performerInstanceId as instanceId, COUNT(*) as sceneCount
         FROM ScenePerformer
-        GROUP BY performerId
-      ) lib ON lib.performerId = ups.performerId
+        GROUP BY performerId, performerInstanceId
+      ) lib ON lib.performerId = ups.performerId AND lib.instanceId = ups.instanceId
       WHERE ups.userId = ${userId}
         AND e.id IS NULL
         AND (ups.playCount > 0 OR ups.oCounter > 0)
@@ -241,18 +241,18 @@ class RankingComputeService {
         AND e.entityType = 'studio'
         AND e.entityId = uss.studioId
       LEFT JOIN (
-        SELECT s.studioId, SUM(w.playDuration) as totalDuration
+        SELECT s.studioId, s.stashInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM StashScene s
-        JOIN WatchHistory w ON w.sceneId = s.id AND w.userId = ${userId}
+        JOIN WatchHistory w ON w.sceneId = s.id AND w.instanceId = s.stashInstanceId AND w.userId = ${userId}
         WHERE s.studioId IS NOT NULL
-        GROUP BY s.studioId
-      ) dur ON dur.studioId = uss.studioId
+        GROUP BY s.studioId, s.stashInstanceId
+      ) dur ON dur.studioId = uss.studioId AND dur.instanceId = uss.instanceId
       LEFT JOIN (
-        SELECT studioId, COUNT(*) as sceneCount
+        SELECT studioId, stashInstanceId as instanceId, COUNT(*) as sceneCount
         FROM StashScene
         WHERE studioId IS NOT NULL
-        GROUP BY studioId
-      ) lib ON lib.studioId = uss.studioId
+        GROUP BY studioId, stashInstanceId
+      ) lib ON lib.studioId = uss.studioId AND lib.instanceId = uss.instanceId
       WHERE uss.userId = ${userId}
         AND e.id IS NULL
         AND (uss.playCount > 0 OR uss.oCounter > 0)
@@ -280,16 +280,16 @@ class RankingComputeService {
         AND e.entityType = 'tag'
         AND e.entityId = uts.tagId
       LEFT JOIN (
-        SELECT st.tagId, SUM(w.playDuration) as totalDuration
+        SELECT st.tagId, st.tagInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM SceneTag st
-        JOIN WatchHistory w ON w.sceneId = st.sceneId AND w.userId = ${userId}
-        GROUP BY st.tagId
-      ) dur ON dur.tagId = uts.tagId
+        JOIN WatchHistory w ON w.sceneId = st.sceneId AND w.instanceId = st.sceneInstanceId AND w.userId = ${userId}
+        GROUP BY st.tagId, st.tagInstanceId
+      ) dur ON dur.tagId = uts.tagId AND dur.instanceId = uts.instanceId
       LEFT JOIN (
-        SELECT tagId, COUNT(*) as sceneCount
+        SELECT tagId, tagInstanceId as instanceId, COUNT(*) as sceneCount
         FROM SceneTag
-        GROUP BY tagId
-      ) lib ON lib.tagId = uts.tagId
+        GROUP BY tagId, tagInstanceId
+      ) lib ON lib.tagId = uts.tagId AND lib.instanceId = uts.instanceId
       WHERE uts.userId = ${userId}
         AND e.id IS NULL
         AND (uts.playCount > 0 OR uts.oCounter > 0)

--- a/server/services/SceneTagInheritanceService.ts
+++ b/server/services/SceneTagInheritanceService.ts
@@ -16,6 +16,7 @@ import { logger } from "../utils/logger.js";
  * - Direct scene tags are NOT included in inheritedTagIds (they're already in SceneTag)
  * - Tags are deduplicated across all sources
  * - Stored as JSON array for efficient querying
+ * - Multi-instance aware: uses composite keys (id:instanceId) to prevent cross-instance contamination
  */
 class SceneTagInheritanceService {
   async computeInheritedTags(): Promise<void> {
@@ -24,7 +25,7 @@ class SceneTagInheritanceService {
     try {
       const scenes = await prisma.stashScene.findMany({
         where: { deletedAt: null },
-        select: { id: true, studioId: true },
+        select: { id: true, stashInstanceId: true, studioId: true },
       });
 
       const BATCH_SIZE = 500;
@@ -50,101 +51,117 @@ class SceneTagInheritanceService {
     }
   }
 
-  private async processBatch(scenes: { id: string; studioId: string | null }[]): Promise<void> {
+  private async processBatch(scenes: { id: string; stashInstanceId: string; studioId: string | null }[]): Promise<void> {
     const sceneIds = scenes.map((s) => s.id);
+    const sceneInstanceIds = [...new Set(scenes.map((s) => s.stashInstanceId))];
 
-    // Get direct tags for all scenes in batch
+    // Composite key helper
+    const KEY_SEP = "\0";
+    const compositeKey = (id: string, instanceId: string) => `${id}${KEY_SEP}${instanceId}`;
+
+    // Get direct tags for all scenes in batch (scoped by instance)
     const directTags = await prisma.sceneTag.findMany({
-      where: { sceneId: { in: sceneIds } },
-      select: { sceneId: true, tagId: true },
+      where: { sceneId: { in: sceneIds }, sceneInstanceId: { in: sceneInstanceIds } },
+      select: { sceneId: true, sceneInstanceId: true, tagId: true },
     });
     const directTagsByScene = new Map<string, Set<string>>();
     for (const dt of directTags) {
-      if (!directTagsByScene.has(dt.sceneId)) {
-        directTagsByScene.set(dt.sceneId, new Set());
+      const key = compositeKey(dt.sceneId, dt.sceneInstanceId);
+      if (!directTagsByScene.has(key)) {
+        directTagsByScene.set(key, new Set());
       }
-      directTagsByScene.get(dt.sceneId)!.add(dt.tagId);
+      directTagsByScene.get(key)!.add(dt.tagId);
     }
 
-    // Get performer tags for all scenes in batch
+    // Get performer tags for all scenes in batch (scoped by instance)
     const scenePerformers = await prisma.scenePerformer.findMany({
-      where: { sceneId: { in: sceneIds } },
-      select: { sceneId: true, performerId: true },
+      where: { sceneId: { in: sceneIds }, sceneInstanceId: { in: sceneInstanceIds } },
+      select: { sceneId: true, sceneInstanceId: true, performerId: true, performerInstanceId: true },
     });
     const performerIds = [...new Set(scenePerformers.map((sp) => sp.performerId))];
+    const performerInstanceIds = [...new Set(scenePerformers.map((sp) => sp.performerInstanceId))];
     const performerTags = await prisma.performerTag.findMany({
-      where: { performerId: { in: performerIds } },
-      select: { performerId: true, tagId: true },
+      where: { performerId: { in: performerIds }, performerInstanceId: { in: performerInstanceIds } },
+      select: { performerId: true, performerInstanceId: true, tagId: true },
     });
     const tagsByPerformer = new Map<string, string[]>();
     for (const pt of performerTags) {
-      if (!tagsByPerformer.has(pt.performerId)) {
-        tagsByPerformer.set(pt.performerId, []);
+      const key = compositeKey(pt.performerId, pt.performerInstanceId);
+      if (!tagsByPerformer.has(key)) {
+        tagsByPerformer.set(key, []);
       }
-      tagsByPerformer.get(pt.performerId)!.push(pt.tagId);
+      tagsByPerformer.get(key)!.push(pt.tagId);
     }
 
-    // Get studio tags
+    // Get studio tags (scoped by instance)
     const studioIds = [...new Set(scenes.filter((s) => s.studioId).map((s) => s.studioId!))];
     const studioTags = await prisma.studioTag.findMany({
-      where: { studioId: { in: studioIds } },
-      select: { studioId: true, tagId: true },
+      where: { studioId: { in: studioIds }, studioInstanceId: { in: sceneInstanceIds } },
+      select: { studioId: true, studioInstanceId: true, tagId: true },
     });
     const tagsByStudio = new Map<string, string[]>();
     for (const st of studioTags) {
-      if (!tagsByStudio.has(st.studioId)) {
-        tagsByStudio.set(st.studioId, []);
+      const key = compositeKey(st.studioId, st.studioInstanceId);
+      if (!tagsByStudio.has(key)) {
+        tagsByStudio.set(key, []);
       }
-      tagsByStudio.get(st.studioId)!.push(st.tagId);
+      tagsByStudio.get(key)!.push(st.tagId);
     }
 
-    // Get group tags for all scenes in batch
+    // Get group tags for all scenes in batch (scoped by instance)
     const sceneGroups = await prisma.sceneGroup.findMany({
-      where: { sceneId: { in: sceneIds } },
-      select: { sceneId: true, groupId: true },
+      where: { sceneId: { in: sceneIds }, sceneInstanceId: { in: sceneInstanceIds } },
+      select: { sceneId: true, sceneInstanceId: true, groupId: true, groupInstanceId: true },
     });
     const groupIds = [...new Set(sceneGroups.map((sg) => sg.groupId))];
+    const groupInstanceIds = [...new Set(sceneGroups.map((sg) => sg.groupInstanceId))];
     const groupTags = await prisma.groupTag.findMany({
-      where: { groupId: { in: groupIds } },
-      select: { groupId: true, tagId: true },
+      where: { groupId: { in: groupIds }, groupInstanceId: { in: groupInstanceIds } },
+      select: { groupId: true, groupInstanceId: true, tagId: true },
     });
     const tagsByGroup = new Map<string, string[]>();
     for (const gt of groupTags) {
-      if (!tagsByGroup.has(gt.groupId)) {
-        tagsByGroup.set(gt.groupId, []);
+      const key = compositeKey(gt.groupId, gt.groupInstanceId);
+      if (!tagsByGroup.has(key)) {
+        tagsByGroup.set(key, []);
       }
-      tagsByGroup.get(gt.groupId)!.push(gt.tagId);
+      tagsByGroup.get(key)!.push(gt.tagId);
     }
 
-    // Build scene -> performer mapping
+    // Build scene -> performer mapping (using composite keys)
     const performersByScene = new Map<string, string[]>();
     for (const sp of scenePerformers) {
-      if (!performersByScene.has(sp.sceneId)) {
-        performersByScene.set(sp.sceneId, []);
+      const sceneKey = compositeKey(sp.sceneId, sp.sceneInstanceId);
+      const perfKey = compositeKey(sp.performerId, sp.performerInstanceId);
+      if (!performersByScene.has(sceneKey)) {
+        performersByScene.set(sceneKey, []);
       }
-      performersByScene.get(sp.sceneId)!.push(sp.performerId);
+      performersByScene.get(sceneKey)!.push(perfKey);
     }
 
-    // Build scene -> group mapping
+    // Build scene -> group mapping (using composite keys)
     const groupsByScene = new Map<string, string[]>();
     for (const sg of sceneGroups) {
-      if (!groupsByScene.has(sg.sceneId)) {
-        groupsByScene.set(sg.sceneId, []);
+      const sceneKey = compositeKey(sg.sceneId, sg.sceneInstanceId);
+      const grpKey = compositeKey(sg.groupId, sg.groupInstanceId);
+      if (!groupsByScene.has(sceneKey)) {
+        groupsByScene.set(sceneKey, []);
       }
-      groupsByScene.get(sg.sceneId)!.push(sg.groupId);
+      groupsByScene.get(sceneKey)!.push(grpKey);
     }
 
     // Compute inherited tags for each scene
-    const updates: { id: string; inheritedTagIds: string }[] = [];
+    const updates: { id: string; instanceId: string; inheritedTagIds: string }[] = [];
 
     for (const scene of scenes) {
+      const sceneKey = compositeKey(scene.id, scene.stashInstanceId);
       const inheritedTags = new Set<string>();
-      const directTagsForScene = directTagsByScene.get(scene.id) || new Set();
+      const directTagsForScene = directTagsByScene.get(sceneKey) || new Set();
 
-      // Collect performer tags
-      const performers = performersByScene.get(scene.id) || [];
-      for (const performerId of performers) {
-        const tags = tagsByPerformer.get(performerId) || [];
+      // Collect performer tags (using composite performer keys)
+      const performers = performersByScene.get(sceneKey) || [];
+      for (const performerKey of performers) {
+        const tags = tagsByPerformer.get(performerKey) || [];
         for (const tagId of tags) {
           if (!directTagsForScene.has(tagId)) {
             inheritedTags.add(tagId);
@@ -152,9 +169,10 @@ class SceneTagInheritanceService {
         }
       }
 
-      // Collect studio tags
+      // Collect studio tags (studio is on the same instance as the scene)
       if (scene.studioId) {
-        const tags = tagsByStudio.get(scene.studioId) || [];
+        const studioKey = compositeKey(scene.studioId, scene.stashInstanceId);
+        const tags = tagsByStudio.get(studioKey) || [];
         for (const tagId of tags) {
           if (!directTagsForScene.has(tagId)) {
             inheritedTags.add(tagId);
@@ -162,10 +180,10 @@ class SceneTagInheritanceService {
         }
       }
 
-      // Collect group tags
-      const groups = groupsByScene.get(scene.id) || [];
-      for (const groupId of groups) {
-        const tags = tagsByGroup.get(groupId) || [];
+      // Collect group tags (using composite group keys)
+      const groups = groupsByScene.get(sceneKey) || [];
+      for (const groupKey of groups) {
+        const tags = tagsByGroup.get(groupKey) || [];
         for (const tagId of tags) {
           if (!directTagsForScene.has(tagId)) {
             inheritedTags.add(tagId);
@@ -175,23 +193,27 @@ class SceneTagInheritanceService {
 
       updates.push({
         id: scene.id,
+        instanceId: scene.stashInstanceId,
         inheritedTagIds: JSON.stringify(Array.from(inheritedTags)),
       });
     }
 
     // Bulk update using raw SQL for performance
     // SQLite doesn't support UPDATE FROM, so we use CASE expressions
+    // Use composite key (id, stashInstanceId) for multi-instance correctness
     // Note: IDs come from our database (Stash UUIDs), not user input
     if (updates.length > 0) {
       const cases = updates
         .map((u) => `WHEN '${u.id}' THEN '${u.inheritedTagIds.replace(/'/g, "''")}'`)
         .join(" ");
-      const ids = updates.map((u) => `'${u.id}'`).join(",");
+      const idInstancePairs = updates
+        .map((u) => `('${u.id}', '${u.instanceId}')`)
+        .join(",");
 
       await prisma.$executeRawUnsafe(`
         UPDATE StashScene
         SET inheritedTagIds = CASE id ${cases} END
-        WHERE id IN (${ids})
+        WHERE (id, stashInstanceId) IN (${idInstancePairs})
       `);
     }
   }


### PR DESCRIPTION
## Summary
- Adds `instanceId` constraints to all junction table JOINs, subqueries, and Map lookups across 16 files
- Prevents cross-instance entity ID collisions when multiple Stash servers share numeric IDs (e.g., performer "82" on server A conflating with performer "82" on server B)
- Uses composite keys (`entityId:instanceId`) in all controller merge functions, QueryBuilder `populateRelations` methods, and raw SQL queries
- Fixes SceneQueryBuilder transform methods that were silently dropping `instanceId` from nested entity objects

Fixes #368

## Affected areas
- **Controllers**: scenes, galleries, images, tags — composite key Maps for rating/favorite/watch data merges
- **QueryBuilders**: Scene, Performer, Gallery, Group, Studio, Tag, Image — filter subqueries + `populateRelations`
- **Services**: RankingComputeService, StashEntityService, ExclusionComputationService, SceneTagInheritanceService, EntityImageCountService

## Test plan
- [x] 869/869 unit tests pass
- [x] 602/602 integration tests pass (fixed test data: added performer to studio 5 scenes on test instance)
- [x] TypeScript compilation clean
- [x] Lint clean (0 errors)
- [x] Client build succeeds
- [x] Client 1063/1063 tests pass