### PR TITLE
Lightbox improvements: zoom, flicker fix, double-tap actions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peek-client",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peek-client",
-      "version": "3.3.0-beta.1",
+      "version": "3.3.3-beta.2",
       "dependencies": {
         "@silvermine/videojs-airplay": "^1.2.0",
         "@silvermine/videojs-chromecast": "^1.4.1",
@@ -24,6 +24,7 @@
         "react-photo-album": "^3.4.0",
         "react-router-dom": "^7.9.4",
         "react-swipeable": "^7.0.2",
+        "react-zoom-pan-pinch": "^3.7.0",
         "video.js": "^7.21.3",
         "videojs-seek-buttons": "^3.0.1",
         "videojs-vr": "^2.0.0",
@@ -6162,6 +6163,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "react-photo-album": "^3.4.0",
     "react-router-dom": "^7.9.4",
     "react-swipeable": "^7.0.2",
+    "react-zoom-pan-pinch": "^3.7.0",
     "video.js": "^7.21.3",
     "videojs-seek-buttons": "^3.0.1",
     "videojs-vr": "^2.0.0",

--- a/client/src/components/settings/tabs/CustomizationTab.jsx
+++ b/client/src/components/settings/tabs/CustomizationTab.jsx
@@ -15,6 +15,7 @@ const CustomizationTab = () => {
   const { unitPreference, setUnitPreference } = useUnitPreference();
   const [preferredPreviewQuality, setPreferredPreviewQuality] = useState("sprite");
   const [wallPlayback, setWallPlayback] = useState("autoplay");
+  const [lightboxDoubleTapAction, setLightboxDoubleTapAction] = useState("favorite");
   const [tableColumnDefaults, setTableColumnDefaults] = useState({});
 
   // Load settings on mount
@@ -27,6 +28,7 @@ const CustomizationTab = () => {
 
         setPreferredPreviewQuality(settings.preferredPreviewQuality || "sprite");
         setWallPlayback(settings.wallPlayback || "autoplay");
+        setLightboxDoubleTapAction(settings.lightboxDoubleTapAction || "favorite");
         setTableColumnDefaults(settings.tableColumnDefaults || {});
       } catch {
         showError("Failed to load customization settings");
@@ -48,6 +50,8 @@ const CustomizationTab = () => {
         setPreferredPreviewQuality(value);
       } else if (key === "wallPlayback") {
         setWallPlayback(value);
+      } else if (key === "lightboxDoubleTapAction") {
+        setLightboxDoubleTapAction(value);
       }
       showSuccess("View preference saved!");
     } catch (err) {
@@ -184,6 +188,35 @@ const CustomizationTab = () => {
             <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>
               Display performer height, weight, and measurements in your preferred unit
               system.
+            </p>
+          </div>
+
+          {/* Image Lightbox Double-Tap Action */}
+          <div>
+            <label
+              htmlFor="lightboxDoubleTapAction"
+              className="block text-sm font-medium mb-2"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              Image Lightbox Double-Tap Action
+            </label>
+            <select
+              id="lightboxDoubleTapAction"
+              value={lightboxDoubleTapAction}
+              onChange={(e) => saveViewPreference("lightboxDoubleTapAction", e.target.value)}
+              className="w-full px-4 py-2 rounded-lg"
+              style={{
+                backgroundColor: "var(--bg-secondary)",
+                border: "1px solid var(--border-color)",
+                color: "var(--text-primary)",
+              }}
+            >
+              <option value="favorite">Toggle Favorite (Default)</option>
+              <option value="o_counter">Increment O Counter</option>
+            </select>
+            <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>
+              Action performed when double-tapping (mobile) or double-clicking (desktop) an
+              image in the lightbox.
             </p>
           </div>
         </div>

--- a/client/src/components/ui/PageLayout.jsx
+++ b/client/src/components/ui/PageLayout.jsx
@@ -5,7 +5,7 @@
 const PageLayout = ({ children, className = "", fullHeight = false }) => {
   return (
     <div
-      className={`w-full py-3 sm:py-8 px-3 sm:px-4 ${fullHeight ? "min-h-screen" : ""} ${className}`}
+      className={`w-full py-3 pb-6 sm:py-8 px-3 sm:px-4 ${fullHeight ? "min-h-screen" : ""} ${className}`}
     >
       {children}
     </div>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -9,6 +9,16 @@ export default {
         '4xl': '2560px',  // QHD/1440p displays
         '5xl': '3840px',  // 4K UHD monitors/TVs
       },
+      keyframes: {
+        'ping-once': {
+          '0%': { transform: 'scale(1)', opacity: '1' },
+          '50%': { transform: 'scale(1.3)', opacity: '0.8' },
+          '100%': { transform: 'scale(1)', opacity: '0' },
+        },
+      },
+      animation: {
+        'ping-once': 'ping-once 0.6s ease-out forwards',
+      },
     },
   },
   plugins: [],

--- a/client/tests/components/ui/Lightbox.test.jsx
+++ b/client/tests/components/ui/Lightbox.test.jsx
@@ -5,12 +5,14 @@ import Lightbox from "../../../src/components/ui/Lightbox.jsx";
 
 // Mock the API
 vi.mock("../../../services/api.js", () => ({
+  apiGet: vi.fn().mockResolvedValue({ settings: {} }),
   libraryApi: {
     updateRating: vi.fn().mockResolvedValue({}),
     updateFavorite: vi.fn().mockResolvedValue({}),
   },
   imageViewHistoryApi: {
     recordView: vi.fn().mockResolvedValue({}),
+    incrementO: vi.fn().mockResolvedValue({}),
   },
 }));
 
@@ -374,9 +376,19 @@ describe("Lightbox", () => {
         await new Promise((r) => setTimeout(r, 0));
       });
 
-      // Should show page 2 image 0
-      expect(getVisibility()).toBe("visible");
+      // Post-transition: container stays hidden until image loads (prevents flicker)
+      expect(getVisibility()).toBe("hidden");
       expect(getImgSrc()).toBe("http://example.com/page2/image0.jpg");
+
+      // Simulate image load — now the container becomes visible
+      const img = container.querySelector("img");
+      fireEvent.load(img);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(getVisibility()).toBe("visible");
     });
   });
 

--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -139,6 +139,7 @@ export const getUserSettings = async (
         tableColumnDefaults: true,
         cardDisplaySettings: true,
         landingPagePreference: true,
+        lightboxDoubleTapAction: true,
       },
     });
 
@@ -164,6 +165,7 @@ export const getUserSettings = async (
         tableColumnDefaults: user.tableColumnDefaults || null,
         cardDisplaySettings: user.cardDisplaySettings || null,
         landingPagePreference: user.landingPagePreference || { pages: ["home"], randomize: false },
+        lightboxDoubleTapAction: user.lightboxDoubleTapAction || "favorite",
       },
     });
   } catch (error) {
@@ -216,6 +218,7 @@ export const updateUserSettings = async (
       tableColumnDefaults,
       cardDisplaySettings,
       landingPagePreference,
+      lightboxDoubleTapAction,
     } = req.body;
 
     // Validate values
@@ -427,6 +430,16 @@ export const updateUserSettings = async (
       }
     }
 
+    // Validate lightboxDoubleTapAction if provided
+    if (lightboxDoubleTapAction !== undefined) {
+      const validActions = ["favorite", "o_counter"];
+      if (!validActions.includes(lightboxDoubleTapAction)) {
+        return res
+          .status(400)
+          .json({ error: "Lightbox double-tap action must be 'favorite' or 'o_counter'" });
+      }
+    }
+
     const updatedUser = await prisma.user.update({
       where: { id: targetUserId },
       data: {
@@ -446,6 +459,7 @@ export const updateUserSettings = async (
         ...(tableColumnDefaults !== undefined && { tableColumnDefaults }),
         ...(cardDisplaySettings !== undefined && { cardDisplaySettings }),
         ...(landingPagePreference !== undefined && { landingPagePreference }),
+        ...(lightboxDoubleTapAction !== undefined && { lightboxDoubleTapAction }),
       },
       select: {
         id: true,
@@ -463,6 +477,7 @@ export const updateUserSettings = async (
         tableColumnDefaults: true,
         cardDisplaySettings: true,
         landingPagePreference: true,
+        lightboxDoubleTapAction: true,
       },
     });
 
@@ -481,6 +496,7 @@ export const updateUserSettings = async (
         tableColumnDefaults: updatedUser.tableColumnDefaults || null,
         cardDisplaySettings: updatedUser.cardDisplaySettings || null,
         landingPagePreference: updatedUser.landingPagePreference || { pages: ["home"], randomize: false },
+        lightboxDoubleTapAction: updatedUser.lightboxDoubleTapAction || "favorite",
       },
     });
   } catch (error) {
@@ -906,6 +922,7 @@ export const saveFilterPreset = async (
       "tag",
       "group",
       "gallery",
+      "image",
       "clip",
     ];
     if (!validTypes.includes(artifactType)) {
@@ -925,6 +942,7 @@ export const saveFilterPreset = async (
         "tag",
         "group",
         "gallery",
+        "image",
         "clip",
       ];
       if (!validContexts.includes(context)) {
@@ -1009,6 +1027,7 @@ export const deleteFilterPreset = async (
       "tag",
       "group",
       "gallery",
+      "image",
       "clip",
     ];
     if (!validTypes.includes(artifactType)) {

--- a/server/prisma/migrations/20260215000000_add_lightbox_double_tap_action/migration.sql
+++ b/server/prisma/migrations/20260215000000_add_lightbox_double_tap_action/migration.sql
@@ -1,0 +1,2 @@
+-- Add lightbox double-tap/double-click action preference
+ALTER TABLE "User" ADD COLUMN "lightboxDoubleTapAction" TEXT DEFAULT 'favorite';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   tableColumnDefaults     Json? // Object with keys: scene, performer, studio, tag, group, gallery, image - each containing {visible: string[], order: string[]}
   cardDisplaySettings     Json? // Object with per-entity-type card display toggles: {scene: {showCodeOnCard, showDescriptionOnCard, ...}, performer: {...}, ...}
   landingPagePreference   Json? @default("{\"pages\":[\"home\"],\"randomize\":false}")
+  lightboxDoubleTapAction String? @default("favorite") // "favorite" or "o_counter" - action on double-tap/double-click in image lightbox
 
   // First-login setup wizard tracking
   setupCompleted    Boolean   @default(false)


### PR DESCRIPTION
## Summary
- Add pinch-to-zoom and pan support in image lightbox (scroll-to-zoom on desktop, swipe nav auto-disabled when zoomed)
- Fix page boundary flicker — container stays hidden until new image loads after page transition
- Remove fullscreen padding — images now fill the full viewport in fullscreen mode
- Add configurable double-tap (mobile) / double-click (desktop) action: toggle favorite or increment O counter
- New user preference `lightboxDoubleTapAction` with settings UI in Customization tab
- Fix filter preset save for `image` entity type (missing from validation arrays)
- Add bottom padding on mobile to prevent pagination buttons hugging screen edge

## Test plan
- [x] Server lint: 0 errors
- [x] Client lint: 0 errors
- [x] Server tsc --noEmit: no type errors
- [x] Server tests: 869 passed
- [x] Client tests: 1063 passed
- [x] Client build: success
- [ ] Manual: open lightbox, navigate across page boundaries, verify no flicker
- [ ] Manual: pinch-to-zoom on mobile, scroll-to-zoom on desktop, pan while zoomed
- [ ] Manual: fullscreen mode shows image edge-to-edge
- [ ] Manual: double-tap/double-click triggers correct action based on setting