### PR TITLE
fix: prevent background pings from redirecting to /login during playback

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -12,6 +12,16 @@ const REDIRECT_STORAGE_KEY = "peek_auth_redirect";
 // the flag would need to be reset after successful login.
 let isRedirectingToLogin = false;
 
+// Endpoints where 401/403 should NOT trigger a redirect to /login.
+// These are background/fire-and-forget calls (e.g., watch history pings during
+// video playback) that should fail silently instead of disrupting the user.
+const AUTH_SILENT_ENDPOINTS = new Set([
+  "/watch-history/save-activity",
+  "/watch-history/increment-play-count",
+  "/image-view-history/increment-o",
+  "/image-view-history/view",
+]);
+
 /**
  * Base fetch wrapper with error handling
  */
@@ -19,6 +29,7 @@ async function apiFetch(endpoint, options = {}) {
   const url = `${API_BASE_URL}${endpoint}`;
 
   const config = {
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       ...options.headers,
@@ -47,18 +58,38 @@ async function apiFetch(endpoint, options = {}) {
     }
 
     // Handle auth failures (401/403) - redirect to login
-    // Exclude auth endpoints to avoid redirect loops
+    // Exclude auth endpoints to avoid redirect loops, and silent endpoints
+    // (background pings) to avoid disrupting video playback
     const isAuthEndpoint = endpoint.startsWith("/auth/");
-    if ((response.status === 401 || response.status === 403) && !isAuthEndpoint && !isRedirectingToLogin) {
-      isRedirectingToLogin = true;
-      // Save current URL for redirect after login
-      const currentUrl = window.location.pathname + window.location.search;
-      if (currentUrl !== "/login" && currentUrl !== "/setup") {
-        sessionStorage.setItem(REDIRECT_STORAGE_KEY, currentUrl);
+    const isSilentEndpoint = AUTH_SILENT_ENDPOINTS.has(endpoint);
+    if ((response.status === 401 || response.status === 403) && !isAuthEndpoint) {
+      // Log telemetry for debugging mobile playback redirect issue
+      console.warn(
+        `[API] Auth failure: ${response.status} on ${endpoint}`,
+        `| error: ${errorData?.error || "unknown"}`,
+        `| cookie present: ${document.cookie.length > 0}`,
+        `| page: ${window.location.pathname}`
+      );
+
+      if (isSilentEndpoint) {
+        // Don't redirect for background pings — throw so retry logic can handle it
+        const error = new Error(errorData?.error || `Auth failure on ${endpoint}`);
+        error.status = response.status;
+        error.data = errorData;
+        throw error;
       }
-      window.location.href = "/login";
-      // Return a never-resolving promise to prevent further processing
-      return new Promise(() => {});
+
+      if (!isRedirectingToLogin) {
+        isRedirectingToLogin = true;
+        // Save current URL for redirect after login
+        const currentUrl = window.location.pathname + window.location.search;
+        if (currentUrl !== "/login" && currentUrl !== "/setup") {
+          sessionStorage.setItem(REDIRECT_STORAGE_KEY, currentUrl);
+        }
+        window.location.href = "/login";
+        // Return a never-resolving promise to prevent further processing
+        return new Promise(() => {});
+      }
     }
 
     // Create error with additional metadata


### PR DESCRIPTION
## Summary
- Adds `credentials: "include"` to `apiFetch` to ensure cookies are always sent, particularly on mobile browsers in fullscreen/landscape mode
- Introduces a silent endpoint allowlist (`AUTH_SILENT_ENDPOINTS`) so background pings (watch history, image view history) throw errors instead of triggering a `/login` redirect — existing retry/catch logic handles these gracefully
- Adds `console.warn` telemetry on auth failures to help diagnose the mobile playback redirect issue reported in #370

## Context
Users on Android Firefox/Thorium report that playing a video for 2-3 minutes in fullscreen landscape causes the page to redirect to `/login`. The root cause appears to be the watch history tracker's 10-second ping cycle: if a cookie isn't sent (mobile browser quirk), the server returns 401, and the global interceptor in `apiFetch` immediately redirects. This fix ensures: (1) cookies are explicitly included, and (2) background pings can never trigger a redirect.

## Test plan
- [x] Client tests pass (1063 tests)
- [x] Client lint clean (0 errors)
- [x] Client build succeeds
- [x] Server tests pass (931 tests)
- [ ] Manual: play a video on Android Firefox in fullscreen for 5+ minutes — should not redirect
- [ ] Manual: check browser console for `[API] Auth failure` telemetry if any 401s occur