### PR TITLE
chore: fix all lint warnings across client and server

### DIFF
--- a/client/src/components/pages/SceneDetails.jsx
+++ b/client/src/components/pages/SceneDetails.jsx
@@ -75,7 +75,7 @@ const SceneDetails = ({
       }
     }
     fetchClips();
-  }, [scene?.id]);
+  }, [scene?.id, scene?.instanceId]);
 
   // Handle clip click - dispatch event to seek video player
   const handleClipClick = (clip) => {

--- a/client/src/components/playlists/SharePlaylistModal.jsx
+++ b/client/src/components/playlists/SharePlaylistModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Share2 } from "lucide-react";
 import { getMyGroups, getPlaylistShares, updatePlaylistShares } from "../../services/api.js";
 import { showError, showSuccess } from "../../utils/toast.jsx";
@@ -10,13 +10,7 @@ const SharePlaylistModal = ({ playlistId, playlistName, isOpen, onClose }) => {
   const [userGroups, setUserGroups] = useState([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState(new Set());
 
-  useEffect(() => {
-    if (isOpen) {
-      loadData();
-    }
-  }, [isOpen, playlistId]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true);
       const [groupsResult, sharesResult] = await Promise.all([
@@ -32,7 +26,13 @@ const SharePlaylistModal = ({ playlistId, playlistName, isOpen, onClose }) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [playlistId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadData();
+    }
+  }, [isOpen, playlistId, loadData]);
 
   const handleToggleGroup = (groupId) => {
     setSelectedGroupIds((prev) => {

--- a/client/src/components/settings/StashInstanceSection.jsx
+++ b/client/src/components/settings/StashInstanceSection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Paper, Button } from "../ui/index.js";
 import { useAuth } from "../../hooks/useAuth.js";
 
@@ -24,11 +24,7 @@ const StashInstanceSection = ({ api }) => {
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
 
-  useEffect(() => {
-    loadInstances();
-  }, []);
-
-  const loadInstances = async () => {
+  const loadInstances = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -49,7 +45,11 @@ const StashInstanceSection = ({ api }) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [api, isAdmin]);
+
+  useEffect(() => {
+    loadInstances();
+  }, [loadInstances]);
 
   const formatDate = (dateString) => {
     if (!dateString) return "N/A";

--- a/client/src/components/settings/VersionInfoSection.jsx
+++ b/client/src/components/settings/VersionInfoSection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button, Paper } from "../ui/index.js";
 
 const VersionInfoSection = ({ clientVersion, api }) => {
@@ -7,21 +7,16 @@ const VersionInfoSection = ({ clientVersion, api }) => {
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [updateError, setUpdateError] = useState(null);
 
-  useEffect(() => {
-    loadServerVersion();
-    checkForUpdates();
-  }, []);
-
-  const loadServerVersion = async () => {
+  const loadServerVersion = useCallback(async () => {
     try {
       const response = await api.get("/version");
       setServerVersion(response.data.server);
     } catch (err) {
       console.error("Failed to load server version:", err);
     }
-  };
+  }, [api]);
 
-  const checkForUpdates = async () => {
+  const checkForUpdates = useCallback(async () => {
     setCheckingUpdate(true);
     setUpdateError(null);
 
@@ -48,7 +43,12 @@ const VersionInfoSection = ({ clientVersion, api }) => {
     } finally {
       setCheckingUpdate(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    loadServerVersion();
+    checkForUpdates();
+  }, [loadServerVersion, checkForUpdates]);
 
   const parseVersion = (v) => {
     const [core, pre] = v.split("-");

--- a/client/src/components/timeline/useTimelineState.js
+++ b/client/src/components/timeline/useTimelineState.js
@@ -163,6 +163,7 @@ export function useTimelineState({ entityType, autoSelectRecent = false, initial
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- filterKey = JSON.stringify(filters) captures all filter property changes
   }, [entityType, zoomLevel, autoSelectRecent, filterKey]);
 
   const selectPeriod = useCallback(

--- a/client/src/components/video-player/PlaybackControls.jsx
+++ b/client/src/components/video-player/PlaybackControls.jsx
@@ -28,12 +28,15 @@ const PlaybackControls = () => {
   const [permissions, setPermissions] = useState(null);
 
   // Sync state when scene changes
+  const sceneId = scene?.id;
+  const sceneRating = scene?.rating;
+  const sceneFavorite = scene?.favorite;
   useEffect(() => {
-    if (scene) {
-      setRating(scene.rating ?? null);
-      setIsFavorite(scene.favorite || false);
+    if (sceneId != null) {
+      setRating(sceneRating ?? null);
+      setIsFavorite(sceneFavorite || false);
     }
-  }, [scene?.id, scene?.rating, scene?.favorite]);
+  }, [sceneId, sceneRating, sceneFavorite]);
 
   // Fetch user permissions on mount
   useEffect(() => {

--- a/client/src/components/video-player/VideoPlayer.jsx
+++ b/client/src/components/video-player/VideoPlayer.jsx
@@ -109,7 +109,7 @@ const VideoPlayer = () => {
       }
     }
     fetchClips();
-  }, [scene?.id]);
+  }, [scene?.id, scene?.instanceId]);
 
   // Add clip markers to timeline using the markers plugin
   useEffect(() => {

--- a/client/src/components/video-player/useVideoPlayer.js
+++ b/client/src/components/video-player/useVideoPlayer.js
@@ -282,6 +282,7 @@ export function useVideoPlayer({
       performers,
       scene.paths?.screenshot || ""
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps list all accessed scene properties individually; adding `scene` object would cause re-runs on every render
   }, [scene?.id, scene?.title, scene?.performers, scene?.paths?.screenshot, playerRef]);
 
   // ============================================================================
@@ -349,6 +350,7 @@ export function useVideoPlayer({
     // This ensures proper layout before metadata loads
     const aspectRatio = `${firstFile.width}:${firstFile.height}`;
     player.aspectRatio(aspectRatio);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scene?.id captures scene changes; adding `scene` object would re-run aspect ratio setup on every render
   }, [scene?.id, playerRef]);
 
   // ============================================================================
@@ -467,7 +469,8 @@ export function useVideoPlayer({
     return () => {
       player.off("error", handleError);
     };
-  }, [scene?.id, dispatch]); // Only re-run when scene changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scene?.id captures scene changes; playerRef is a stable ref; adding `scene` object would re-initialize error handler on every render
+  }, [scene?.id, playerRef, dispatch]); // Only re-run when scene changes
 
   // ============================================================================
   // VIDEO SOURCES LOADING (using sourceSelector plugin - Stash pattern)

--- a/client/src/hooks/useFolderViewTags.js
+++ b/client/src/hooks/useFolderViewTags.js
@@ -70,6 +70,7 @@ export function useFolderViewTags(isActive, filters = null) {
     };
 
     fetchTags();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- filterKey = JSON.stringify(filters) captures all filter changes
   }, [isActive, filterKey]);
 
   return { tags, isLoading, error };

--- a/server/controllers/playlist.ts
+++ b/server/controllers/playlist.ts
@@ -714,20 +714,24 @@ export const reorderPlaylist = async (
 
     // Update positions in a transaction
     await prisma.$transaction(
-      items.map((item) =>
-        prisma.playlistItem.update({
+      items.map((item) => {
+        const instanceId = instanceIdMap.get(item.sceneId);
+        if (!instanceId) {
+          throw new Error(`Missing instanceId for scene ${item.sceneId}`);
+        }
+        return prisma.playlistItem.update({
           where: {
             playlistId_instanceId_sceneId: {
               playlistId,
-              instanceId: instanceIdMap.get(item.sceneId)!,
+              instanceId,
               sceneId: item.sceneId,
             },
           },
           data: {
             position: item.position,
           },
-        })
-      )
+        });
+      })
     );
 
     res.json({ success: true, message: "Playlist reordered" });


### PR DESCRIPTION
## Summary
- Fix missing `scene.instanceId` dependency in clip fetch effects — clips now correctly refetch when switching between instances
- Stabilize mount-effect functions with `useCallback` to prevent stale closure bugs in settings and playlist sharing
- Replace non-null assertion with proper error handling in playlist reorder
- Zero lint warnings across both client and server (was 12 total)

## Test plan
- [x] Server unit tests — 931/931 passing
- [x] Client unit tests — 1063/1063 passing
- [x] Server lint — 0 errors, 0 warnings
- [x] Client lint — 0 errors, 0 warnings
- [x] Server tsc — 0 errors
- [x] Client build — success
- [ ] Manual: verify video playback still works (suppressions in useVideoPlayer.js are safe — no behavior change)
- [ ] Manual: verify playlist reorder still works