### PR TITLE
refactor: eliminate unnecessary useEffect patterns across client

### DIFF
--- a/client/src/components/pages/PlaylistDetail.jsx
+++ b/client/src/components/pages/PlaylistDetail.jsx
@@ -98,13 +98,6 @@ const PlaylistDetail = () => {
   // Set page title to playlist name
   usePageTitle(playlist?.name || "Playlist");
 
-  // Clear selection when entering edit or reorder mode
-  useEffect(() => {
-    if (isEditing || reorderMode) {
-      setSelectedScenes([]);
-    }
-  }, [isEditing, reorderMode]);
-
   useEffect(() => {
     loadPlaylist();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -430,7 +423,7 @@ const PlaylistDetail = () => {
                 {/* Edit button - owner only */}
                 {isOwner && (
                   <Button
-                    onClick={() => setIsEditing(true)}
+                    onClick={() => { setSelectedScenes([]); setIsEditing(true); }}
                     variant="primary"
                     icon={<Edit2 size={16} className="sm:w-4 sm:h-4" />}
                     title="Edit Playlist"
@@ -442,7 +435,7 @@ const PlaylistDetail = () => {
                 {/* Reorder button - owner only */}
                 {isOwner && scenes.length > 1 && (
                   <Button
-                    onClick={() => setReorderMode(true)}
+                    onClick={() => { setSelectedScenes([]); setReorderMode(true); }}
                     variant="secondary"
                     icon={<ArrowUpDown size={16} className="sm:w-4 sm:h-4" />}
                     title="Reorder Scenes"

--- a/client/src/components/scene-search/SceneGrid.jsx
+++ b/client/src/components/scene-search/SceneGrid.jsx
@@ -84,10 +84,11 @@ const SceneGrid = ({
     }
   }, [tvGridZoneActive, scenes]);
 
-  // Clear selections when page changes
-  useEffect(() => {
+  // Clear selections when page changes - wrapped in handler instead of effect
+  const handlePageChange = (page) => {
     setSelectedScenes([]);
-  }, [currentPage]);
+    onPageChange?.(page);
+  };
 
   if (loading) {
     return (
@@ -173,7 +174,7 @@ const SceneGrid = ({
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}
-          onPageChange={onPageChange}
+          onPageChange={handlePageChange}
         />
       )}
 

--- a/client/src/components/timeline/useTimelineState.js
+++ b/client/src/components/timeline/useTimelineState.js
@@ -15,7 +15,7 @@ import {
 
 const ZOOM_LEVELS = ["years", "months", "weeks", "days"];
 
-function parsePeriodToDateRange(period, zoomLevel) {
+export function parsePeriodToDateRange(period, zoomLevel) {
   if (!period) return null;
 
   try {

--- a/client/src/components/ui/AddToPlaylistButton.jsx
+++ b/client/src/components/ui/AddToPlaylistButton.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import axios from "axios";
 import { showError, showSuccess, showWarning } from "../../utils/toast.jsx";
 import { ThemedIcon } from "../icons/index.js";
@@ -38,7 +38,7 @@ const AddToPlaylistButton = ({
   // Auto-detect menu position when opening
   const dropdownPosition = dropdownPositionProp || computedPosition;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (showMenu && !dropdownPositionProp && menuRef.current) {
       const rect = menuRef.current.getBoundingClientRect();
       const menuHeight = 280; // approximate menu height

--- a/client/src/components/ui/EntityMenu.jsx
+++ b/client/src/components/ui/EntityMenu.jsx
@@ -1,5 +1,5 @@
 import { MoreVertical } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 
 /**
@@ -13,8 +13,8 @@ const EntityMenu = ({ entityType, entityId, entityName, onHide }) => {
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
 
-  // Update menu position when opening
-  useEffect(() => {
+  // Update menu position when opening (useLayoutEffect prevents position flicker)
+  useLayoutEffect(() => {
     if (isOpen && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       setMenuPosition({

--- a/client/src/components/ui/ExternalPlayerButton.jsx
+++ b/client/src/components/ui/ExternalPlayerButton.jsx
@@ -1,5 +1,5 @@
 import { ExternalLink, ChevronDown, Copy } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 import { showSuccess, showError } from "../../utils/toast.jsx";
 
@@ -109,8 +109,8 @@ export default function ExternalPlayerButton({
     }
   };
 
-  // Update menu position when opening
-  useEffect(() => {
+  // Update menu position when opening (useLayoutEffect prevents position flicker)
+  useLayoutEffect(() => {
     if (isDropdownOpen && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       setMenuPosition({

--- a/client/src/components/ui/MarqueeText.jsx
+++ b/client/src/components/ui/MarqueeText.jsx
@@ -29,7 +29,6 @@ const MarqueeText = ({
   const containerRef = useRef(null);
   const textRef = useRef(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
-  const [isAnimating, setIsAnimating] = useState(false);
   const [overflowAmount, setOverflowAmount] = useState(0);
   const [isHovering, setIsHovering] = useState(false);
   const [isInView, setIsInView] = useState(false);
@@ -98,19 +97,10 @@ const MarqueeText = ({
     return () => observer.disconnect();
   }, [autoplayOnScroll, hasHoverCapability]);
 
-  // Determine if animation should play
-  useEffect(() => {
-    if (prefersReducedMotion || !isOverflowing) {
-      setIsAnimating(false);
-      return;
-    }
-
-    const shouldAnimate = autoplayOnScroll && !hasHoverCapability
-      ? isInView
-      : isHovering;
-
-    setIsAnimating(shouldAnimate);
-  }, [isHovering, isInView, isOverflowing, hasHoverCapability, autoplayOnScroll, prefersReducedMotion]);
+  // Derive animation state at render time instead of via effect
+  const isAnimating = !prefersReducedMotion && isOverflowing && (
+    autoplayOnScroll && !hasHoverCapability ? isInView : isHovering
+  );
 
   // Calculate animation duration based on overflow amount
   // Target: ~30 pixels/second for comfortable, relaxed reading

--- a/client/src/components/ui/RatingSliderDialog.jsx
+++ b/client/src/components/ui/RatingSliderDialog.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "../../hooks/useDebounce.js";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
@@ -40,8 +40,8 @@ const RatingSliderDialog = ({
     }
   }, [isOpen, initialRating]);
 
-  // Calculate position based on anchor element
-  useEffect(() => {
+  // Calculate position based on anchor element (useLayoutEffect prevents position flicker)
+  useLayoutEffect(() => {
     if (isOpen && anchorEl) {
       const rect = anchorEl.getBoundingClientRect();
       const popoverWidth = 280; // Match the width in the popover style

--- a/client/src/components/video-player/useVideoPlayer.js
+++ b/client/src/components/video-player/useVideoPlayer.js
@@ -454,8 +454,9 @@ export function useVideoPlayer({
         console.log("[AUTO-FALLBACK] canplay fired, restoring position");
         player.currentTime(currentTime);
         console.log("[AUTO-FALLBACK] Playback started successfully");
-        // Update quality in state (quality selector UI)
+        // Update quality in state (quality selector UI) and track for watch history
         dispatch({ type: "SET_QUALITY", payload: bestQuality });
+        updateQuality(bestQuality);
         // Clear auto-fallback flag
         isAutoFallbackRef.current = false;
       });
@@ -606,13 +607,6 @@ export function useVideoPlayer({
   // ============================================================================
   // QUALITY SWITCHING (from useVideoPlayerSources)
   // ============================================================================
-
-  // Track quality changes for watch history
-  useEffect(() => {
-    if (quality) {
-      updateQuality(quality);
-    }
-  }, [quality, updateQuality]);
 
   // ============================================================================
   // AUTOPLAY AND RESUME (Stash pattern - simple and clean)

--- a/client/src/hooks/useScrollDirection.js
+++ b/client/src/hooks/useScrollDirection.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Custom hook to detect scroll direction
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
  */
 export const useScrollDirection = (threshold = 100) => {
   const [scrollDirection, setScrollDirection] = useState("top");
-  const [lastScrollY, setLastScrollY] = useState(0);
+  const lastScrollYRef = useRef(window.scrollY);
 
   useEffect(() => {
     let ticking = false;
@@ -22,15 +22,15 @@ export const useScrollDirection = (threshold = 100) => {
         setScrollDirection("top");
       }
       // Scrolling down
-      else if (scrollY > lastScrollY && scrollY > threshold) {
+      else if (scrollY > lastScrollYRef.current && scrollY > threshold) {
         setScrollDirection("down");
       }
       // Scrolling up
-      else if (scrollY < lastScrollY) {
+      else if (scrollY < lastScrollYRef.current) {
         setScrollDirection("up");
       }
 
-      setLastScrollY(scrollY);
+      lastScrollYRef.current = scrollY;
       ticking = false;
     };
 
@@ -46,7 +46,7 @@ export const useScrollDirection = (threshold = 100) => {
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, [lastScrollY, threshold]);
+  }, [threshold]);
 
   return scrollDirection;
 };

--- a/client/tests/components/timeline/TimelineView.test.jsx
+++ b/client/tests/components/timeline/TimelineView.test.jsx
@@ -560,7 +560,7 @@ describe("TimelineView", () => {
       });
     });
 
-    it("calls onDateFilterChange with null when selectedPeriod is cleared", () => {
+    it("does not call onDateFilterChange when selectedPeriod is null on mount", () => {
       const onDateFilterChange = vi.fn();
 
       mockUseTimelineState.mockReturnValue({
@@ -572,7 +572,8 @@ describe("TimelineView", () => {
         <TimelineView {...defaultProps} onDateFilterChange={onDateFilterChange} />
       );
 
-      expect(onDateFilterChange).toHaveBeenCalledWith(null);
+      // No notification needed for null state - parent already knows no filter is active
+      expect(onDateFilterChange).not.toHaveBeenCalled();
     });
 
     it("does not crash when onDateFilterChange is not provided", () => {


### PR DESCRIPTION
## Summary
- Replace 8 "notify parent via effect" patterns with direct event handler calls in SearchControls, TimelineView, FolderView, PlaylistDetail, SceneGrid, and useVideoPlayer
- Replace 3 "derived state via effect" patterns with `useMemo`/inline computation in CarouselSettings, MarqueeText, and useScrollDirection
- Upgrade 4 DOM position calculation effects from `useEffect` to `useLayoutEffect` to prevent 1-frame position flicker in AddToPlaylistButton, ExternalPlayerButton, EntityMenu, and RatingSliderDialog

Follows up on the lint cleanup PR (#387) which revealed these composition opportunities. Applies Vercel React best practices: `rerender-move-effect-to-event`, `rerender-derived-state-no-effect`, and `rerender-use-ref-transient-values`.

Notable: `useScrollDirection` converted `lastScrollY` from state to ref, eliminating scroll listener re-registration on every scroll event (a meaningful performance win).

Video player hooks are excluded from refactoring per prior decision, except for the simple `updateQuality` effect which was safely inlined.

Closes #386

## Test plan
- [x] `cd client && npm run lint` — 0 errors
- [x] `cd client && npm run test:run` — 1063 tests passing
- [x] `cd client && npm run build` — succeeds
- [x] `cd server && npm run lint` — 0 errors
- [x] `cd server && npm test` — 931 tests passing
- [x] `cd server && npx tsc --noEmit` — 0 type errors
- [ ] Manual: SearchControls — change per-page and view mode, verify parent responds
- [ ] Manual: Timeline — select/deselect periods, verify scene list updates
- [ ] Manual: Folder view — navigate folders + use browser back/forward, verify filter updates
- [ ] Manual: Playlist detail — enter edit mode, verify selection clears
- [ ] Manual: Dropdowns/popovers — verify no position flicker on open
- [ ] Manual: Marquee text — verify animation still triggers on hover