### PR TITLE
fix: multi-instance data isolation and video stream stability

### DIFF
--- a/client/src/components/video-player/useVideoPlayer.js
+++ b/client/src/components/video-player/useVideoPlayer.js
@@ -580,7 +580,7 @@ export function useVideoPlayer({
 
     // Setup subtitles if available (using sourceSelector for track management)
     if (scene.captions && scene.captions.length > 0) {
-      setupSubtitles(player, scene.id, scene.captions);
+      setupSubtitles(player, scene.id, scene.captions, scene.instanceId);
     }
 
     // Configure player

--- a/client/src/components/video-player/videoPlayerUtils.js
+++ b/client/src/components/video-player/videoPlayerUtils.js
@@ -31,7 +31,7 @@ export const togglePlaybackRateControl = (player, show) => {
  * Adds text tracks via sourceSelector for proper lifecycle management
  * Video.js automatically shows/hides the caption button based on available tracks
  */
-export const setupSubtitles = (player, sceneId, captions) => {
+export const setupSubtitles = (player, sceneId, captions, instanceId) => {
   if (!player || player.isDisposed()) return;
   if (!captions || captions.length === 0) return;
 
@@ -91,7 +91,7 @@ export const setupSubtitles = (player, sceneId, captions) => {
 
     const trackOptions = {
       kind: "captions", // Use "captions" not "subtitles" to match Stash
-      src: `/api/scene/${sceneId}/caption?lang=${lang}&type=${caption.caption_type}`,
+      src: `/api/scene/${sceneId}/caption?lang=${lang}&type=${caption.caption_type}${instanceId ? `&instanceId=${instanceId}` : ""}`,
       srclang: lang,
       label: label,
       default: setAsDefault,

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -25,6 +25,23 @@ server {
         proxy_read_timeout 900s;  # 15 minutes for Stash sync operations
     }
 
+    # Long timeout for video stream proxying (direct play, HLS segments)
+    # Without this, Nginx kills streams on slow connections causing playback failures
+    location ~ ^/api/scene/[^/]+/proxy-stream/ {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;  # 5 minutes for video streams
+    }
+
     # Proxy API requests to backend (standard timeout)
     location /api/ {
         proxy_pass http://localhost:8000;

--- a/server/controllers/proxy.ts
+++ b/server/controllers/proxy.ts
@@ -317,6 +317,11 @@ export const proxyStashMedia = async (req: Request, res: Response) => {
       .json({ error: "Missing or invalid path parameter" });
   }
 
+  // Validate path to prevent traversal attacks
+  if (!path.startsWith("/") || path.includes("..") || path.includes("://")) {
+    return res.status(400).json({ error: "Invalid path parameter" });
+  }
+
   let stashUrl: string;
   let apiKey: string;
 

--- a/server/services/ClipQueryBuilder.ts
+++ b/server/services/ClipQueryBuilder.ts
@@ -94,7 +94,7 @@ class ClipQueryBuilder {
         FROM StashClip c
         INNER JOIN StashScene s ON c.sceneId = s.id AND c.sceneInstanceId = s.stashInstanceId
         LEFT JOIN StashTag pt ON c.primaryTagId = pt.id AND c.primaryTagInstanceId = pt.stashInstanceId
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'scene' AND e.entityId = c.sceneId
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'scene' AND e.entityId = c.sceneId AND (e.instanceId = '' OR e.instanceId = c.sceneInstanceId)
       `.trim(),
       params: [userId],
     };

--- a/server/services/GalleryQueryBuilder.ts
+++ b/server/services/GalleryQueryBuilder.ts
@@ -60,7 +60,7 @@ class GalleryQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'gallery' AND e.entityId = g.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'gallery' AND e.entityId = g.id AND (e.instanceId = '' OR e.instanceId = g.stashInstanceId)`,
         params: [userId, userId],
       };
     }
@@ -547,7 +547,7 @@ class GalleryQueryBuilder {
 
     if (hasUserDataFilters || applyExclusions) {
       const countSql = `
-        SELECT COUNT(DISTINCT g.id) as total
+        SELECT COUNT(DISTINCT g.id || ':' || g.stashInstanceId) as total
         ${fromClause.sql}
         WHERE ${whereSQL}
       `;

--- a/server/services/GroupQueryBuilder.ts
+++ b/server/services/GroupQueryBuilder.ts
@@ -58,7 +58,7 @@ class GroupQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'group' AND e.entityId = g.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'group' AND e.entityId = g.id AND (e.instanceId = '' OR e.instanceId = g.stashInstanceId)`,
         params: [userId, userId],
       };
     }
@@ -539,7 +539,7 @@ class GroupQueryBuilder {
 
     if (hasUserDataFilters || applyExclusions) {
       const countSql = `
-        SELECT COUNT(DISTINCT g.id) as total
+        SELECT COUNT(DISTINCT g.id || ':' || g.stashInstanceId) as total
         ${fromClause.sql}
         WHERE ${whereSQL}
       `;

--- a/server/services/ImageQueryBuilder.ts
+++ b/server/services/ImageQueryBuilder.ts
@@ -76,7 +76,7 @@ class ImageQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'image' AND e.entityId = i.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'image' AND e.entityId = i.id AND (e.instanceId = '' OR e.instanceId = i.stashInstanceId)`,
         params: [userId, userId, userId],
       };
     }
@@ -600,7 +600,7 @@ class ImageQueryBuilder {
 
     // Count query
     const countSql = `
-      SELECT COUNT(DISTINCT i.id) as total
+      SELECT COUNT(DISTINCT i.id || ':' || i.stashInstanceId) as total
       ${fromClause.sql}
       WHERE ${whereSQL}
     `;

--- a/server/services/RankingComputeService.ts
+++ b/server/services/RankingComputeService.ts
@@ -203,6 +203,7 @@ class RankingComputeService {
         ON e.userId = ${userId}
         AND e.entityType = 'performer'
         AND e.entityId = ups.performerId
+        AND (e.instanceId = '' OR e.instanceId = ups.instanceId)
       LEFT JOIN (
         SELECT sp.performerId, sp.performerInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM ScenePerformer sp
@@ -240,6 +241,7 @@ class RankingComputeService {
         ON e.userId = ${userId}
         AND e.entityType = 'studio'
         AND e.entityId = uss.studioId
+        AND (e.instanceId = '' OR e.instanceId = uss.instanceId)
       LEFT JOIN (
         SELECT s.studioId, s.stashInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM StashScene s
@@ -279,6 +281,7 @@ class RankingComputeService {
         ON e.userId = ${userId}
         AND e.entityType = 'tag'
         AND e.entityId = uts.tagId
+        AND (e.instanceId = '' OR e.instanceId = uts.instanceId)
       LEFT JOIN (
         SELECT st.tagId, st.tagInstanceId as instanceId, SUM(w.playDuration) as totalDuration
         FROM SceneTag st
@@ -317,6 +320,7 @@ class RankingComputeService {
         ON e.userId = ${userId}
         AND e.entityType = 'scene'
         AND e.entityId = w.sceneId
+        AND (e.instanceId = '' OR e.instanceId = COALESCE(w.instanceId, ''))
       WHERE w.userId = ${userId}
         AND e.id IS NULL
         AND (w.playCount > 0 OR w.oCount > 0 OR w.playDuration > 0)

--- a/server/services/SceneQueryBuilder.ts
+++ b/server/services/SceneQueryBuilder.ts
@@ -71,7 +71,7 @@ class SceneQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'scene' AND e.entityId = s.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'scene' AND e.entityId = s.id AND (e.instanceId = '' OR e.instanceId = s.stashInstanceId)`,
         params: [userId, userId, userId],
       };
     }
@@ -1269,7 +1269,7 @@ class SceneQueryBuilder {
     if (hasUserDataFilters || applyExclusions) {
       // Need full JOINs for accurate count with user data filters or exclusions
       const countSql = `
-        SELECT COUNT(DISTINCT s.id) as total
+        SELECT COUNT(DISTINCT s.id || ':' || s.stashInstanceId) as total
         ${fromClause.sql}
         WHERE ${whereSQL}
       `;

--- a/server/services/StudioQueryBuilder.ts
+++ b/server/services/StudioQueryBuilder.ts
@@ -59,7 +59,7 @@ class StudioQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'studio' AND e.entityId = s.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'studio' AND e.entityId = s.id AND (e.instanceId = '' OR e.instanceId = s.stashInstanceId)`,
         params: [userId, userId, userId],
       };
     }
@@ -379,7 +379,7 @@ class StudioQueryBuilder {
 
     if (hasUserDataFilters || applyExclusions) {
       const countSql = `
-        SELECT COUNT(DISTINCT s.id) as total
+        SELECT COUNT(DISTINCT s.id || ':' || s.stashInstanceId) as total
         ${fromClause.sql}
         WHERE ${whereSQL}
       `;

--- a/server/services/TagQueryBuilder.ts
+++ b/server/services/TagQueryBuilder.ts
@@ -60,7 +60,7 @@ class TagQueryBuilder {
     if (applyExclusions) {
       return {
         sql: `${baseJoins}
-        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'tag' AND e.entityId = t.id`,
+        LEFT JOIN UserExcludedEntity e ON e.userId = ? AND e.entityType = 'tag' AND e.entityId = t.id AND (e.instanceId = '' OR e.instanceId = t.stashInstanceId)`,
         params: [userId, userId, userId],
       };
     }
@@ -543,7 +543,7 @@ class TagQueryBuilder {
 
     if (hasUserDataFilters || applyExclusions) {
       const countSql = `
-        SELECT COUNT(DISTINCT t.id) as total
+        SELECT COUNT(DISTINCT t.id || ':' || t.stashInstanceId) as total
         ${fromClause.sql}
         WHERE ${whereSQL}
       `;

--- a/server/services/TimelineService.ts
+++ b/server/services/TimelineService.ts
@@ -106,7 +106,7 @@ export class TimelineService {
       FROM ${config.table} ${config.alias}
       ${joinClause}
       LEFT JOIN UserExcludedEntity e
-        ON e.userId = ? AND e.entityType = '${entityType}' AND e.entityId = ${config.alias}.id
+        ON e.userId = ? AND e.entityType = '${entityType}' AND e.entityId = ${config.alias}.id AND (e.instanceId = '' OR e.instanceId = ${config.alias}.stashInstanceId)
       WHERE ${config.alias}.deletedAt IS NULL
         AND e.id IS NULL
         AND ${config.dateField} IS NOT NULL


### PR DESCRIPTION
## Summary

Deep audit of all changes since v3.3.2 targeting the two most troublesome areas: multi-instance data isolation and video streaming stability. Fixes 16 files across server, client, and Docker config.

**Multi-instance data isolation:**
- **PerformerQueryBuilder.populateRelations**: Use composite keys (`id:instanceId`) for entity lookups to prevent cross-instance data leakage (tags/groups/galleries/studios from wrong instance appearing on performers)
- **All 9 query builders + TimelineService**: Scope `UserExcludedEntity` JOINs with `instanceId` to prevent content exclusions leaking across instances
- **All 7 query builders**: Fix `COUNT(DISTINCT)` to use composite keys so entities with same ID across instances aren't undercounted in pagination
- **RankingComputeService**: Scope exclusion JOINs with `instanceId` in all 4 ranking queries
- **Caption URLs**: Pass `instanceId` for multi-instance routing

**Video stream stability:**
- **Nginx**: Add dedicated location block for `/api/scene/*/proxy-stream/` with 300s timeout (was 60s from the general `/api/` block — likely root cause of user-reported video redirect/playback failures on slow connections)
- **video.ts**: Handle `"default"` instanceId consistently with proxy.ts
- **video.ts**: Don't send empty `Range` header when no range requested

**Race condition fix:**
- **ExclusionComputationService**: Add mutex for SQLite temp table operations to prevent concurrent user computations from interfering (single shared connection)

**Security:**
- **proxy.ts**: Add path traversal validation for media proxy path parameter

## Verification

All pre-release checks pass after fixes:
- Server unit tests: 935 passed (50 files)
- Client unit tests: 1063 passed (74 files)
- Integration tests: 602 passed (41 files)
- Server lint: 0 errors, 2 warnings
- Server type check: Clean
- Client lint: Clean
- Client build: Success
- Docker build: Success
- Temp table race condition: Verified fixed (no more `no such table: temp_excluded_*` errors)

## Test plan

- [ ] Verify video playback works on slow connections (direct play + HLS)
- [ ] Verify seeking doesn't cause stream termination
- [ ] Test with multiple Stash instances: confirm performer tags/groups/studios come from correct instance
- [ ] Test content exclusions don't leak across instances
- [ ] Test pagination counts are correct with overlapping entity IDs
- [ ] Test rankings exclude only the correct instance's entities
- [ ] Test captions load for scenes from non-default instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)