### PR TITLE
fix: restore folder/timeline view mode on back navigation

### DIFF
--- a/client/src/components/pages/Galleries.jsx
+++ b/client/src/components/pages/Galleries.jsx
@@ -59,7 +59,10 @@ const Galleries = () => {
   const { data, isLoading, error, initMessage, execute } = useCancellableQuery();
 
   // Track current view mode for timeline date filter and folder view
-  const [currentViewMode, setCurrentViewMode] = useState("grid");
+  // Initialize from URL to stay in sync with useFilterState on back navigation
+  const [currentViewMode, setCurrentViewMode] = useState(
+    searchParams.get("view") || "grid"
+  );
 
   // Fetch tags for folder view (only when folder view is active)
   const { tags: folderTags, isLoading: tagsLoading } = useFolderViewTags(

--- a/client/src/components/pages/Images.jsx
+++ b/client/src/components/pages/Images.jsx
@@ -55,7 +55,10 @@ const Images = () => {
   } = useTableColumns("image");
 
   // Track current view mode for timeline date filter and folder view
-  const [currentViewMode, setCurrentViewMode] = useState("grid");
+  // Initialize from URL to stay in sync with useFilterState on back navigation
+  const [currentViewMode, setCurrentViewMode] = useState(
+    searchParams.get("view") || "grid"
+  );
 
   // Fetch tags for folder view (only when folder view is active)
   const { tags: folderTags, isLoading: tagsLoading } = useFolderViewTags(

--- a/client/src/components/scene-search/SceneSearch.jsx
+++ b/client/src/components/scene-search/SceneSearch.jsx
@@ -86,7 +86,10 @@ const SceneSearch = ({
   const { data, isLoading, error, initMessage, execute, setData } = useCancellableQuery();
 
   // Track current view mode for context settings
-  const [currentViewMode, setCurrentViewMode] = useState("grid");
+  // Initialize from URL to stay in sync with useFilterState on back navigation
+  const [currentViewMode, setCurrentViewMode] = useState(
+    searchParams.get("view") || "grid"
+  );
 
   // Extract filter IDs for timeline/folder views
   const viewFilters = useMemo(() => {


### PR DESCRIPTION
## Summary
- Fixes view mode resetting to grid when pressing back from a detail page while in folder or timeline view
- Affects Galleries, Images, and Scene Search pages
- Root cause: `currentViewMode` state always initialized to `"grid"`, ignoring URL params that `useFilterState` correctly restores

## Context
Regression introduced by PR #389 which removed `useEffect` watchers that notified parent components of view mode changes (correctly, for user interactions) but missed the initialization path on remount/back navigation.

The fix initializes `currentViewMode` from URL search params — the same source `useFilterState` reads from — so parent state stays in sync without re-adding effects.

Closes #396

## Test plan
- [x] `cd client && npm run lint` — 0 errors
- [x] `cd client && npm run test:run` — 1063 tests passing
- [x] `cd client && npm run build` — succeeds
- [x] `cd server && npm run lint` — 0 errors
- [x] `cd server && npm test` — 935 tests passing
- [x] `cd server && npx tsc --noEmit` — 0 type errors
- [ ] Manual: Go to Galleries → set folder view → open a gallery → press back → verify folder view is preserved
- [ ] Manual: Go to Images → set timeline view → open an image → press back → verify timeline view is preserved
- [ ] Manual: Go to Scenes → set folder view → navigate into a folder → open a scene → press back → verify folder + path preserved