### PR TITLE
fix: isolate entity filters by instance to prevent cross-server contamination

### DIFF
--- a/client/src/components/pages/GalleryDetail.jsx
+++ b/client/src/components/pages/GalleryDetail.jsx
@@ -425,7 +425,7 @@ const GalleryDetail = () => {
                   context="gallery_scenes"
                   permanentFilters={{
                     galleries: {
-                      value: [parseInt(galleryId, 10)],
+                      value: [instanceId ? `${galleryId}:${instanceId}` : String(galleryId)],
                       modifier: "INCLUDES"
                     }
                   }}

--- a/client/src/components/pages/GroupDetail.jsx
+++ b/client/src/components/pages/GroupDetail.jsx
@@ -209,7 +209,7 @@ const GroupDetail = () => {
                   context="scene_group"
                   initialSort="scene_index"
                   permanentFilters={{
-                    groups: { value: [parseInt(groupId, 10)], modifier: "INCLUDES" } }}
+                    groups: { value: [instanceId ? `${groupId}:${instanceId}` : String(groupId)], modifier: "INCLUDES" } }}
                   permanentFiltersMetadata={{
                     groups: [
                       { id: groupId, name: group?.name || "Unknown Collection" },
@@ -224,7 +224,7 @@ const GroupDetail = () => {
                   lockedFilters={{
                     performer_filter: {
                       groups: {
-                        value: [parseInt(groupId, 10)],
+                        value: [instanceId ? `${groupId}:${instanceId}` : String(groupId)],
                         modifier: "INCLUDES" } } }}
                   hideLockedFilters
                   emptyMessage={`No performers found in "${group?.name}"`}

--- a/client/src/components/pages/PerformerDetail.jsx
+++ b/client/src/components/pages/PerformerDetail.jsx
@@ -206,7 +206,7 @@ const PerformerDetail = () => {
                   context="scene_performer"
                   permanentFilters={{
                     performers: {
-                      value: [parseInt(performerId, 10)],
+                      value: [instanceId ? `${performerId}:${instanceId}` : String(performerId)],
                       modifier: "INCLUDES" } }}
                   permanentFiltersMetadata={{
                     performers: [{ id: performerId, name: performer.name }] }}
@@ -220,7 +220,7 @@ const PerformerDetail = () => {
                   lockedFilters={{
                     gallery_filter: {
                       performers: {
-                        value: [parseInt(performerId, 10)],
+                        value: [instanceId ? `${performerId}:${instanceId}` : String(performerId)],
                         modifier: "INCLUDES" } } }}
                   hideLockedFilters
                   emptyMessage={`No galleries found for ${performer.name}`}
@@ -228,7 +228,7 @@ const PerformerDetail = () => {
               )}
 
               {activeTab === 'images' && (
-                <ImagesTab performerId={performerId} performerName={performer?.name} />
+                <ImagesTab performerId={performerId} instanceId={instanceId} performerName={performer?.name} />
               )}
 
               {activeTab === 'groups' && (
@@ -236,7 +236,7 @@ const PerformerDetail = () => {
                   lockedFilters={{
                     group_filter: {
                       performers: {
-                        value: [parseInt(performerId, 10)],
+                        value: [instanceId ? `${performerId}:${instanceId}` : String(performerId)],
                         modifier: "INCLUDES" } } }}
                   hideLockedFilters
                   emptyMessage={`No collections found for ${performer.name}`}
@@ -699,7 +699,7 @@ const PerformerLinks = ({ performer, settings }) => {
 };
 
 // Images Tab Component with Lightbox
-const ImagesTab = ({ performerId, performerName }) => {
+const ImagesTab = ({ performerId, instanceId, performerName }) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   // URL-based page state for image pagination
@@ -722,7 +722,7 @@ const ImagesTab = ({ performerId, performerName }) => {
         filter: { page, per_page: perPage },
         image_filter: {
           performers: {
-            value: [parseInt(performerId, 10)],
+            value: [instanceId ? `${performerId}:${instanceId}` : String(performerId)],
             modifier: "INCLUDES",
           },
         },
@@ -732,12 +732,12 @@ const ImagesTab = ({ performerId, performerName }) => {
         count: data.findImages?.count || 0,
       };
     },
-    [performerId]
+    [performerId, instanceId]
   );
 
   const { images, totalCount, isLoading, lightbox, setImages } = useImagesPagination({
     fetchImages,
-    dependencies: [performerId],
+    dependencies: [performerId, instanceId],
     externalPage: urlPage,
     onExternalPageChange: handleImagePageChange,
   });

--- a/client/src/components/pages/Scene.jsx
+++ b/client/src/components/pages/Scene.jsx
@@ -247,7 +247,7 @@ const SceneContent = () => {
                   lockedFilters={{
                     group_filter: {
                       scenes: {
-                        value: [parseInt(scene.id, 10)],
+                        value: [scene.instanceId ? `${scene.id}:${scene.instanceId}` : String(scene.id)],
                         modifier: "INCLUDES"
                       }
                     }
@@ -264,7 +264,7 @@ const SceneContent = () => {
                   lockedFilters={{
                     gallery_filter: {
                       scenes: {
-                        value: [parseInt(scene.id, 10)],
+                        value: [scene.instanceId ? `${scene.id}:${scene.instanceId}` : String(scene.id)],
                         modifier: "INCLUDES"
                       }
                     }

--- a/client/src/components/pages/StudioDetail.jsx
+++ b/client/src/components/pages/StudioDetail.jsx
@@ -260,7 +260,7 @@ const StudioDetail = () => {
                   context="scene_studio"
                   permanentFilters={{
                     studios: {
-                      value: [parseInt(studioId, 10)],
+                      value: [instanceId ? `${studioId}:${instanceId}` : String(studioId)],
                       modifier: "INCLUDES",
                       ...(includeSubStudios && { depth: -1 }) } }}
                   permanentFiltersMetadata={{
@@ -278,7 +278,7 @@ const StudioDetail = () => {
                   lockedFilters={{
                     gallery_filter: {
                       studios: {
-                        value: [parseInt(studioId, 10)],
+                        value: [instanceId ? `${studioId}:${instanceId}` : String(studioId)],
                         modifier: "INCLUDES",
                         ...(includeSubStudios && { depth: -1 }) } } }}
                   hideLockedFilters
@@ -289,6 +289,7 @@ const StudioDetail = () => {
               {activeTab === "images" && (
                 <ImagesTab
                   studioId={studioId}
+                  instanceId={instanceId}
                   studioName={studio?.name}
                   includeSubStudios={includeSubStudios}
                 />
@@ -299,7 +300,7 @@ const StudioDetail = () => {
                   lockedFilters={{
                     performer_filter: {
                       studios: {
-                        value: [parseInt(studioId, 10)],
+                        value: [instanceId ? `${studioId}:${instanceId}` : String(studioId)],
                         modifier: "INCLUDES" } } }}
                   hideLockedFilters
                   emptyMessage={`No performers found for ${studio?.name}`}
@@ -311,7 +312,7 @@ const StudioDetail = () => {
                   lockedFilters={{
                     group_filter: {
                       studios: {
-                        value: [parseInt(studioId, 10)],
+                        value: [instanceId ? `${studioId}:${instanceId}` : String(studioId)],
                         modifier: "INCLUDES" } } }}
                   hideLockedFilters
                   emptyMessage={`No collections found for ${studio?.name}`}
@@ -645,7 +646,7 @@ const StudioDetails = ({ studio, settings, hasMultipleInstances }) => {
 };
 
 // Images Tab Component with Lightbox
-const ImagesTab = ({ studioId, studioName, includeSubStudios = false }) => {
+const ImagesTab = ({ studioId, instanceId, studioName, includeSubStudios = false }) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   // URL-based page state for image pagination
@@ -668,7 +669,7 @@ const ImagesTab = ({ studioId, studioName, includeSubStudios = false }) => {
         filter: { page, per_page: perPage },
         image_filter: {
           studios: {
-            value: [parseInt(studioId, 10)],
+            value: [instanceId ? `${studioId}:${instanceId}` : String(studioId)],
             modifier: "INCLUDES",
             ...(includeSubStudios && { depth: -1 }),
           },
@@ -679,12 +680,12 @@ const ImagesTab = ({ studioId, studioName, includeSubStudios = false }) => {
         count: data.findImages?.count || 0,
       };
     },
-    [studioId, includeSubStudios]
+    [studioId, instanceId, includeSubStudios]
   );
 
   const { images, totalCount, isLoading, lightbox, setImages } = useImagesPagination({
     fetchImages,
-    dependencies: [studioId, includeSubStudios],
+    dependencies: [studioId, instanceId, includeSubStudios],
     externalPage: urlPage,
     onExternalPageChange: handleImagePageChange,
   });

--- a/client/src/components/pages/TagDetail.jsx
+++ b/client/src/components/pages/TagDetail.jsx
@@ -293,7 +293,7 @@ const TagDetail = () => {
                   context="scene_tag"
                   permanentFilters={{
                     tags: {
-                      value: [parseInt(tagId, 10)],
+                      value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
                       modifier: "INCLUDES",
                       ...(includeSubTags && { depth: -1 }),
                     },
@@ -312,7 +312,7 @@ const TagDetail = () => {
                   lockedFilters={{
                     gallery_filter: {
                       tags: {
-                        value: [parseInt(tagId, 10)],
+                        value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
                         modifier: "INCLUDES",
                         ...(includeSubTags && { depth: -1 }),
                       },
@@ -324,7 +324,7 @@ const TagDetail = () => {
               )}
 
               {activeTab === 'images' && (
-                <ImagesTab tagId={tagId} tagName={tag?.name} includeSubTags={includeSubTags} />
+                <ImagesTab tagId={tagId} instanceId={instanceId} tagName={tag?.name} includeSubTags={includeSubTags} />
               )}
 
               {activeTab === 'performers' && (
@@ -332,7 +332,7 @@ const TagDetail = () => {
                   lockedFilters={{
                     performer_filter: {
                       tags: {
-                        value: [parseInt(tagId, 10)],
+                        value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
                         modifier: "INCLUDES",
                       },
                     },
@@ -347,7 +347,7 @@ const TagDetail = () => {
                   lockedFilters={{
                     studio_filter: {
                       tags: {
-                        value: [parseInt(tagId, 10)],
+                        value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
                         modifier: "INCLUDES",
                       },
                     },
@@ -362,7 +362,7 @@ const TagDetail = () => {
                   lockedFilters={{
                     group_filter: {
                       tags: {
-                        value: [parseInt(tagId, 10)],
+                        value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
                         modifier: "INCLUDES",
                       },
                     },
@@ -595,7 +595,7 @@ const TagDetails = ({ tag, hasMultipleInstances }) => {
 };
 
 // Images Tab Component with Lightbox
-const ImagesTab = ({ tagId, tagName, includeSubTags = false }) => {
+const ImagesTab = ({ tagId, instanceId, tagName, includeSubTags = false }) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   // URL-based page state for image pagination
@@ -618,7 +618,7 @@ const ImagesTab = ({ tagId, tagName, includeSubTags = false }) => {
         filter: { page, per_page: perPage },
         image_filter: {
           tags: {
-            value: [parseInt(tagId, 10)],
+            value: [instanceId ? `${tagId}:${instanceId}` : String(tagId)],
             modifier: "INCLUDES",
             ...(includeSubTags && { depth: -1 }),
           },
@@ -629,12 +629,12 @@ const ImagesTab = ({ tagId, tagName, includeSubTags = false }) => {
         count: data.findImages?.count || 0,
       };
     },
-    [tagId, includeSubTags]
+    [tagId, instanceId, includeSubTags]
   );
 
   const { images, totalCount, isLoading, lightbox, setImages } = useImagesPagination({
     fetchImages,
-    dependencies: [tagId, includeSubTags],
+    dependencies: [tagId, instanceId, includeSubTags],
     externalPage: urlPage,
     onExternalPageChange: handleImagePageChange,
   });

--- a/client/tests/utils/urlParams.test.js
+++ b/client/tests/utils/urlParams.test.js
@@ -1,0 +1,176 @@
+/**
+ * Tests for URL parameter serialization/deserialization
+ * Focuses on the singular-to-plural param mapping with instance support
+ * for card indicator click navigation.
+ */
+import { describe, it, expect } from "vitest";
+import { buildSearchParams, parseSearchParams } from "@/utils/urlParams.js";
+
+// Minimal filterOptions for testing - matches the shape from filterConfig.js
+const mockFilterOptions = [
+  { key: "performerIds", type: "searchable-select", multi: true },
+  { key: "tagIds", type: "searchable-select", multi: true },
+  { key: "studioId", type: "searchable-select", multi: false },
+  { key: "groupIds", type: "searchable-select", multi: true },
+  { key: "galleryIds", type: "searchable-select", multi: true },
+];
+
+describe("parseSearchParams", () => {
+  describe("singular entity params with instance", () => {
+    it("maps performerId + instance to performerIds array with composite key", () => {
+      const params = new URLSearchParams("performerId=82&instance=server-1");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.performerIds).toEqual(["82:server-1"]);
+    });
+
+    it("maps tagId + instance to tagIds array with composite key", () => {
+      const params = new URLSearchParams("tagId=5&instance=server-2");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.tagIds).toEqual(["5:server-2"]);
+    });
+
+    it("maps studioId + instance to studioId string (single-select)", () => {
+      const params = new URLSearchParams("studioId=3&instance=server-1");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.studioId).toBe("3:server-1");
+    });
+
+    it("maps groupId + instance to groupIds array with composite key", () => {
+      const params = new URLSearchParams("groupId=10&instance=server-1");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.groupIds).toEqual(["10:server-1"]);
+    });
+
+    it("maps galleryId + instance to galleryIds array with composite key", () => {
+      const params = new URLSearchParams("galleryId=7&instance=abc-123");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.galleryIds).toEqual(["7:abc-123"]);
+    });
+  });
+
+  describe("singular entity params without instance", () => {
+    it("maps performerId without instance to bare ID", () => {
+      const params = new URLSearchParams("performerId=82");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.performerIds).toEqual(["82"]);
+    });
+
+    it("maps studioId without instance to bare string", () => {
+      const params = new URLSearchParams("studioId=3");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.studioId).toBe("3");
+    });
+  });
+
+  describe("standard filter params (plural keys)", () => {
+    it("parses multi-select comma-separated values", () => {
+      const params = new URLSearchParams("performerIds=82:server-1,5:server-2");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.performerIds).toEqual(["82:server-1", "5:server-2"]);
+    });
+
+    it("parses single-select value", () => {
+      const params = new URLSearchParams("studioId=3:server-1");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.filters.studioId).toBe("3:server-1");
+    });
+  });
+
+  describe("non-filter params", () => {
+    it("parses search text", () => {
+      const params = new URLSearchParams("q=test");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.searchText).toBe("test");
+    });
+
+    it("parses sort and direction", () => {
+      const params = new URLSearchParams("sort=date&dir=ASC");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.sortField).toBe("date");
+      expect(result.sortDirection).toBe("ASC");
+    });
+
+    it("parses page and perPage", () => {
+      const params = new URLSearchParams("page=3&per_page=48");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.currentPage).toBe(3);
+      expect(result.perPage).toBe(48);
+    });
+
+    it("parses view mode", () => {
+      const params = new URLSearchParams("view=wall");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.viewMode).toBe("wall");
+    });
+
+    it("uses defaults for missing params", () => {
+      const params = new URLSearchParams("");
+      const result = parseSearchParams(params, mockFilterOptions);
+      expect(result.searchText).toBe("");
+      expect(result.sortField).toBe("o_counter");
+      expect(result.sortDirection).toBe("DESC");
+      expect(result.currentPage).toBe(1);
+      expect(result.perPage).toBe(24);
+      expect(result.viewMode).toBe("grid");
+    });
+  });
+});
+
+describe("buildSearchParams", () => {
+  it("serializes composite filter values as comma-separated", () => {
+    const params = buildSearchParams({
+      searchText: "",
+      sortField: "",
+      sortDirection: "",
+      currentPage: 1,
+      perPage: 24,
+      filters: { performerIds: ["82:server-1", "5:server-2"] },
+      filterOptions: mockFilterOptions,
+    });
+    expect(params.get("performerIds")).toBe("82:server-1,5:server-2");
+  });
+
+  it("serializes single-select composite value", () => {
+    const params = buildSearchParams({
+      searchText: "",
+      sortField: "",
+      sortDirection: "",
+      currentPage: 1,
+      perPage: 24,
+      filters: { studioId: "3:server-1" },
+      filterOptions: mockFilterOptions,
+    });
+    expect(params.get("studioId")).toBe("3:server-1");
+  });
+
+  it("skips empty filters", () => {
+    const params = buildSearchParams({
+      searchText: "",
+      sortField: "",
+      sortDirection: "",
+      currentPage: 1,
+      perPage: 24,
+      filters: { performerIds: [] },
+      filterOptions: mockFilterOptions,
+    });
+    expect(params.has("performerIds")).toBe(false);
+  });
+
+  it("only includes non-default view params", () => {
+    const params = buildSearchParams({
+      searchText: "",
+      sortField: "",
+      sortDirection: "",
+      currentPage: 1,
+      perPage: 24,
+      viewMode: "grid",
+      zoomLevel: "medium",
+      gridDensity: "medium",
+      filters: {},
+      filterOptions: mockFilterOptions,
+    });
+    expect(params.has("view")).toBe(false);
+    expect(params.has("zoom")).toBe(false);
+    expect(params.has("grid_density")).toBe(false);
+  });
+});

--- a/server/controllers/library/galleries.ts
+++ b/server/controllers/library/galleries.ts
@@ -469,6 +469,7 @@ export const findGalleriesMinimal = async (
     const minimalGalleries = galleries.map((g) => ({
       id: g.id,
       title: g.title || "", // Galleries use 'title' not 'name'
+      instanceId: g.instanceId || "",
     }));
 
     res.json({

--- a/server/controllers/library/groups.ts
+++ b/server/controllers/library/groups.ts
@@ -318,6 +318,7 @@ export const findGroupsMinimal = async (
     const minimalGroups = groups.map((g) => ({
       id: g.id,
       name: g.name,
+      instanceId: g.instanceId || "",
       favorite: g.favorite,
     }));
 

--- a/server/tests/utils/entityInstanceId.test.ts
+++ b/server/tests/utils/entityInstanceId.test.ts
@@ -308,8 +308,8 @@ describe("entityInstanceId", () => {
       ]);
 
       expect(result).toEqual([
-        { id: "1", name: "Jane Doe" },
-        { id: "2", name: "John Smith" },
+        { id: "1", name: "Jane Doe", instanceId: "aaa-111" },
+        { id: "2", name: "John Smith", instanceId: "aaa-111" },
       ]);
     });
 
@@ -320,8 +320,8 @@ describe("entityInstanceId", () => {
       ]);
 
       expect(result).toEqual([
-        { id: "1", name: "Jane Doe" },
-        { id: "2", name: "John Smith" },
+        { id: "1", name: "Jane Doe", instanceId: "aaa-111" },
+        { id: "2", name: "John Smith", instanceId: "bbb-222" },
       ]);
     });
 
@@ -332,9 +332,9 @@ describe("entityInstanceId", () => {
       ]);
 
       // Default instance (lowest priority) keeps plain name
-      expect(result[0]).toEqual({ id: "1", name: "Jane Doe" });
+      expect(result[0]).toEqual({ id: "1", name: "Jane Doe", instanceId: "aaa-111" });
       // Non-default instance gets suffix
-      expect(result[1]).toEqual({ id: "2", name: "Jane Doe (Secondary Stash)" });
+      expect(result[1]).toEqual({ id: "2", name: "Jane Doe (Secondary Stash)", instanceId: "bbb-222" });
     });
 
     it("disambiguates case-insensitively", () => {
@@ -343,8 +343,8 @@ describe("entityInstanceId", () => {
         { id: "2", name: "Jane Doe", instanceId: "bbb-222" },
       ]);
 
-      expect(result[0]).toEqual({ id: "1", name: "jane doe" });
-      expect(result[1]).toEqual({ id: "2", name: "Jane Doe (Secondary Stash)" });
+      expect(result[0]).toEqual({ id: "1", name: "jane doe", instanceId: "aaa-111" });
+      expect(result[1]).toEqual({ id: "2", name: "Jane Doe (Secondary Stash)", instanceId: "bbb-222" });
     });
 
     it("does not suffix default instance even with duplicates", () => {
@@ -371,8 +371,8 @@ describe("entityInstanceId", () => {
       ]);
 
       // Both empty names = duplicates, non-default gets suffix
-      expect(result[0]).toEqual({ id: "1", name: "" });
-      expect(result[1]).toEqual({ id: "2", name: " (Secondary Stash)" });
+      expect(result[0]).toEqual({ id: "1", name: "", instanceId: "aaa-111" });
+      expect(result[1]).toEqual({ id: "2", name: " (Secondary Stash)", instanceId: "bbb-222" });
     });
 
     it("handles no instances configured", () => {
@@ -383,7 +383,7 @@ describe("entityInstanceId", () => {
       ]);
 
       // With 0 instances, no disambiguation needed
-      expect(result).toEqual([{ id: "1", name: "Test" }]);
+      expect(result).toEqual([{ id: "1", name: "Test", instanceId: "aaa-111" }]);
     });
 
     it("handles multiple duplicated names correctly", () => {

--- a/server/types/api/library.ts
+++ b/server/types/api/library.ts
@@ -137,7 +137,7 @@ export interface FindPerformersMinimalRequest {
 }
 
 export interface FindPerformersMinimalResponse {
-  performers: Array<{ id: string; name: string }>;
+  performers: Array<{ id: string; name: string; instanceId: string }>;
 }
 
 /**
@@ -187,7 +187,7 @@ export interface FindStudiosMinimalRequest {
 }
 
 export interface FindStudiosMinimalResponse {
-  studios: Array<{ id: string; name: string }>;
+  studios: Array<{ id: string; name: string; instanceId: string }>;
 }
 
 /**
@@ -237,7 +237,7 @@ export interface FindTagsMinimalRequest {
 }
 
 export interface FindTagsMinimalResponse {
-  tags: Array<{ id: string; name: string }>;
+  tags: Array<{ id: string; name: string; instanceId: string }>;
 }
 
 /**
@@ -366,7 +366,7 @@ export interface FindGalleriesMinimalRequest {
 }
 
 export interface FindGalleriesMinimalResponse {
-  galleries: Array<{ id: string; title: string }>;
+  galleries: Array<{ id: string; title: string; instanceId: string }>;
 }
 
 // =============================================================================
@@ -398,7 +398,7 @@ export interface FindGroupsMinimalRequest {
 }
 
 export interface FindGroupsMinimalResponse {
-  groups: Array<{ id: string; name: string }>;
+  groups: Array<{ id: string; name: string; instanceId: string }>;
 }
 
 // =============================================================================

--- a/server/utils/entityInstanceId.ts
+++ b/server/utils/entityInstanceId.ts
@@ -393,6 +393,7 @@ interface EntityWithInstance {
 interface MinimalEntityResult {
   id: string;
   name: string;
+  instanceId: string;
 }
 
 /**
@@ -413,7 +414,7 @@ export function disambiguateEntityNames(entities: EntityWithInstance[]): Minimal
 
   // If only one instance or no instances, no disambiguation needed
   if (instances.length <= 1) {
-    return entities.map(e => ({ id: e.id, name: e.name }));
+    return entities.map(e => ({ id: e.id, name: e.name, instanceId: e.instanceId }));
   }
 
   // Find the default instance (lowest priority number)
@@ -455,9 +456,10 @@ export function disambiguateEntityNames(entities: EntityWithInstance[]): Minimal
       return {
         id: entity.id,
         name: `${entity.name} (${instanceName})`,
+        instanceId: entity.instanceId,
       };
     }
 
-    return { id: entity.id, name: entity.name };
+    return { id: entity.id, name: entity.name, instanceId: entity.instanceId };
   });
 }

--- a/server/utils/sqlFilterBuilders.ts
+++ b/server/utils/sqlFilterBuilders.ts
@@ -11,6 +11,185 @@ export interface FilterClause {
 }
 
 /**
+ * Parsed composite filter value.
+ * Values can be either "entityId" (bare) or "entityId:instanceId" (composite).
+ */
+export interface ParsedFilterValue {
+  id: string;
+  instanceId: string | undefined;
+}
+
+/**
+ * Parse composite filter values (e.g., "82:uuid-server1") into separate
+ * entity IDs and instance IDs. Supports both bare IDs and composite keys.
+ *
+ * @param values - Array of filter values, either bare IDs or "id:instanceId" composites
+ * @returns Object with separate arrays for SQL parameterization
+ */
+export function parseCompositeFilterValues(values: string[]): {
+  parsed: ParsedFilterValue[];
+  hasInstanceIds: boolean;
+} {
+  const parsed = values.map((v) => {
+    const colonIdx = v.indexOf(":");
+    if (colonIdx === -1) {
+      return { id: v, instanceId: undefined };
+    }
+    return { id: v.substring(0, colonIdx), instanceId: v.substring(colonIdx + 1) };
+  });
+
+  const hasInstanceIds = parsed.some((p) => p.instanceId !== undefined);
+  return { parsed, hasInstanceIds };
+}
+
+/**
+ * Build a junction table entity filter with instance-aware matching.
+ * Generates SQL for INCLUDES, INCLUDES_ALL, or EXCLUDES with optional
+ * instanceId constraints when composite keys are provided.
+ *
+ * @param ids - Array of filter values (bare IDs or "id:instanceId" composites)
+ * @param junctionTable - Junction table name (e.g., "ScenePerformer")
+ * @param parentIdCol - Parent entity ID column in junction table (e.g., "sceneId")
+ * @param parentInstanceCol - Parent entity instance column (e.g., "sceneInstanceId")
+ * @param entityIdCol - Filtered entity ID column (e.g., "performerId")
+ * @param entityInstanceCol - Filtered entity instance column (e.g., "performerInstanceId")
+ * @param parentAlias - Alias for the parent table (e.g., "s")
+ * @param modifier - Filter modifier: INCLUDES, INCLUDES_ALL, or EXCLUDES
+ */
+export function buildJunctionFilter(
+  ids: string[],
+  junctionTable: string,
+  parentIdCol: string,
+  parentInstanceCol: string,
+  entityIdCol: string,
+  entityInstanceCol: string,
+  parentAlias: string,
+  modifier: string
+): FilterClause {
+  const { parsed, hasInstanceIds } = parseCompositeFilterValues(ids);
+  const bareIds = parsed.map((p) => p.id);
+  const alias = junctionTable.charAt(0).toLowerCase() + junctionTable.charAt(1);
+  const placeholders = bareIds.map(() => "?").join(", ");
+
+  if (!hasInstanceIds) {
+    // No instance IDs provided — match by entity ID only (backward compat)
+    switch (modifier) {
+      case "INCLUDES":
+        return {
+          sql: `EXISTS (SELECT 1 FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND ${alias}.${entityIdCol} IN (${placeholders}))`,
+          params: bareIds,
+        };
+      case "INCLUDES_ALL":
+        return {
+          sql: `(SELECT COUNT(DISTINCT ${alias}.${entityIdCol}) FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND ${alias}.${entityIdCol} IN (${placeholders})) = ?`,
+          params: [...bareIds, bareIds.length],
+        };
+      case "EXCLUDES":
+        return {
+          sql: `NOT EXISTS (SELECT 1 FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND ${alias}.${entityIdCol} IN (${placeholders}))`,
+          params: bareIds,
+        };
+      default:
+        return { sql: "", params: [] };
+    }
+  }
+
+  // Instance-aware matching: build (entityId = ? AND entityInstanceId = ?) OR ... pairs
+  const pairConditions = parsed.map((p) => {
+    if (p.instanceId) {
+      return `(${alias}.${entityIdCol} = ? AND ${alias}.${entityInstanceCol} = ?)`;
+    }
+    // Bare ID within a mixed set — match any instance
+    return `(${alias}.${entityIdCol} = ?)`;
+  });
+  const pairParams: string[] = [];
+  for (const p of parsed) {
+    pairParams.push(p.id);
+    if (p.instanceId) {
+      pairParams.push(p.instanceId);
+    }
+  }
+  const pairSql = pairConditions.join(" OR ");
+
+  switch (modifier) {
+    case "INCLUDES":
+      return {
+        sql: `EXISTS (SELECT 1 FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND (${pairSql}))`,
+        params: pairParams,
+      };
+    case "INCLUDES_ALL":
+      return {
+        sql: `(SELECT COUNT(DISTINCT ${alias}.${entityIdCol} || ':' || ${alias}.${entityInstanceCol}) FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND (${pairSql})) = ?`,
+        params: [...pairParams, parsed.length],
+      };
+    case "EXCLUDES":
+      return {
+        sql: `NOT EXISTS (SELECT 1 FROM ${junctionTable} ${alias} WHERE ${alias}.${parentIdCol} = ${parentAlias}.id AND ${alias}.${parentInstanceCol} = ${parentAlias}.stashInstanceId AND (${pairSql}))`,
+        params: pairParams,
+      };
+    default:
+      return { sql: "", params: [] };
+  }
+}
+
+/**
+ * Build a direct column entity filter with instance-aware matching.
+ * For entities that use a direct FK (e.g., studios) rather than a junction table.
+ *
+ * @param ids - Array of filter values (bare IDs or "id:instanceId" composites)
+ * @param idColumn - Column for entity ID (e.g., "s.studioId")
+ * @param instanceColumn - Column for entity instance (e.g., "s.studioInstanceId")
+ * @param modifier - Filter modifier: INCLUDES or EXCLUDES
+ */
+export function buildDirectFilter(
+  ids: string[],
+  idColumn: string,
+  instanceColumn: string,
+  modifier: string
+): FilterClause {
+  const { parsed, hasInstanceIds } = parseCompositeFilterValues(ids);
+  const bareIds = parsed.map((p) => p.id);
+  const placeholders = bareIds.map(() => "?").join(", ");
+
+  if (!hasInstanceIds) {
+    // No instance IDs — match by entity ID only
+    switch (modifier) {
+      case "INCLUDES":
+        return { sql: `${idColumn} IN (${placeholders})`, params: bareIds };
+      case "EXCLUDES":
+        return { sql: `(${idColumn} IS NULL OR ${idColumn} NOT IN (${placeholders}))`, params: bareIds };
+      default:
+        return { sql: "", params: [] };
+    }
+  }
+
+  // Instance-aware: build pair conditions
+  const pairConditions = parsed.map((p) => {
+    if (p.instanceId) {
+      return `(${idColumn} = ? AND ${instanceColumn} = ?)`;
+    }
+    return `(${idColumn} = ?)`;
+  });
+  const pairParams: string[] = [];
+  for (const p of parsed) {
+    pairParams.push(p.id);
+    if (p.instanceId) {
+      pairParams.push(p.instanceId);
+    }
+  }
+  const pairSql = pairConditions.join(" OR ");
+
+  switch (modifier) {
+    case "INCLUDES":
+      return { sql: `(${pairSql})`, params: pairParams };
+    case "EXCLUDES":
+      return { sql: `NOT (${pairSql})`, params: pairParams };
+    default:
+      return { sql: "", params: [] };
+  }
+}
+
+/**
  * Build a numeric comparison filter clause.
  * Handles EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN, BETWEEN, NOT_BETWEEN.
  *


### PR DESCRIPTION
## Summary

Fixes #400 — Entity filter dropdowns and query builders now carry `instanceId` through the full filter pipeline using composite `"entityId:instanceId"` keys. This prevents ID collisions across Stash servers from returning wrong results (e.g., selecting performer 82 from server1 no longer returns scenes belonging to performer 82 on server2).

**Changes across 23 files:**

- **Minimal endpoints** (`entityInstanceId.ts`, `library.ts`) now return `instanceId` in all entity responses
- **SearchableSelect** stores composite `id:instanceId` keys and parses them for API lookups
- **All 7 query builders** (Scene, Image, Gallery, Performer, Studio, Tag, Group) use new shared `buildJunctionFilter`/`buildDirectFilter` utilities that add `instanceId` constraints when composite keys are provided
- **URL param handling** (`urlParams.js`) maps singular card-click params (`performerId=82&instance=xyz`) to composite filter values
- **Detail pages** (Performer, Studio, Tag, Group, Gallery, Scene) pass composite keys in `permanentFilters`
- **Backward compatible**: Bare IDs (no colon) match any instance, preserving existing behavior for carousel rules and content restrictions

## Test plan

- [x] 955 server tests pass (including 37 new `sqlFilterBuilders` tests for composite key parsing, junction filters, and direct filters)
- [x] 1081 client tests pass (including 18 new `urlParams` tests for singular-to-plural mapping with instance support)
- [x] Server lint: 0 errors
- [x] Client lint: 0 errors, 0 warnings
- [ ] Manual: Multi-instance setup — filter by performer from server1, verify only server1 scenes returned
- [ ] Manual: Card indicator click navigates with instance param, filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)