### PR TITLE
chore: multi-instance audit — fix remaining edge cases

### DIFF
--- a/server/controllers/playlist.ts
+++ b/server/controllers/playlist.ts
@@ -929,6 +929,7 @@ export const duplicatePlaylist = async (
         items: {
           create: original.items.map((item) => ({
             sceneId: item.sceneId,
+            instanceId: item.instanceId,
             position: item.position,
           })),
         },

--- a/server/services/PlaylistZipService.ts
+++ b/server/services/PlaylistZipService.ts
@@ -127,7 +127,10 @@ export class PlaylistZipService {
         // Get scene with relations for NFO generation
         // Use findFirst since composite primary key [id, stashInstanceId] requires both fields for findUnique
         const scene = await prisma.stashScene.findFirst({
-          where: { id: item.sceneId },
+          where: {
+            id: item.sceneId,
+            ...(item.instanceId ? { stashInstanceId: item.instanceId } : {}),
+          },
           include: {
             performers: {
               include: {
@@ -157,7 +160,10 @@ export class PlaylistZipService {
         if (scene.studioId) {
           // Use findFirst since composite primary key [id, stashInstanceId] requires both fields for findUnique
           const studio = await prisma.stashStudio.findFirst({
-            where: { id: scene.studioId },
+            where: {
+              id: scene.studioId,
+              ...(scene.stashInstanceId ? { stashInstanceId: scene.stashInstanceId } : {}),
+            },
             select: { name: true },
           });
           studioName = studio?.name;


### PR DESCRIPTION
## Summary

Closes #403 — Final audit pass for multi-instance support. Fixes the remaining edge cases identified after #402:

- **ClipQueryBuilder**: All 4 filter methods (tags, scene tags, performers, studio) now support composite `id:instanceId` keys with instance-aware SQL, matching the pattern used by all other query builders
- **Playlist duplication**: `duplicatePlaylist()` now copies `instanceId` when creating new items (was silently dropping it, breaking cross-instance playlist copies)
- **PlaylistZipService**: Scene and studio lookups now filter by `stashInstanceId` to avoid returning wrong-instance data when IDs collide

**No changes needed for:**
- Carousel rules — intentionally global (filtered by user's allowed instances at query time)
- Content restrictions — intentionally global (`instanceId=""` in exclusions means "all instances")
- Hidden entities — already have instanceId support in schema and query builders
- Type-level enforcement — tracked separately in #401

## Test plan

- [x] 955 server tests pass
- [x] 1081 client tests pass
- [x] Server lint: 0 errors
- [x] Client lint: 0 errors, 0 warnings
- [ ] Manual: Clip filtering by performer from server1 returns only server1 clips
- [ ] Manual: Duplicate a cross-instance playlist, verify items retain correct instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)