### PR TITLE
fix: use user's minimumPlayPercent setting instead of hard-coded value

### DIFF
--- a/client/src/components/video-player/VideoPlayer.jsx
+++ b/client/src/components/video-player/VideoPlayer.jsx
@@ -47,16 +47,18 @@ const VideoPlayer = () => {
   const initialResumeTimeRef = useRef(null); // Capture resume time once
 
   const [enableCast, setEnableCast] = useState(true); // Default to true
+  const [minimumPlayPercent, setMinimumPlayPercent] = useState(20); // Default to 20%
   const [clips, setClips] = useState([]);
 
-  // Fetch user settings for cast preference
+  // Fetch user settings for cast preference and playback thresholds
   useEffect(() => {
     const fetchSettings = async () => {
       try {
         const response = await api.get("/user/settings");
         setEnableCast(response.data.settings.enableCast !== false);
+        setMinimumPlayPercent(response.data.settings.minimumPlayPercent ?? 20);
       } catch (error) {
-        // If error, default to true (enabled)
+        // If error, keep defaults
         console.error("Failed to fetch user settings:", error);
       }
     };
@@ -165,6 +167,7 @@ const VideoPlayer = () => {
     watchHistory,
     loadingWatchHistory,
     enableCast,
+    minimumPlayPercent,
   });
 
   // Media keys for playlist navigation

--- a/client/src/components/video-player/useVideoPlayer.js
+++ b/client/src/components/video-player/useVideoPlayer.js
@@ -147,6 +147,7 @@ export function useVideoPlayer({
   watchHistory,
   loadingWatchHistory,
   enableCast = true,
+  minimumPlayPercent = 20,
 }) {
   // Track previous scene for detecting changes
   const prevSceneIdRef = useRef(null);
@@ -300,7 +301,7 @@ export function useVideoPlayer({
 
     // Enable tracking
     trackActivityPlugin.setEnabled(true);
-    trackActivityPlugin.minimumPlayPercent = 10; // Match Stash's 10% threshold
+    trackActivityPlugin.minimumPlayPercent = minimumPlayPercent;
 
     // Connect plugin callbacks to API endpoints
     // saveActivity is called periodically (every 10s) during playback
@@ -333,7 +334,7 @@ export function useVideoPlayer({
       trackActivityPlugin.setEnabled(false);
       trackActivityPlugin.reset();
     };
-  }, [scene?.id, playerRef]);
+  }, [scene?.id, playerRef, minimumPlayPercent]);
 
   // ============================================================================
   // ASPECT RATIO UPDATES (fix layout when switching scenes)


### PR DESCRIPTION
## Summary
- The track activity plugin was hard-coded to a 10% minimum play threshold, ignoring the user's configured `minimumPlayPercent` from Playback Settings
- Now fetches the setting from `/user/settings` alongside `enableCast` and passes it through to the `trackActivity` plugin
- Default remains 20% (matching the PlaybackTab default) when no setting is saved

Closes #406

## Test plan
- [x] Lint passes
- [x] All 1081 client tests pass
- [ ] Verify in browser: change Minimum Play Percent in Settings > Playback, then confirm the play count only increments after that threshold is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)