### PR TITLE
refactor: tighten remaining type casts from #391 follow-up

### DIFF
--- a/server/controllers/playlist.ts
+++ b/server/controllers/playlist.ts
@@ -209,7 +209,7 @@ export const getSharedPlaylists = async (
     // Fetch scene details for preview items from cache
     const playlistsWithScenes = await Promise.all(
       sharedPlaylists.map(async (p) => {
-        let itemsWithScenes: Array<{ instanceId: string | null; sceneId: string; scene: ReturnType<typeof transformScene> | null }> = [];
+        let itemsWithScenes: Array<{ instanceId: string | null; sceneId: string; scene: NormalizedScene | null }> = [];
 
         if (p.items.length > 0) {
           const sceneIds = p.items.map((item) => item.sceneId);

--- a/server/services/GroupQueryBuilder.ts
+++ b/server/services/GroupQueryBuilder.ts
@@ -694,15 +694,12 @@ class GroupQueryBuilder {
     const tagKeys = [...new Map(
       tagJunctions.map((j) => [`${j.tagId}:${j.tagInstanceId}`, { id: j.tagId, instanceId: j.tagInstanceId }])
     ).values()];
-    // Cast via `unknown` because studioId is set on the raw SQL row in transformRow()
-    // but NormalizedGroup (from GraphQL's Group type) only has `studio?: Maybe<Studio>`,
-    // not a flat studioId field.
     const studioKeys = [...new Map(
       groups
-        .filter((g) => (g as unknown as { studioId: string | null }).studioId)
+        .filter((g) => g.studioId)
         .map((g) => {
-          const studioId = (g as unknown as { studioId: string | null }).studioId;
-          return [`${studioId}:${g.instanceId}`, { id: studioId as string, instanceId: g.instanceId }];
+          const studioId = g.studioId!;
+          return [`${studioId}:${g.instanceId}`, { id: studioId, instanceId: g.instanceId }];
         })
     ).values()];
     const performerKeys = [...new Map(

--- a/server/services/SceneQueryBuilder.ts
+++ b/server/services/SceneQueryBuilder.ts
@@ -1350,9 +1350,9 @@ class SceneQueryBuilder {
     // Collect unique (studioId, instanceId) pairs - each scene's studio comes from its own instance
     const studioKeys = [...new Map(
       scenes
-        .filter((s) => (s as unknown as { studioId: string | null }).studioId)
+        .filter((s) => s.studioId)
         .map((s) => {
-          const studioId = (s as unknown as { studioId: string }).studioId;
+          const studioId = s.studioId!;
           return [`${studioId}:${normalizeInstanceId(s.instanceId)}`, { id: studioId, instanceId: normalizeInstanceId(s.instanceId) }] as const;
         })
     ).values()];
@@ -1558,7 +1558,7 @@ class SceneQueryBuilder {
       scene.tags = tagsByScene.get(sceneKey) || [];
       scene.groups = groupsByScene.get(sceneKey) || [];
       scene.galleries = galleriesByScene.get(sceneKey) || [];
-      const studioId = (scene as unknown as { studioId: string | null }).studioId;
+      const studioId = scene.studioId;
       if (studioId) {
         const studioKey = `${studioId}:${normalizedSceneInstanceId}`;
         scene.studio = studiosByKey.get(studioKey) || null;

--- a/server/types/api/playlist.ts
+++ b/server/types/api/playlist.ts
@@ -30,7 +30,7 @@ export interface PlaylistItemWithScene {
 export interface PlaylistPreviewItem {
   instanceId: string | null;
   sceneId: string;
-  scene?: Partial<Scene> | null;
+  scene?: Partial<Scene> | NormalizedScene | null;
 }
 
 /**

--- a/server/types/entities.ts
+++ b/server/types/entities.ts
@@ -142,6 +142,10 @@ export interface NormalizedScene {
   last_played_at: string | null;
   last_o_at: string | null;
 
+  // Transient field: set by QueryBuilder transformRow() but not part of the GraphQL type.
+  // Used internally by populateRelations to look up studios without re-parsing.
+  studioId?: string | null;
+
   // Timestamps
   created_at: string | null;
   updated_at: string | null;
@@ -284,6 +288,10 @@ export interface NormalizedGroup {
   back_image_path: string | null;
   created_at: string | null;
   updated_at: string | null;
+
+  // Transient field: set by QueryBuilder transformRow() but not part of the GraphQL type.
+  // Used internally by populateRelations to look up studios without re-parsing.
+  studioId?: string | null;
 
   // User activity fields
   rating: number | null;

--- a/shared/types/entities.ts
+++ b/shared/types/entities.ts
@@ -138,6 +138,10 @@ export interface NormalizedScene {
   last_played_at: string | null;
   last_o_at: string | null;
 
+  // Transient field: set by QueryBuilder transformRow() but not part of the GraphQL type.
+  // Used internally by populateRelations to look up studios without re-parsing.
+  studioId?: string | null;
+
   // Timestamps
   created_at: string | null;
   updated_at: string | null;
@@ -280,6 +284,10 @@ export interface NormalizedGroup {
   back_image_path: string | null;
   created_at: string | null;
   updated_at: string | null;
+
+  // Transient field: set by QueryBuilder transformRow() but not part of the GraphQL type.
+  // Used internally by populateRelations to look up studios without re-parsing.
+  studioId?: string | null;
 
   // User activity fields
   rating: number | null;


### PR DESCRIPTION
## Summary
- Declare `studioId` as a transient field on `NormalizedScene` and `NormalizedGroup`, removing 5 `as unknown as` casts across SceneQueryBuilder and GroupQueryBuilder
- Tighten `HasImagePath`, `SceneLike`, and `GroupLike` structural types in stashUrlProxy.ts from `{ [key: string]: any }` to minimal field constraints matching actual property access
- Fix `PlaylistPreviewItem.scene` to accept `NormalizedScene` (pre-existing mismatch exposed by tighter types)

## Notes
Follow-up to #420 / #391. Index signatures (`[key: string]: unknown`) were initially planned but removed because concrete interfaces like `PerformerRef` and `ScenePaths` lack index signatures, making them structurally incompatible. Named property constraints provide the same type safety without the compatibility issues.

Closes #421

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm test` — 979/979 tests pass
- [x] `grep -r "as unknown as" SceneQueryBuilder.ts GroupQueryBuilder.ts` — no studioId casts remain
- [x] No `[key: string]: any` in stashUrlProxy.ts