### PR TITLE
fix: apply preset perPage during initial load (#418)

### DIFF
--- a/client/src/hooks/useFilterState.js
+++ b/client/src/hooks/useFilterState.js
@@ -75,20 +75,21 @@ export const useFilterState = ({
           filters: { ...permanentFilters },
         });
 
-        // Check if URL explicitly has sort params
+        // Check if URL explicitly has sort/pagination params
         const hasUrlSort = searchParams.has("sort");
         const hasUrlDirection = searchParams.has("dir");
+        const hasUrlPerPage = searchParams.has("per_page");
 
         let finalState;
 
         if (hasFilterParams) {
-          // URL has filter params: use URL sort if explicit, otherwise preset SORT, URL filters
+          // URL has filter params: use URL sort/perPage if explicit, otherwise preset values, URL filters
           finalState = {
             filters: urlState.filters,
             sortField: hasUrlSort ? urlState.sortField : (defaultPreset?.sort || initialSort),
             sortDirection: hasUrlDirection ? urlState.sortDirection : (defaultPreset?.direction || "DESC"),
             currentPage: urlState.currentPage,
-            perPage: urlState.perPage,
+            perPage: hasUrlPerPage ? urlState.perPage : (defaultPreset?.perPage || urlState.perPage),
             searchText: urlState.searchText,
             viewMode: urlState.viewMode,
             zoomLevel: urlState.zoomLevel,
@@ -96,13 +97,13 @@ export const useFilterState = ({
             timelinePeriod: urlState.timelinePeriod,
           };
         } else if (defaultPreset) {
-          // No URL params: use full preset
+          // No URL filter params: use full preset, but URL per_page takes precedence
           finalState = {
             filters: { ...permanentFilters, ...defaultPreset.filters },
             sortField: defaultPreset.sort,
             sortDirection: defaultPreset.direction,
             currentPage: 1,
-            perPage: urlState.perPage,
+            perPage: hasUrlPerPage ? urlState.perPage : (defaultPreset.perPage || urlState.perPage),
             searchText: "",
             viewMode: defaultPreset.viewMode || defaultViewMode,
             zoomLevel: defaultPreset.zoomLevel || defaultZoomLevel,


### PR DESCRIPTION
## Summary
- When `useFilterState` loads a default preset on init, it now applies the preset's `perPage` value (e.g., 48) instead of always falling back to the hardcoded default of 24
- URL `per_page` param still takes precedence when explicitly present, preserving the URL-as-source-of-truth pattern
- Follows the same conditional pattern already used for `sort` and `direction` fields

Closes #418

## Test plan
- [x] Updated existing test that documented the old (buggy) behavior to expect preset perPage (48) on init
- [x] Added test: URL `per_page=12` overrides preset `perPage: 48` (no filter params in URL)
- [x] Added test: default perPage (24) used when no preset and no URL param
- [x] Added test: preset perPage applied when URL has filter params but no `per_page`
- [x] All 1108 client tests pass
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)