### PR TITLE
Fill documentation gaps for undocumented features

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -13,6 +13,54 @@ The wizard runs automatically on first access. No environment variables needed f
 
 > **Upgrading from v1.x?** Your existing `STASH_URL` and `STASH_API_KEY` environment variables will auto-migrate to the database on first start. You can remove them from your container configuration after successful migration.
 
+## Multi-Instance Support
+
+Peek can connect to **multiple Stash servers** simultaneously. This is useful when you have separate Stash instances for different media types, locations, or libraries.
+
+### Adding Instances
+
+**Location:** Settings → Server Configuration → Stash Instances
+
+1. Click **Add Instance**
+2. Fill in the instance details:
+   - **Name** (required) — Display name (e.g., "Main Library", "Archive Server")
+   - **Description** — Help users understand what content this instance contains
+   - **URL** (required) — Stash GraphQL endpoint (must end with `/graphql`)
+   - **API Key** (required) — From the Stash instance's Settings → Security
+   - **Priority** — Lower number = higher priority for deduplication
+3. Click **Test Connection** to validate
+4. Save the instance
+
+Peek automatically triggers a full sync for new instances in the background.
+
+### Managing Instances
+
+Each instance can be:
+
+- **Edited** — Update URL, API key, name, or priority
+- **Enabled/Disabled** — Temporarily hide an instance without deleting it
+- **Deleted** — Permanently remove (cannot delete the last enabled instance)
+
+### Per-User Instance Selection
+
+When multiple instances are configured, each user can choose which instances they see content from:
+
+**Location:** Settings → Content → Content Sources
+
+- Check or uncheck instances to control which content appears in your library
+- At least one instance must remain selected
+- New users see all instances by default
+
+!!! tip "First-Login Setup"
+    When a new user logs in and multiple instances are available, they're prompted to select which instances they want to see.
+
+### How Multi-Instance Content Works
+
+- Content from all selected instances appears together in search results, carousels, and browsing pages
+- Each entity is tagged internally with its source instance
+- If the same content exists on multiple instances, the instance with the lowest priority number is used as the primary source
+- Ratings, watch history, and playlists track which instance each scene belongs to
+
 ## Required Environment Variables
 
 | Variable     | Description     | Example                             |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -35,12 +35,31 @@ Get Peek up and running in 5 minutes!
 
 ## Step 2: Setup Wizard
 
-1. Open browser: `http://localhost:6969` (or your server IP)
-2. Complete the 4-step setup wizard:
-   - **Welcome** - Introduction to Peek
-   - **Create Admin** - Set your admin username and password
-   - **Connect to Stash** - Enter your Stash URL and API key
-   - **Complete** - Setup finished!
+Open your browser to `http://localhost:6969` (or your server IP). The setup wizard runs automatically on first access.
+
+**Step 1 — Welcome**
+
+Introduction to Peek. Click **Get Started** to begin.
+
+**Step 2 — Create Admin Account**
+
+- Username is set to "admin"
+- Choose a password (minimum 8 characters, at least 1 letter and 1 number)
+- You're automatically logged in after creation
+
+**Step 3 — Connect to Stash**
+
+- Enter your **Stash URL** — the full GraphQL endpoint (e.g., `http://192.168.1.100:9999/graphql`)
+- Enter your **API Key** — found in your Stash instance under Settings → Security
+- Click **Test Connection** to verify before continuing
+- The wizard provides clear error messages if the connection fails (wrong URL, bad API key, host not found, etc.)
+
+**Step 4 — Complete**
+
+Setup is finished. Click **Start Browsing** to enter Peek. Your first library sync begins automatically in the background.
+
+!!! tip "Adding More Stash Servers Later"
+    You can connect additional Stash instances after setup. See [Multi-Instance Support](configuration.md#multi-instance-support).
 
 ## Step 3: Browse Your Library
 

--- a/docs/user-guide/clips.md
+++ b/docs/user-guide/clips.md
@@ -1,0 +1,67 @@
+# Clips
+
+Browse and play scene markers (clips) from your Stash library. Clips are short segments of scenes, typically created around tags or specific moments.
+
+## Browsing Clips
+
+**Location:** Navigation menu → **Clips**
+
+The Clips page shows all clips synced from your Stash library. Each clip card displays:
+
+- Animated preview thumbnail (if generated in Stash)
+- Clip title
+- Duration badge
+- Tag indicators
+- "No preview" badge for ungenerated clips
+
+### View Modes
+
+Clips support three view modes, selectable from the toolbar:
+
+- **Grid** (default) — Card-based layout with animated previews on hover
+- **Wall** — Compact masonry layout
+- **Table** — Sortable table with configurable columns
+
+All view modes support adjustable density controls.
+
+## Filtering Clips
+
+Click the filter icon in the toolbar to open the filter panel. Available filters:
+
+| Filter | Description |
+|--------|-------------|
+| **Clip Tags** | Tags applied directly to the clip. Supports ANY / ALL / NONE modifiers |
+| **Scene Tags** | Tags on the parent scene |
+| **Performers** | Performers in the parent scene. Supports ANY / ALL / NONE modifiers |
+| **Studio** | Studio of the parent scene |
+| **Has Preview** | Filter by generation status: "With preview only", "Without preview only", or "All clips" |
+
+Filters are cumulative (AND logic). Use the search box to filter by clip title.
+
+## Sorting
+
+| Sort Option | Description |
+|-------------|-------------|
+| **Created At** (default) | When the clip was created in Stash |
+| **Title** | Alphabetical by clip title |
+| **Position in Scene** | By start time within the scene |
+| **Duration** | By clip length |
+| **Random** | Randomized order (consistent across pages) |
+
+All sorts support ascending and descending direction.
+
+## Playing Clips
+
+Clicking a clip navigates to the parent scene and automatically seeks to the clip's start position. The video begins playing from that point.
+
+!!! tip "Quick Preview"
+    On desktop, hover over a clip card to see an animated preview without navigating away. Clips without generated previews show a static screenshot instead.
+
+## Clips Without Previews
+
+Some clips may show a "No preview" badge. This means the clip marker exists in Stash but the preview video hasn't been generated yet. Use the **Has Preview** filter to find these clips, and generate previews in Stash using the "Generate" task.
+
+## Related
+
+- [Browse and Display](browse-and-display.md) — View modes and density controls
+- [Keyboard Navigation](keyboard-navigation.md) — Navigate clips with keyboard or TV remote

--- a/docs/user-guide/galleries.md
+++ b/docs/user-guide/galleries.md
@@ -1,0 +1,77 @@
+# Galleries
+
+Browse image galleries synced from your Stash library. Galleries group related images together and support ratings, favorites, and full-screen lightbox viewing.
+
+## Browsing Galleries
+
+**Location:** Navigation menu → **Galleries**
+
+### View Modes
+
+Galleries support five view modes:
+
+- **Grid** (default) — Card-based layout
+- **Wall** — Compact masonry display
+- **Table** — Sortable table with configurable columns
+- **Timeline** — Chronological display grouped by date ranges
+- **Folder** — Hierarchical tag-based folder navigation
+
+### Filtering
+
+| Filter | Description |
+|--------|-------------|
+| **Title** | Text search on gallery title |
+| **Performers** | Filter by performers. Supports ANY / ALL / NONE modifiers |
+| **Studio** | Filter by studio, including sub-studios |
+| **Tags** | Filter by tags with hierarchy support |
+| **Rating** | 0-100 range slider |
+| **Image Count** | Range filter for number of images |
+| **Favorites** | Show only favorited galleries |
+| **Has Favorite Image** | Show galleries containing at least one favorited image |
+
+### Sorting
+
+Sort by Created At, Date, Image Count, Path, Random, Rating, Title, or Updated At.
+
+## Gallery Detail Page
+
+Click a gallery to open its detail page showing:
+
+- **Header** — Gallery title, favorite toggle, and "View in Stash" link
+- **Rating** — 0-100 slider (keyboard shortcut: ++r++ then ++1++ through ++5++)
+- **Description** — If available from Stash
+- **Performers** — Scrollable grid with clickable performer links
+- **Tags** — Clickable tag chips
+
+### Tabs
+
+The detail page has two tabs:
+
+**Images**
+
+Displays gallery images in a wall layout with pagination (100 images per page). Click any image to open the lightbox viewer.
+
+The lightbox supports:
+
+- Full-screen viewing
+- Slideshow mode (click "Play Slideshow")
+- Individual image rating and favoriting
+- O counter
+- Navigation with automatic page boundary handling
+
+**Scenes**
+
+Shows scenes associated with this gallery, with full search and filtering.
+
+## Rating and Favorites
+
+- **Rate** a gallery using the slider on the detail page, or press ++r++ then a number key
+- **Favorite** a gallery with the heart icon, or press ++r++ then ++f++
+- Ratings use a 0-100 scale (displayed as 5 stars)
+- Ratings and favorites are per-user and do not affect your Stash library
+
+## Related
+
+- [Images](images.md) — Image browsing and lightbox details
+- [Browse and Display](browse-and-display.md) — View modes and density controls
+- [Content Restrictions](content-restrictions.md) — Restrict gallery access by user

--- a/docs/user-guide/groups.md
+++ b/docs/user-guide/groups.md
@@ -1,0 +1,97 @@
+# Groups
+
+Browse and explore groups (collections) synced from your Stash library. Groups organize scenes into curated sets — commonly used for movie series, themed collections, or multi-part releases.
+
+## Browsing Groups
+
+**Location:** Navigation menu → **Collections**
+
+### View Modes
+
+Groups support two view modes:
+
+- **Grid** (default) — Card-based layout with front cover images
+- **Table** — Sortable table with configurable columns
+
+### Filtering
+
+| Filter | Description |
+|--------|-------------|
+| **Name** | Text search on group name |
+| **Synopsis** | Text search on group synopsis |
+| **Director** | Text search on director name |
+| **Performers** | Performers in any scene within the group. Supports ANY / ALL / NONE modifiers |
+| **Studio** | Filter by studio |
+| **Tags** | Filter by tags. Supports ANY / ALL / NONE modifiers |
+| **Rating** | 0-100 range slider |
+| **Scene Count** | Range filter for number of scenes |
+| **Duration** | Range filter for total duration in minutes |
+| **Favorites** | Show only favorited groups |
+| **Release Date** | Date range filter |
+| **Created Date** | Date range filter |
+| **Updated Date** | Date range filter |
+
+### Sorting
+
+Sort by Created At, Date, Duration, Name (default), Random, Rating, Scene Count, or Updated At.
+
+## Group Detail Page
+
+Click a group to open its detail page showing:
+
+- **Header** — Group name, aliases, favorite toggle, and "View in Stash" link
+- **Cover Art** — Front and back images with a toggle to flip between them (DVD cover style, 2:3 aspect ratio)
+- **Rating** — 0-100 slider (keyboard shortcut: ++r++ then ++1++ through ++5++)
+
+### Statistics
+
+A summary card shows at-a-glance metrics. Click any metric to jump to its tab:
+
+| Metric | Description |
+|--------|-------------|
+| **Scenes** | Number of scenes in the group |
+| **Performers** | Number of performers across all scenes |
+| **Duration** | Total combined duration |
+| **Date** | Release date |
+
+### Details
+
+Conditional sections appear when data is available:
+
+- **Studio** — Studio logo and name (clickable)
+- **Director** — Director name
+- **Part Of** — Parent collections this group belongs to (clickable links with descriptions)
+- **Sub-Collections** — Child collections (clickable links with descriptions)
+- **Tags** — Tag chips
+- **Links** — External URLs
+
+### Tabs
+
+**Scenes**
+
+Shows all scenes in the group, sorted by scene number (position within the group) by default. Full scene search and filtering available.
+
+**Performers**
+
+Shows all performers appearing in any scene within the group, with full performer browsing and filtering.
+
+## Group Hierarchy
+
+Groups can have parent-child relationships:
+
+- A group can belong to one or more parent collections (shown in "Part Of")
+- A group can contain sub-collections (shown in "Sub-Collections")
+- Click any parent or child link to navigate the hierarchy
+
+## Rating and Favorites
+
+- **Rate** a group using the slider, or press ++r++ then a number key
+- **Favorite** a group with the heart icon, or press ++r++ then ++f++
+- Ratings use a 0-100 scale (displayed as 5 stars)
+- Ratings and favorites are per-user and do not affect your Stash library
+
+## Related
+
+- [Browse and Display](browse-and-display.md) — View modes and density controls
+- [Content Restrictions](content-restrictions.md) — Restrict access using group-based restrictions
+- [Keyboard Navigation](keyboard-navigation.md) — Navigate with keyboard or TV remote

--- a/docs/user-guide/playlists.md
+++ b/docs/user-guide/playlists.md
@@ -151,6 +151,48 @@ There's no limit to how many:
 - Scenes you can add to a playlist
 - Playlists a single scene can be in
 
+## Sharing Playlists
+
+Share your playlists with other users through user groups. Shared playlists appear in recipients' "Shared with Me" tab.
+
+!!! note "Permission Required"
+    Sharing requires the **Can Share** permission. Admins can grant this per-user or per-group in Settings → User Management.
+
+### How Sharing Works
+
+Playlists are shared with **user groups**, not individual users. All members of a shared group can access the playlist. This makes it easy to share with teams or households at once.
+
+### Sharing a Playlist
+
+1. Open a playlist you own
+2. Click the **Share** button
+3. A modal shows all groups you belong to
+4. Check the groups you want to share with
+5. Click **Save**
+
+To stop sharing, uncheck all groups and save.
+
+### Viewing Shared Playlists
+
+1. Go to **Playlists** in the navigation
+2. Click the **Shared with Me** tab
+3. Shared playlists show the owner's name and which groups they're shared through
+
+### What Shared Users Can Do
+
+| Action | Owner | Shared User |
+|--------|-------|-------------|
+| View playlist and scenes | Yes | Yes |
+| Add scenes to playlist | Yes | Yes |
+| Edit name/description | Yes | No |
+| Reorder or remove scenes | Yes | No |
+| Manage sharing settings | Yes | No |
+| Delete playlist | Yes | No |
+| Download playlist | Yes (with permission) | No |
+
+!!! tip "Duplicating Shared Playlists"
+    Shared users can duplicate a shared playlist to create their own copy, which they can then edit freely.
+
 ## Downloading Playlists
 
 You can download entire playlists as zip archives for offline viewing. The zip includes all video files plus an M3U playlist and Kodi-compatible NFO metadata files.
@@ -184,10 +226,17 @@ You can download entire playlists as zip archives for offline viewing. The zip i
 - Check your internet connection
 - Try refreshing and making changes again
 
+### Multi-Select
+
+Select multiple scenes at once for bulk actions:
+
+1. Click the checkbox on any scene card (or long-press on mobile)
+2. Select additional scenes
+3. Use the bulk action bar to **Add to Playlist** or **Remove** selected scenes
+
 ## Next Steps
 
-- [Downloads](downloads.md) - Download playlists, scenes, and images for offline viewing
-- [Watch History](watch-history.md) - Resume playback from where you left off
-- [Keyboard Navigation](keyboard-navigation.md) - Complete keyboard shortcuts and TV mode
-- [Troubleshooting](../getting-started/troubleshooting.md) - Fix common issues
-- [FAQ](../getting-started/faq.md) - Frequently asked questions
+- [Downloads](downloads.md) — Download playlists, scenes, and images for offline viewing
+- [Watch History](watch-history.md) — Resume playback from where you left off
+- [User Management](user-management.md) — Set up user groups for playlist sharing
+- [Keyboard Navigation](keyboard-navigation.md) — Keyboard shortcuts and TV mode

--- a/docs/user-guide/stats.md
+++ b/docs/user-guide/stats.md
@@ -1,0 +1,80 @@
+# User Stats
+
+Track your viewing engagement with detailed statistics, rankings, and highlights across your library.
+
+**Location:** Navigation menu → **User Stats** (or set as your landing page in [Personalization](personalization.md))
+
+## Overview
+
+The stats page shows your personal engagement data organized into four sections:
+
+- **Library totals** — Scene, performer, studio, tag, gallery, image, and clip counts
+- **Engagement totals** — Cumulative watch time, play count, O count, and coverage
+- **Top lists** — Your most-engaged performers, studios, tags, and scenes
+- **Highlights** — Your single most-watched scene, most-viewed image, and top O'd scene/performer
+
+## Engagement Totals
+
+The hero section at the top displays your cumulative activity:
+
+| Metric | What It Measures |
+|--------|------------------|
+| **Watch Time** | Total time spent watching scenes |
+| **Play Count** | Number of play sessions (5+ minutes counts as one play) |
+| **O Count** | Combined O counter increments across scenes and images |
+| **Scenes Watched** | Unique scenes watched and percentage of library coverage |
+| **Images Viewed** | Unique images viewed |
+
+## Top Lists
+
+Four ranked lists show your top 10 most-engaged entities:
+
+- **Top Scenes** — By engagement score
+- **Top Performers** — By engagement score
+- **Top Studios** — By engagement score
+- **Top Tags** — By engagement score
+
+### Sorting Top Lists
+
+Use the sort toggle to change how top lists are ranked:
+
+| Sort | Shows |
+|------|-------|
+| **Engagement** (default) | Percentile rank (e.g., "Top 85%"), watch duration, play count, O count |
+| **O Count** | Total O counter increments, watch duration, play count |
+| **Play Count** | Total plays, watch duration, O count |
+
+Changing the sort updates all four lists simultaneously.
+
+### How Engagement Scores Work
+
+Engagement scores combine multiple signals to reflect your actual preferences:
+
+- **O count** is weighted most heavily — it's the strongest signal of preference
+- **Watch duration** is normalized against average scene length
+- **Play count** adds a straightforward popularity measure
+
+Scores are then normalized by how many scenes feature each entity. A performer who appears in 5 scenes but has high engagement ranks higher than one in 500 scenes with moderate engagement. This prevents entities that simply appear frequently from dominating the rankings.
+
+Percentile ranks show where each entity falls relative to all others — "Top 92%" means that entity is in your 92nd percentile of engagement.
+
+## Highlights
+
+Four highlight cards showcase your single best-of entries:
+
+- **Most Watched Scene** — Highest play count
+- **Most Viewed Image** — Highest view count
+- **Most O'd Scene** — Highest O count
+- **Most O'd Performer** — Highest O count across all their scenes
+
+## Refreshing Stats
+
+Rankings are automatically refreshed when they become stale (typically after an hour of activity). Click the **Refresh** button on the stats page to manually trigger a recalculation.
+
+Stats update in real-time as you watch scenes and interact with content — rankings are the only component that recalculates periodically.
+
+## Related
+
+- [Watch History](watch-history.md) — How play tracking works
+- [Recommendations](recommendations.md) — How engagement data powers recommendations
+- [Personalization](personalization.md) — Set User Stats as your landing page

--- a/docs/user-guide/user-management.md
+++ b/docs/user-guide/user-management.md
@@ -353,6 +353,41 @@ The user should change their password after logging in.
 
 ---
 
+## Database Backup
+
+Admins can create and manage backups of the Peek database from the settings UI.
+
+**Location:** Settings → Server Configuration → Backup
+
+### Creating a Backup
+
+1. Click **Create Backup**
+2. Peek creates an atomic snapshot of the entire SQLite database
+3. The backup appears in the list with its creation date and file size
+
+### What's Included
+
+Backups contain all Peek data:
+
+- User accounts, preferences, and permissions
+- Ratings, favorites, and watch history
+- Playlists and playlist shares
+- Cached entity data from Stash
+- Custom themes and carousels
+
+Backups do **not** include Stash media files or Stash server configuration.
+
+### Managing Backups
+
+- Backups are listed newest-first with creation date and file size
+- Click the trash icon to delete a backup (with confirmation)
+- Backups are stored in the Peek data directory alongside the database
+
+!!! tip "Before Upgrading"
+    Create a backup before upgrading Peek to a new version. If something goes wrong, you can restore the backup by replacing the database file.
+
+---
+
 ## Next Steps
 
 - [Downloads](downloads.md) — Download scenes, images, and playlists

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,10 +122,13 @@ nav:
       - FAQ: getting-started/faq.md
   - User Guide:
       - Browse and Display: user-guide/browse-and-display.md
+      - Clips: user-guide/clips.md
       - Content Restrictions: user-guide/content-restrictions.md
       - Custom Carousels: user-guide/custom-carousels.md
       - Downloads: user-guide/downloads.md
       - External Player: user-guide/external-player.md
+      - Galleries: user-guide/galleries.md
+      - Groups: user-guide/groups.md
       - Hidden Items: user-guide/hidden-items.md
       - Images: user-guide/images.md
       - Keyboard Navigation: user-guide/keyboard-navigation.md
@@ -134,6 +137,7 @@ nav:
       - Playlists: user-guide/playlists.md
       - Recommendations: user-guide/recommendations.md
       - User Management: user-guide/user-management.md
+      - User Stats: user-guide/stats.md
       - Watch History: user-guide/watch-history.md
   - Reference:
       - Docker Basics: reference/docker-basics.md


### PR DESCRIPTION
## Summary
- Add new user guides for **Clips**, **Galleries**, **Groups/Collections**, and **User Stats** — all had zero documentation despite being fully implemented features
- Add **Playlist Sharing** section to playlists docs — group-based sharing, "Shared with Me" tab, and access levels
- Add **Multi-Instance Support** section to configuration docs — adding/managing multiple Stash servers and per-user instance selection
- Expand **Setup Wizard** documentation in quick-start with detailed step-by-step walkthrough
- Add **Database Backup** section to user management docs
- Update mkdocs.yml nav to include all new pages

## Notes
Gap analysis driven by reviewing ~966 commits of recent git history against existing docs.