### PR TITLE
chore: multi-instance brain backfill and test coverage

### DIFF
--- a/docs/plans/2026-02-27-brain-backfill-tracker.md
+++ b/docs/plans/2026-02-27-brain-backfill-tracker.md
@@ -26,7 +26,7 @@ Priority order based on bug history, complexity, and how often each area is touc
 |---|------|-----------|----------|--------|
 | 1 | Video proxy & HLS rewriting | `server/controllers/video.ts`, `server/controllers/proxy.ts` | Critical | **Done** (10 memories) |
 | 2 | Exclusions & content restrictions | `server/services/ExclusionComputationService.ts`, related middleware | Critical | **Done** (5 memories, 18 tests added) |
-| 3 | Multi-instance routing & composite keys | `server/services/StashInstanceManager.ts`, all `@@id` models | Critical | Not started |
+| 3 | Multi-instance routing & composite keys | `server/services/StashInstanceManager.ts`, all `@@id` models | Critical | **Done** (5 memories, 6 tests added) |
 | 4 | StashSyncService & entity caching | `server/services/StashSyncService.ts`, `StashEntityService.ts` | High | Not started |
 | 5 | Query builders | `server/services/SceneQueryBuilder.ts`, `PerformerQueryBuilder.ts`, etc. | High | Not started |
 | 6 | Authentication & route guards | `server/middleware/auth.ts`, JWT flow, proxy auth | Medium | Not started |


### PR DESCRIPTION
## Summary
- Stored 5 brain memories covering multi-instance architecture, gotchas, composite key patterns, cross-area relationships, and test coverage analysis
- Added 6 targeted tests filling identified gaps in StashInstanceManager and entityInstanceId
- Updated brain backfill tracker (area #3 complete)

## New Tests
- **StashInstanceManager**: `initialize()` error path when StashClient constructor throws, `getBaseUrl`/`getApiKey` with unknown instanceId
- **entityInstanceId**: null `stashInstanceId` handling in single lookup, null handling in batch lookup, null skipping in duplicate detection

## Test plan
- [x] All 1034 server tests pass
- [x] StashInstanceManager: 33 tests pass (was 26)
- [x] entityInstanceId: 32 tests pass (was 29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)