### PR TITLE
chore: sync service brain backfill and test coverage

### DIFF
--- a/docs/plans/2026-02-27-brain-backfill-tracker.md
+++ b/docs/plans/2026-02-27-brain-backfill-tracker.md
@@ -27,7 +27,7 @@ Priority order based on bug history, complexity, and how often each area is touc
 | 1 | Video proxy & HLS rewriting | `server/controllers/video.ts`, `server/controllers/proxy.ts` | Critical | **Done** (10 memories) |
 | 2 | Exclusions & content restrictions | `server/services/ExclusionComputationService.ts`, related middleware | Critical | **Done** (5 memories, 18 tests added) |
 | 3 | Multi-instance routing & composite keys | `server/services/StashInstanceManager.ts`, all `@@id` models | Critical | **Done** (5 memories, 6 tests added) |
-| 4 | StashSyncService & entity caching | `server/services/StashSyncService.ts`, `StashEntityService.ts` | High | Not started |
+| 4 | StashSyncService & entity caching | `server/services/StashSyncService.ts`, `StashEntityService.ts` | High | **Done** (5 memories, 24 tests added) |
 | 5 | Query builders | `server/services/SceneQueryBuilder.ts`, `PerformerQueryBuilder.ts`, etc. | High | Not started |
 | 6 | Authentication & route guards | `server/middleware/auth.ts`, JWT flow, proxy auth | Medium | Not started |
 | 7 | Playlist system & sharing | `server/controllers/playlist.ts`, `PlaylistShare` model | Medium | Not started |


### PR DESCRIPTION
## Summary
- Stored 5 brain memories: StashSyncService architecture, sync gotchas (timestamp precision, dependency order, cleanup safety), SyncScheduler behavior, StashEntityService patterns, and test coverage analysis
- Added 24 tests to StashEntityService covering previously untested areas
- Updated brain backfill tracker (areas #3 and #4 complete)

## New Tests
- **FTS Search** (4 tests): searchScenes/searchPerformers FTS5 success and LIKE fallback on error
- **Image Queries** (3 tests): getImage with relations, null for non-existent, getImageCount
- **Cross-Entity Lookups** (5 tests): getPerformerIdsByStudios, getPerformerIdsByGroups, getGroupIdsByPerformers — empty input and normal flow
- **Studio Name Cache** (2 tests): caching behavior across calls, invalidation forces fresh query
- **Plus 10 existing describe blocks** already passing

## Test plan
- [x] All 1057 server tests pass
- [x] StashEntityService: 54 tests pass (was 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)