### PR TITLE
chore: query builder brain backfill and test coverage

### DIFF
--- a/docs/plans/2026-02-27-brain-backfill-tracker.md
+++ b/docs/plans/2026-02-27-brain-backfill-tracker.md
@@ -28,7 +28,7 @@ Priority order based on bug history, complexity, and how often each area is touc
 | 2 | Exclusions & content restrictions | `server/services/ExclusionComputationService.ts`, related middleware | Critical | **Done** (5 memories, 18 tests added) |
 | 3 | Multi-instance routing & composite keys | `server/services/StashInstanceManager.ts`, all `@@id` models | Critical | **Done** (5 memories, 6 tests added) |
 | 4 | StashSyncService & entity caching | `server/services/StashSyncService.ts`, `StashEntityService.ts` | High | **Done** (5 memories, 24 tests added) |
-| 5 | Query builders | `server/services/SceneQueryBuilder.ts`, `PerformerQueryBuilder.ts`, etc. | High | Not started |
+| 5 | Query builders | `server/services/SceneQueryBuilder.ts`, `PerformerQueryBuilder.ts`, etc. | High | **Done** (5 memories, 37 tests added) |
 | 6 | Authentication & route guards | `server/middleware/auth.ts`, JWT flow, proxy auth | Medium | Not started |
 | 7 | Playlist system & sharing | `server/controllers/playlist.ts`, `PlaylistShare` model | Medium | Not started |
 | 8 | Stats, rankings, user activity | `server/services/UserStatsService.ts`, `RankingComputeService.ts` | Medium | Not started |

--- a/server/tests/services/ClipQueryBuilder.test.ts
+++ b/server/tests/services/ClipQueryBuilder.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit Tests for ClipQueryBuilder
+ *
+ * Tests the SQL query assembly for clip filtering, sorting, and pagination.
+ * Verifies multi-instance support, exclusion filtering, scene/tag/performer
+ * filters, and search by inspecting generated SQL.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock prisma
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    $queryRawUnsafe: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Mock logger
+vi.mock("../../utils/logger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+  },
+}));
+
+import prisma from "../../prisma/singleton.js";
+import { clipQueryBuilder } from "../../services/ClipQueryBuilder.js";
+
+const mockPrisma = vi.mocked(prisma);
+
+describe("ClipQueryBuilder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: main query returns empty, count query returns {total: 0}
+    mockPrisma.$queryRawUnsafe
+      .mockResolvedValueOnce([]) // main query
+      .mockResolvedValueOnce([{ total: 0 }]); // count query
+  });
+
+  describe("multi-instance support", () => {
+    it("filters to allowed instances when allowedInstanceIds is provided", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        allowedInstanceIds: ["inst-a", "inst-b"],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("c.stashInstanceId IN (?, ?)");
+      expect(mainQuerySql).toContain("c.stashInstanceId IS NULL");
+
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+      expect(mainQueryParams).toContain("inst-a");
+      expect(mainQueryParams).toContain("inst-b");
+    });
+
+    it("does not add instance filter when allowedInstanceIds is empty", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        allowedInstanceIds: [],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).not.toContain("c.stashInstanceId IN");
+    });
+  });
+
+  describe("exclusion filtering", () => {
+    it("always joins UserExcludedEntity for scene-based exclusions", async () => {
+      await clipQueryBuilder.getClips({ userId: 1 });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("UserExcludedEntity");
+      expect(mainQuerySql).toContain("entityType = 'scene'");
+      expect(mainQuerySql).toContain("e.id IS NULL");
+    });
+
+    it("filters both clip and scene deletedAt", async () => {
+      await clipQueryBuilder.getClips({ userId: 1 });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("c.deletedAt IS NULL");
+      expect(mainQuerySql).toContain("s.deletedAt IS NULL");
+    });
+  });
+
+  describe("filters", () => {
+    it("filters by sceneId", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        sceneId: "42",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      expect(mainQuerySql).toContain("c.sceneId = ?");
+      expect(mainQueryParams).toContain("42");
+    });
+
+    it("filters by isGenerated", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        isGenerated: true,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      expect(mainQuerySql).toContain("c.isGenerated = ?");
+      expect(mainQueryParams).toContain(1);
+    });
+
+    it("filters by search query", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        q: "test clip",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      expect(mainQuerySql).toContain("c.title LIKE ?");
+      expect(mainQueryParams).toContain("%test clip%");
+    });
+
+    it("filters by tag IDs with composite key support", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        tagIds: ["5:inst-a"],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should check both primaryTagId and ClipTag junction
+      expect(mainQuerySql).toContain("c.primaryTagId");
+      expect(mainQuerySql).toContain("ClipTag");
+    });
+
+    it("filters by performer IDs", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        performerIds: ["10"],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("ScenePerformer");
+      expect(mainQuerySql).toContain("sp.performerId IN (?)");
+    });
+
+    it("filters by studio ID", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        studioId: "studio-1",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("s.studioId");
+    });
+
+    it("filters by scene tag IDs", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        sceneTagIds: ["20"],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("SceneTag");
+      expect(mainQuerySql).toContain("st.tagId IN (?)");
+    });
+  });
+
+  describe("sort", () => {
+    it("sorts by stashCreatedAt by default", async () => {
+      await clipQueryBuilder.getClips({ userId: 1 });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("ORDER BY c.stashCreatedAt");
+    });
+
+    it("sorts by seconds when specified", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        sortBy: "seconds",
+        sortDir: "asc",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("ORDER BY c.seconds ASC");
+    });
+  });
+
+  describe("pagination", () => {
+    it("applies correct LIMIT and OFFSET", async () => {
+      await clipQueryBuilder.getClips({
+        userId: 1,
+        page: 2,
+        perPage: 20,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      expect(mainQuerySql).toContain("LIMIT ? OFFSET ?");
+
+      // Last two params are LIMIT and OFFSET
+      const limit = mainQueryParams[mainQueryParams.length - 2];
+      const offset = mainQueryParams[mainQueryParams.length - 1];
+      expect(limit).toBe(20);
+      expect(offset).toBe(20); // (2-1) * 20
+    });
+  });
+});

--- a/server/tests/services/SceneQueryBuilder.test.ts
+++ b/server/tests/services/SceneQueryBuilder.test.ts
@@ -1,73 +1,366 @@
-import { describe, it, expect } from "vitest";
+/**
+ * Unit Tests for SceneQueryBuilder
+ *
+ * Tests the SQL query assembly for scene filtering, sorting, and pagination.
+ * Verifies multi-instance support, exclusion filtering, search queries,
+ * and allowedInstanceIds filtering by inspecting generated SQL.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// We'll test the transform logic directly once exported
+// Mock prisma
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    $queryRawUnsafe: vi.fn().mockResolvedValue([]),
+    scenePerformer: { findMany: vi.fn().mockResolvedValue([]) },
+    sceneTag: { findMany: vi.fn().mockResolvedValue([]) },
+    sceneGroup: { findMany: vi.fn().mockResolvedValue([]) },
+    sceneGallery: { findMany: vi.fn().mockResolvedValue([]) },
+    stashPerformer: { findMany: vi.fn().mockResolvedValue([]) },
+    stashTag: { findMany: vi.fn().mockResolvedValue([]) },
+    stashStudio: { findMany: vi.fn().mockResolvedValue([]) },
+    stashGroup: { findMany: vi.fn().mockResolvedValue([]) },
+    stashGallery: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+// Mock logger
+vi.mock("../../utils/logger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+  },
+}));
+
+// Mock hierarchy utils
+vi.mock("../../utils/hierarchyUtils.js", () => ({
+  expandTagIds: vi.fn(async (ids: string[]) => ids),
+  expandStudioIds: vi.fn(async (ids: string[]) => ids),
+}));
+
+// Mock titleUtils
+vi.mock("../../utils/titleUtils.js", () => ({
+  getSceneFallbackTitle: vi.fn().mockReturnValue("Untitled"),
+}));
+
+import prisma from "../../prisma/singleton.js";
+import { sceneQueryBuilder } from "../../services/SceneQueryBuilder.js";
+
+const mockPrisma = vi.mocked(prisma);
+
 describe("SceneQueryBuilder", () => {
-  describe("transformRow", () => {
-    it("should transform a database row to NormalizedScene", () => {
-      const row = {
-        id: "123",
-        title: "Test Scene",
-        code: "ABC123",
-        date: "2024-01-15",
-        studioId: "studio_1",
-        stashRating100: 85,
-        duration: 3600,
-        organized: 1,
-        details: "Test details",
-        filePath: "/path/to/file.mp4",
-        fileBitRate: 8000000,
-        fileFrameRate: 29.97,
-        fileWidth: 1920,
-        fileHeight: 1080,
-        fileVideoCodec: "h264",
-        fileAudioCodec: "aac",
-        fileSize: BigInt(2147483648),
-        pathScreenshot: "/screenshot.jpg",
-        pathPreview: "/preview.mp4",
-        pathSprite: "/sprite.jpg",
-        pathVtt: "/thumbs.vtt",
-        pathChaptersVtt: null,
-        pathStream: "/stream.mp4",
-        pathCaption: null,
-        captions: null,
-        stashOCounter: 5,
-        stashPlayCount: 10,
-        stashPlayDuration: 7200.5,
-        stashCreatedAt: "2024-01-15T10:30:00Z",
-        stashUpdatedAt: "2024-06-20T15:45:00Z",
-        userRating: 90,
-        userFavorite: 1,
-        userPlayCount: 3,
-        userPlayDuration: 1800.0,
-        userLastPlayedAt: "2024-06-19T20:00:00Z",
-        userOCount: 2,
-        userResumeTime: 600.5,
-        userOHistory: '["2024-06-18T21:00:00Z","2024-06-19T20:30:00Z"]',
-        userPlayHistory: "[]",
-      };
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: main query returns empty, count query returns {total: 0}
+    mockPrisma.$queryRawUnsafe
+      .mockResolvedValueOnce([]) // main query
+      .mockResolvedValueOnce([{ total: 0 }]); // count query
+  });
 
-      // Import will be added once we export the transform function
-      // For now, just verify the test structure
-      expect(row.id).toBe("123");
-      expect(row.userFavorite).toBe(1);
+  describe("multi-instance support", () => {
+    it("includes instanceId in Rating and WatchHistory JOINs", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Rating JOIN must match on instanceId
+      expect(mainQuerySql).toContain("s.stashInstanceId = r.instanceId");
+      // WatchHistory JOIN must match on instanceId
+      expect(mainQuerySql).toContain("s.stashInstanceId = w.instanceId");
     });
 
-    it("should handle null user data gracefully", () => {
-      const row = {
-        id: "456",
-        title: "Scene Without User Data",
-        userRating: null,
-        userFavorite: null,
-        userPlayCount: null,
-        userLastPlayedAt: null,
-        userOCount: null,
-        userResumeTime: null,
-        userOHistory: null,
-        userPlayHistory: null,
-      };
+    it("filters to allowed instances when allowedInstanceIds is provided", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        allowedInstanceIds: ["inst-a", "inst-b"],
+      });
 
-      // User data should default to safe values
-      expect(row.userFavorite).toBeNull();
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should contain IN clause for allowed instances
+      expect(mainQuerySql).toContain("s.stashInstanceId IN (?, ?)");
+      // Should include NULL fallback for backward compat
+      expect(mainQuerySql).toContain("s.stashInstanceId IS NULL");
+
+      // Params should contain the instance IDs
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+      expect(mainQueryParams).toContain("inst-a");
+      expect(mainQueryParams).toContain("inst-b");
+    });
+
+    it("does not add instance filter when allowedInstanceIds is empty", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        allowedInstanceIds: [],
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should NOT contain the IN clause
+      expect(mainQuerySql).not.toContain("s.stashInstanceId IN");
+    });
+
+    it("filters to a specific instance when specificInstanceId is provided", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        specificInstanceId: "instance-abc",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("s.stashInstanceId = ?");
+
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+      expect(mainQueryParams).toContain("instance-abc");
+    });
+
+    it("does not add specific instance filter when not provided", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should NOT have a bare equality check
+      expect(mainQuerySql).not.toContain("s.stashInstanceId = ?");
+    });
+  });
+
+  describe("exclusion filtering", () => {
+    it("includes exclusion JOIN and WHERE by default", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should JOIN UserExcludedEntity
+      expect(mainQuerySql).toContain("UserExcludedEntity");
+      expect(mainQuerySql).toContain("entityType = 'scene'");
+      // Should filter out excluded entities
+      expect(mainQuerySql).toContain("e.id IS NULL");
+    });
+
+    it("skips exclusion JOIN when applyExclusions is false", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        applyExclusions: false,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should NOT JOIN UserExcludedEntity
+      expect(mainQuerySql).not.toContain("UserExcludedEntity");
+      expect(mainQuerySql).not.toContain("e.id IS NULL");
+    });
+  });
+
+  describe("search query", () => {
+    it("searches across title, details, path, performers, studio, and tags", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        searchQuery: "test search",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should search across multiple fields
+      expect(mainQuerySql).toContain("LOWER(s.title) LIKE LOWER(?)");
+      expect(mainQuerySql).toContain("LOWER(s.details) LIKE LOWER(?)");
+      expect(mainQuerySql).toContain("LOWER(s.filePath) LIKE LOWER(?)");
+      // Should have performer subquery
+      expect(mainQuerySql).toContain("StashPerformer");
+      expect(mainQuerySql).toContain("LOWER(p.name) LIKE LOWER(?)");
+      // Should have studio subquery
+      expect(mainQuerySql).toContain("StashStudio");
+      // Should have tag subquery
+      expect(mainQuerySql).toContain("StashTag");
+
+      // Search param should be wrapped in wildcards
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+      expect(mainQueryParams).toContain("%test search%");
+    });
+
+    it("does not add search filter for empty search query", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        searchQuery: "",
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // Should not contain search-specific LIKE patterns on s.filePath
+      expect(mainQuerySql).not.toContain("LOWER(s.filePath) LIKE LOWER(?)");
+    });
+  });
+
+  describe("pagination", () => {
+    it("passes correct LIMIT and OFFSET for page 1", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 25,
+      });
+
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      // Last two params are LIMIT and OFFSET
+      const limit = mainQueryParams[mainQueryParams.length - 2];
+      const offset = mainQueryParams[mainQueryParams.length - 1];
+      expect(limit).toBe(25);
+      expect(offset).toBe(0);
+    });
+
+    it("passes correct OFFSET for page 3", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 3,
+        perPage: 10,
+      });
+
+      const mainQueryParams = mockPrisma.$queryRawUnsafe.mock.calls[0].slice(1);
+
+      const limit = mainQueryParams[mainQueryParams.length - 2];
+      const offset = mainQueryParams[mainQueryParams.length - 1];
+      expect(limit).toBe(10);
+      expect(offset).toBe(20); // (3-1) * 10
+    });
+  });
+
+  describe("sort", () => {
+    it("applies ORDER BY for created_at sort", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("s.stashCreatedAt DESC");
+    });
+
+    it("applies COLLATE NOCASE for title sort", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "title",
+        sortDirection: "ASC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      expect(mainQuerySql).toContain("COLLATE NOCASE ASC");
+    });
+
+    it("includes secondary sort by id for stable ordering", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "date",
+        sortDirection: "ASC",
+        page: 1,
+        perPage: 10,
+      });
+
+      const mainQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[0][0] as string;
+
+      // ORDER BY should end with secondary id sort
+      expect(mainQuerySql).toContain("s.id ASC");
+    });
+  });
+
+  describe("count query", () => {
+    it("uses COUNT(DISTINCT) with composite key for count when exclusions are applied", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+      });
+
+      // Second call is the count query
+      const countQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[1][0] as string;
+
+      expect(countQuerySql).toContain("COUNT(DISTINCT s.id || ':' || s.stashInstanceId)");
+    });
+
+    it("uses fast path COUNT(*) when exclusions are disabled and no user data filters", async () => {
+      await sceneQueryBuilder.execute({
+        userId: 1,
+        sort: "created_at",
+        sortDirection: "DESC",
+        page: 1,
+        perPage: 10,
+        applyExclusions: false,
+      });
+
+      const countQuerySql = mockPrisma.$queryRawUnsafe.mock
+        .calls[1][0] as string;
+
+      // Fast path: simple COUNT(*) from StashScene only
+      expect(countQuerySql).toContain("COUNT(*)");
+      expect(countQuerySql).not.toContain("COUNT(DISTINCT");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Store 5 brain memories covering query builder architecture, gotchas, patterns, cross-area relationships, and test coverage analysis
- Add comprehensive SceneQueryBuilder tests: multi-instance support, exclusion filtering, search queries, pagination, sort ordering, count query optimization
- Create new ClipQueryBuilder test file (was entirely untested): multi-instance, exclusions, filters, sort, pagination
- Expand GalleryQueryBuilder tests: allowedInstanceIds filtering, exclusion toggle, search query

## Test plan
- [x] All 1096 server tests pass
- [x] New SceneQueryBuilder tests verify SQL assembly for allowedInstanceIds, specificInstanceId, exclusions, search, pagination, sort, count query
- [x] New ClipQueryBuilder tests verify SQL assembly for all filter types, multi-instance, exclusions
- [x] New GalleryQueryBuilder tests verify allowedInstanceIds, exclusion toggle, search

🤖 Generated with [Claude Code](https://claude.com/claude-code)