### PR TITLE
chore: client-side brain backfill and hook test coverage

### DIFF
--- a/client/tests/hooks/useAsyncData.test.jsx
+++ b/client/tests/hooks/useAsyncData.test.jsx
@@ -1,0 +1,176 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useAsyncData } from "../../src/hooks/useApi.js";
+
+vi.mock("../../src/hooks/useAuth.js", () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true, isLoading: false })),
+}));
+
+import { useAuth } from "../../src/hooks/useAuth.js";
+
+describe("useAsyncData", () => {
+  beforeEach(() => {
+    useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+  });
+
+  describe("initial fetch", () => {
+    it("fetches data on mount when authenticated", async () => {
+      const mockData = { users: [{ id: "1" }] };
+      const fetchFn = vi.fn().mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      expect(result.current.loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual(mockData);
+      expect(result.current.error).toBeNull();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets error on fetch failure", async () => {
+      const error = new Error("Server error");
+      const fetchFn = vi.fn().mockRejectedValue(error);
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe(error);
+      expect(result.current.data).toBeNull();
+    });
+
+    it("preserves full error object including isInitializing flag", async () => {
+      const error = Object.assign(new Error("Initializing"), {
+        isInitializing: true,
+        status: 503,
+      });
+      const fetchFn = vi.fn().mockRejectedValue(error);
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error.isInitializing).toBe(true);
+      expect(result.current.error.status).toBe(503);
+    });
+  });
+
+  describe("auth gate", () => {
+    it("does not fetch when not authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+      const fetchFn = vi.fn().mockResolvedValue({});
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch while auth is loading", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+      const fetchFn = vi.fn().mockResolvedValue({});
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      // Should not call fetchFn while auth is loading
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it("fetches when auth resolves to authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+      const fetchFn = vi.fn().mockResolvedValue({ data: "test" });
+
+      const { result, rerender } = renderHook(() => useAsyncData(fetchFn));
+
+      expect(fetchFn).not.toHaveBeenCalled();
+
+      // Auth resolves
+      useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(fetchFn).toHaveBeenCalled();
+      expect(result.current.data).toEqual({ data: "test" });
+    });
+  });
+
+  describe("dependencies", () => {
+    it("re-fetches when dependencies change", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({ page: 1 });
+
+      const { result, rerender } = renderHook(
+        ({ dep }) => useAsyncData(fetchFn, [dep]),
+        { initialProps: { dep: "a" } }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      fetchFn.mockResolvedValue({ page: 2 });
+      rerender({ dep: "b" });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("refetch", () => {
+    it("manually re-fetches data", async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce({ version: 1 })
+        .mockResolvedValueOnce({ version: 2 });
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual({ version: 1 });
+      });
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.data).toEqual({ version: 2 });
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears previous error on successful refetch", async () => {
+      const fetchFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Failed"))
+        .mockResolvedValueOnce({ recovered: true });
+
+      const { result } = renderHook(() => useAsyncData(fetchFn));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.data).toEqual({ recovered: true });
+    });
+  });
+});

--- a/client/tests/hooks/useCancellableQuery.test.jsx
+++ b/client/tests/hooks/useCancellableQuery.test.jsx
@@ -1,0 +1,266 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useCancellableQuery } from "../../src/hooks/useCancellableQuery.js";
+
+vi.mock("../../src/hooks/useAuth.js", () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true, isLoading: false })),
+}));
+
+import { useAuth } from "../../src/hooks/useAuth.js";
+
+describe("useCancellableQuery", () => {
+  beforeEach(() => {
+    useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("initial state", () => {
+    it("starts with loading true by default", () => {
+      const { result } = renderHook(() => useCancellableQuery());
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeNull();
+      expect(result.current.error).toBeNull();
+      expect(result.current.initMessage).toBeNull();
+    });
+
+    it("respects initialLoading option", () => {
+      const { result } = renderHook(() =>
+        useCancellableQuery({ initialLoading: false })
+      );
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("execute", () => {
+    it("fetches data and updates state", async () => {
+      const mockData = { scenes: [{ id: "1" }] };
+      const queryFn = vi.fn().mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(result.current.data).toEqual(mockData);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(queryFn).toHaveBeenCalledWith(expect.any(AbortSignal));
+    });
+
+    it("sets error state on failure", async () => {
+      const error = new Error("Network error");
+      const queryFn = vi.fn().mockRejectedValue(error);
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(result.current.error).toBe(error);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeNull();
+    });
+
+    it("calls onDataChange callback after data loads", async () => {
+      const mockData = { count: 5 };
+      const queryFn = vi.fn().mockResolvedValue(mockData);
+      const onDataChange = vi.fn();
+
+      const { result } = renderHook(() =>
+        useCancellableQuery({ onDataChange })
+      );
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(onDataChange).toHaveBeenCalledWith(mockData);
+    });
+  });
+
+  describe("request cancellation", () => {
+    it("aborts previous request when new one starts", async () => {
+      let resolveFirst;
+      const firstQuery = vi.fn().mockImplementation(
+        () => new Promise((resolve) => { resolveFirst = resolve; })
+      );
+      const secondQuery = vi.fn().mockResolvedValue({ second: true });
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      // Start first query (don't await — it won't resolve)
+      let firstPromise;
+      act(() => {
+        firstPromise = result.current.execute(firstQuery);
+      });
+
+      // Start second query — should abort first
+      await act(async () => {
+        await result.current.execute(secondQuery);
+      });
+
+      expect(result.current.data).toEqual({ second: true });
+
+      // Resolve the first to clean up — state should not update (aborted)
+      resolveFirst({ first: true });
+      await act(async () => { await firstPromise; });
+
+      // Data should still be from second query
+      expect(result.current.data).toEqual({ second: true });
+    });
+
+    it("swallows AbortError silently", async () => {
+      const abortError = Object.assign(new Error("Aborted"), {
+        name: "AbortError",
+      });
+      const queryFn = vi.fn().mockRejectedValue(abortError);
+
+      const { result } = renderHook(() =>
+        useCancellableQuery({ initialLoading: false })
+      );
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      // AbortError should not set error state
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("503 initializing retry", () => {
+    it("retries on isInitializing error with init message", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const initError = Object.assign(new Error("Initializing"), {
+        isInitializing: true,
+      });
+      const queryFn = vi.fn()
+        .mockRejectedValueOnce(initError)
+        .mockResolvedValueOnce({ scenes: [] });
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      // After first failure, should show init message
+      expect(result.current.initMessage).toBe(
+        "Server is syncing library, please wait..."
+      );
+      expect(queryFn).toHaveBeenCalledTimes(1);
+
+      // Advance timer to trigger retry
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(queryFn).toHaveBeenCalledTimes(2);
+      expect(result.current.data).toEqual({ scenes: [] });
+      expect(result.current.initMessage).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it("stops retrying after 60 attempts", async () => {
+      const initError = Object.assign(new Error("Initializing"), {
+        isInitializing: true,
+      });
+      const queryFn = vi.fn().mockRejectedValue(initError);
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      // Execute with retryCount at the limit
+      await act(async () => {
+        await result.current.execute(queryFn, { retryCount: 60 });
+      });
+
+      // Should set error instead of retrying
+      expect(result.current.error).toBe(initError);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("auth gate", () => {
+    it("does not execute when not authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+      const queryFn = vi.fn().mockResolvedValue({});
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(queryFn).not.toHaveBeenCalled();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("does not execute while auth is loading", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: true });
+      const queryFn = vi.fn().mockResolvedValue({});
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(queryFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all state and aborts in-flight request", async () => {
+      const mockData = { items: [1, 2, 3] };
+      const queryFn = vi.fn().mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(result.current.data).toEqual(mockData);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.data).toBeNull();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.initMessage).toBeNull();
+    });
+  });
+
+  describe("setData", () => {
+    it("allows manual data updates", async () => {
+      const queryFn = vi.fn().mockResolvedValue({ original: true });
+
+      const { result } = renderHook(() => useCancellableQuery());
+
+      await act(async () => {
+        await result.current.execute(queryFn);
+      });
+
+      expect(result.current.data).toEqual({ original: true });
+
+      act(() => {
+        result.current.setData({ updated: true });
+      });
+
+      expect(result.current.data).toEqual({ updated: true });
+    });
+  });
+});

--- a/client/tests/hooks/useUserStats.test.jsx
+++ b/client/tests/hooks/useUserStats.test.jsx
@@ -1,0 +1,167 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useUserStats } from "../../src/hooks/useUserStats.js";
+
+vi.mock("../../src/hooks/useAuth.js", () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true, isLoading: false })),
+}));
+
+vi.mock("../../src/services/api.js", () => ({
+  apiGet: vi.fn(),
+}));
+
+import { useAuth } from "../../src/hooks/useAuth.js";
+import { apiGet } from "../../src/services/api.js";
+
+describe("useUserStats", () => {
+  const mockStats = {
+    totalScenes: 100,
+    totalPlayTime: 5000,
+    topPerformers: [{ id: "1", name: "Test", engagement: 50 }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+    apiGet.mockResolvedValue(mockStats);
+  });
+
+  describe("initial fetch", () => {
+    it("fetches stats on mount with default sort", async () => {
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Default sortBy is "engagement" — should not add query param
+      expect(apiGet).toHaveBeenCalledWith("/user-stats");
+      expect(result.current.data).toEqual(mockStats);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("adds sortBy param when not engagement", async () => {
+      renderHook(() => useUserStats({ sortBy: "oCount" }));
+
+      await waitFor(() => {
+        expect(apiGet).toHaveBeenCalledWith("/user-stats?sortBy=oCount");
+      });
+    });
+
+    it("adds sortBy param for playCount", async () => {
+      renderHook(() => useUserStats({ sortBy: "playCount" }));
+
+      await waitFor(() => {
+        expect(apiGet).toHaveBeenCalledWith("/user-stats?sortBy=playCount");
+      });
+    });
+  });
+
+  describe("auth gate", () => {
+    it("does not fetch when not authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiGet).not.toHaveBeenCalled();
+      expect(result.current.data).toBeNull();
+    });
+  });
+
+  describe("error handling", () => {
+    it("sets error message on failure", async () => {
+      apiGet.mockRejectedValue(new Error("Forbidden"));
+
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe("Forbidden");
+      expect(result.current.data).toBeNull();
+    });
+
+    it("uses fallback message when error has no message", async () => {
+      apiGet.mockRejectedValue({});
+
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe("Failed to fetch stats");
+    });
+  });
+
+  describe("refresh", () => {
+    it("re-fetches stats", async () => {
+      const updatedStats = { ...mockStats, totalScenes: 200 };
+      apiGet
+        .mockResolvedValueOnce(mockStats)
+        .mockResolvedValueOnce(updatedStats);
+
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual(mockStats);
+      });
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(result.current.data).toEqual(updatedStats);
+    });
+
+    it("accepts showLoading parameter", async () => {
+      apiGet.mockResolvedValue(mockStats);
+
+      const { result } = renderHook(() => useUserStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Refresh with showLoading=false should not set loading to true
+      // (this is for sort changes where we want to avoid flicker)
+      let loadingDuringRefresh = null;
+      apiGet.mockImplementation(() => {
+        loadingDuringRefresh = result.current.loading;
+        return Promise.resolve(mockStats);
+      });
+
+      await act(async () => {
+        await result.current.refresh(false);
+      });
+
+      expect(loadingDuringRefresh).toBe(false);
+    });
+  });
+
+  describe("sort change re-fetch", () => {
+    it("re-fetches when sortBy changes", async () => {
+      apiGet.mockResolvedValue(mockStats);
+
+      const { rerender } = renderHook(
+        ({ sortBy }) => useUserStats({ sortBy }),
+        { initialProps: { sortBy: "engagement" } }
+      );
+
+      await waitFor(() => {
+        expect(apiGet).toHaveBeenCalledWith("/user-stats");
+      });
+
+      rerender({ sortBy: "oCount" });
+
+      await waitFor(() => {
+        expect(apiGet).toHaveBeenCalledWith("/user-stats?sortBy=oCount");
+      });
+    });
+  });
+});

--- a/client/tests/hooks/useWatchHistory.test.jsx
+++ b/client/tests/hooks/useWatchHistory.test.jsx
@@ -1,0 +1,255 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  useWatchHistory,
+  useAllWatchHistory,
+} from "../../src/hooks/useWatchHistory.js";
+
+vi.mock("../../src/hooks/useAuth.js", () => ({
+  useAuth: vi.fn(() => ({ isAuthenticated: true, isLoading: false })),
+}));
+
+vi.mock("../../src/services/api.js", () => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+import { useAuth } from "../../src/hooks/useAuth.js";
+import { apiGet, apiPost } from "../../src/services/api.js";
+
+describe("useWatchHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+  });
+
+  describe("initial fetch", () => {
+    it("fetches watch history for scene on mount", async () => {
+      const mockHistory = { resumeTime: 120, oCount: 3, playCount: 10 };
+      apiGet.mockResolvedValue(mockHistory);
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiGet).toHaveBeenCalledWith("/watch-history/scene-1");
+      expect(result.current.watchHistory).toEqual(mockHistory);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("handles fetch error", async () => {
+      apiGet.mockRejectedValue(new Error("Not found"));
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe("Not found");
+      expect(result.current.watchHistory).toBeNull();
+    });
+
+    it("does not fetch without sceneId", async () => {
+      const { result } = renderHook(() => useWatchHistory(null));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiGet).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when not authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("incrementOCounter", () => {
+    it("increments O counter and updates local state", async () => {
+      apiGet.mockResolvedValue({ resumeTime: 0, oCount: 1 });
+      apiPost.mockResolvedValue({ success: true, oCount: 2 });
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      let response;
+      await act(async () => {
+        response = await result.current.incrementOCounter();
+      });
+
+      expect(apiPost).toHaveBeenCalledWith("/watch-history/increment-o", {
+        sceneId: "scene-1",
+      });
+      expect(response).toEqual({ success: true, oCount: 2 });
+      expect(result.current.watchHistory.oCount).toBe(2);
+    });
+
+    it("returns null when not authenticated", async () => {
+      useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      let response;
+      await act(async () => {
+        response = await result.current.incrementOCounter();
+      });
+
+      expect(response).toBeNull();
+      expect(apiPost).not.toHaveBeenCalled();
+    });
+
+    it("throws on API error", async () => {
+      apiGet.mockResolvedValue({ oCount: 1 });
+      apiPost.mockRejectedValue(new Error("Server error"));
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await expect(
+        act(async () => {
+          await result.current.incrementOCounter();
+        })
+      ).rejects.toThrow("Server error");
+    });
+  });
+
+  describe("updateQuality", () => {
+    it("stores quality value in ref", async () => {
+      apiGet.mockResolvedValue({});
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // updateQuality doesn't trigger re-render (ref-based), just verify it doesn't throw
+      act(() => {
+        result.current.updateQuality("1080p");
+      });
+    });
+  });
+
+  describe("refresh", () => {
+    it("re-fetches watch history", async () => {
+      apiGet
+        .mockResolvedValueOnce({ oCount: 1 })
+        .mockResolvedValueOnce({ oCount: 5 });
+
+      const { result } = renderHook(() => useWatchHistory("scene-1"));
+
+      await waitFor(() => {
+        expect(result.current.watchHistory).toEqual({ oCount: 1 });
+      });
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(result.current.watchHistory).toEqual({ oCount: 5 });
+      expect(apiGet).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("useAllWatchHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuth.mockReturnValue({ isAuthenticated: true, isLoading: false });
+  });
+
+  it("fetches all watch history on mount", async () => {
+    const mockHistory = [
+      { sceneId: "1", resumeTime: 60 },
+      { sceneId: "2", resumeTime: 120 },
+    ];
+    apiGet.mockResolvedValue({ watchHistory: mockHistory });
+
+    const { result } = renderHook(() => useAllWatchHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(apiGet).toHaveBeenCalledWith(
+      "/watch-history?limit=20&inProgress=false"
+    );
+    expect(result.current.data).toEqual(mockHistory);
+  });
+
+  it("passes inProgress and limit params", async () => {
+    apiGet.mockResolvedValue({ watchHistory: [] });
+
+    renderHook(() => useAllWatchHistory({ inProgress: true, limit: 10 }));
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        "/watch-history?limit=10&inProgress=true"
+      );
+    });
+  });
+
+  it("does not fetch when not authenticated", async () => {
+    useAuth.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    const { result } = renderHook(() => useAllWatchHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(apiGet).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("handles fetch error", async () => {
+    apiGet.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useAllWatchHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Network error");
+  });
+
+  it("provides refresh function", async () => {
+    apiGet
+      .mockResolvedValueOnce({ watchHistory: [{ sceneId: "1" }] })
+      .mockResolvedValueOnce({ watchHistory: [{ sceneId: "1" }, { sceneId: "2" }] });
+
+    const { result } = renderHook(() => useAllWatchHistory());
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.data).toHaveLength(2);
+  });
+});

--- a/docs/plans/2026-02-27-brain-backfill-tracker.md
+++ b/docs/plans/2026-02-27-brain-backfill-tracker.md
@@ -1,6 +1,6 @@
 # Brain Backfill Tracker
 
-**Status**: Not started
+**Status**: Complete
 **Date**: 2026-02-27
 **Parent**: Brain Integration (Development Quality Initiative Phase 5)
 
@@ -33,7 +33,7 @@ Priority order based on bug history, complexity, and how often each area is touc
 | 7 | Playlist system & sharing | `server/controllers/playlist.ts`, `PlaylistShare` model | Medium | **Done** (5 memories, 28 tests added) |
 | 8 | Stats, rankings, user activity | `server/services/UserStatsService.ts`, `RankingComputeService.ts` | Medium | **Done** (5 memories, 12 tests added) |
 | 9 | Setup wizard & instance management | `server/controllers/setup.ts`, setup flow | Low | **Done** (5 memories, 33 tests added) |
-| 10 | Client-side patterns | Routing, TanStack Query, component conventions, Tailwind patterns | Low | Not started |
+| 10 | Client-side patterns | Routing, data-fetching hooks, component conventions, Tailwind patterns | Low | **Done** (5 memories, 45 tests added) |
 
 ## Per-Area Checklist
 


### PR DESCRIPTION
## Summary
- Stored 5 brain memories covering client data-fetching architecture, gotchas, component patterns, client-server relationships, and testing conventions
- Added 45 tests for core data-fetching hooks: `useCancellableQuery`, `useAsyncData`, `useWatchHistory`, `useAllWatchHistory`, `useUserStats`
- Marked area 10 (client-side patterns) and all remaining areas as done in backfill tracker

## Test plan
- [x] All 45 new tests pass
- [x] Full client test suite passes (1209 tests, 83 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)