### PR TITLE
test: add comprehensive controller coverage for ratings and user (#458)

### DIFF
--- a/server/tests/controllers/ratings.test.ts
+++ b/server/tests/controllers/ratings.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Unit Tests for Ratings Controller
+ *
+ * Tests all 7 entity rating endpoints (scene, performer, studio, tag, gallery,
+ * group, image). Covers input validation, auth checks, Prisma upsert logic,
+ * sync-to-Stash policy per entity type, and error handling.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock prisma
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    user: { findUnique: vi.fn() },
+    sceneRating: { upsert: vi.fn() },
+    performerRating: { upsert: vi.fn() },
+    studioRating: { upsert: vi.fn() },
+    tagRating: { upsert: vi.fn() },
+    galleryRating: { upsert: vi.fn() },
+    groupRating: { upsert: vi.fn() },
+    imageRating: { upsert: vi.fn() },
+  },
+}));
+
+// Mock logger
+vi.mock("../../utils/logger.js", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock StashInstanceManager
+vi.mock("../../services/StashInstanceManager.js", () => ({
+  stashInstanceManager: {
+    getForSync: vi.fn(),
+  },
+}));
+
+// Mock entityInstanceId
+vi.mock("../../utils/entityInstanceId.js", () => ({
+  getEntityInstanceId: vi.fn().mockResolvedValue("instance-1"),
+}));
+
+import prisma from "../../prisma/singleton.js";
+import { stashInstanceManager } from "../../services/StashInstanceManager.js";
+import { getEntityInstanceId } from "../../utils/entityInstanceId.js";
+import {
+  updateSceneRating,
+  updatePerformerRating,
+  updateStudioRating,
+  updateTagRating,
+  updateGalleryRating,
+  updateGroupRating,
+  updateImageRating,
+} from "../../controllers/ratings.js";
+
+const mockPrisma = vi.mocked(prisma);
+const mockInstanceManager = vi.mocked(stashInstanceManager);
+const mockGetEntityInstanceId = vi.mocked(getEntityInstanceId);
+
+const USER = { id: 1, username: "testuser", role: "USER" };
+
+function mockReq(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  user: typeof USER | undefined = USER
+) {
+  return { body, params, user } as any;
+}
+
+function mockRes() {
+  const res: any = {
+    json: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+    _getStatus: () => res.status.mock.calls[0]?.[0] ?? 200,
+    _getBody: () => {
+      const jsonCalls = res.json.mock.calls;
+      return jsonCalls[jsonCalls.length - 1]?.[0];
+    },
+  };
+  return res;
+}
+
+/** Standard mock for a successful upsert */
+const UPSERT_RESULT = {
+  id: 1,
+  userId: 1,
+  instanceId: "instance-1",
+  rating: 85,
+  favorite: false,
+};
+
+describe("Ratings Controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.user.findUnique.mockResolvedValue({ syncToStash: false } as any);
+  });
+
+  // ─── Shared validation tests (tested via updateSceneRating, applies to all) ───
+
+  describe("shared validation (via updateSceneRating)", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, { sceneId: "1" }, {} as any);
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(401);
+      expect(res._getBody().error).toBe("Unauthorized");
+    });
+
+    it("returns 401 when user is missing entirely", async () => {
+      const req = { body: {}, params: { sceneId: "1" } } as any;
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(401);
+      expect(res._getBody().error).toBe("Unauthorized");
+    });
+
+    it("returns 400 when entity ID is missing", async () => {
+      const req = mockReq({ rating: 50 }, {});
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toBe("Missing sceneId");
+    });
+
+    it("returns 400 when rating is not a number", async () => {
+      const req = mockReq({ rating: "high" }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Rating must be a number/);
+    });
+
+    it("returns 400 when rating is below 0", async () => {
+      const req = mockReq({ rating: -1 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Rating must be a number/);
+    });
+
+    it("returns 400 when rating is above 100", async () => {
+      const req = mockReq({ rating: 101 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Rating must be a number/);
+    });
+
+    it("accepts rating of 0 (boundary)", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 0 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("accepts rating of 100 (boundary)", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 100 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("accepts null rating (clearing a rating)", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: null }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("returns 400 when favorite is not a boolean", async () => {
+      const req = mockReq({ favorite: "yes" }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toBe("Favorite must be a boolean");
+    });
+
+    it("accepts favorite as true/false", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ favorite: true }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("returns 500 when database throws", async () => {
+      mockPrisma.user.findUnique.mockRejectedValue(new Error("DB down"));
+      const req = mockReq({ rating: 50 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+      expect(res._getStatus()).toBe(500);
+      expect(res._getBody().error).toMatch(/Failed to update/);
+    });
+  });
+
+  // ─── Instance ID handling ───
+
+  describe("instance ID resolution", () => {
+    it("uses instanceId from request body when provided", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq(
+        { rating: 50, instanceId: "custom-instance" },
+        { sceneId: "1" }
+      );
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockGetEntityInstanceId).not.toHaveBeenCalled();
+      expect(mockPrisma.sceneRating.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId_instanceId_sceneId: {
+              userId: 1,
+              instanceId: "custom-instance",
+              sceneId: "1",
+            },
+          },
+        })
+      );
+    });
+
+    it("looks up instanceId from DB when not provided in request", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 50 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockGetEntityInstanceId).toHaveBeenCalledWith("scene", "1");
+      expect(mockPrisma.sceneRating.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId_instanceId_sceneId: {
+              userId: 1,
+              instanceId: "instance-1",
+              sceneId: "1",
+            },
+          },
+        })
+      );
+    });
+  });
+
+  // ─── Upsert behavior ───
+
+  describe("upsert behavior", () => {
+    it("creates with rating and default favorite when rating provided", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 75 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockPrisma.sceneRating.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            userId: 1,
+            instanceId: "instance-1",
+            sceneId: "1",
+            rating: 75,
+            favorite: false,
+          }),
+          update: expect.objectContaining({ rating: 75 }),
+        })
+      );
+    });
+
+    it("creates with favorite and null rating when only favorite provided", async () => {
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ favorite: true }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockPrisma.sceneRating.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            rating: null,
+            favorite: true,
+          }),
+          update: expect.objectContaining({ favorite: true }),
+        })
+      );
+    });
+
+    it("returns success with upserted record", async () => {
+      const upsertResult = { id: 1, instanceId: "instance-1", rating: 85, favorite: true };
+      mockPrisma.sceneRating.upsert.mockResolvedValue(upsertResult as any);
+      const req = mockReq({ rating: 85, favorite: true }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      const body = res._getBody();
+      expect(body.success).toBe(true);
+      expect(body.rating).toEqual(upsertResult);
+    });
+  });
+
+  // ─── Sync-to-Stash policy ───
+
+  describe("sync-to-Stash policy", () => {
+    const mockStash = {
+      sceneUpdate: vi.fn().mockResolvedValue({}),
+      performerUpdate: vi.fn().mockResolvedValue({}),
+      studioUpdate: vi.fn().mockResolvedValue({}),
+      tagUpdate: vi.fn().mockResolvedValue({}),
+      galleryUpdate: vi.fn().mockResolvedValue({}),
+      groupUpdate: vi.fn().mockResolvedValue({}),
+      imageUpdate: vi.fn().mockResolvedValue({}),
+    };
+
+    beforeEach(() => {
+      mockPrisma.user.findUnique.mockResolvedValue({ syncToStash: true } as any);
+      mockInstanceManager.getForSync.mockReturnValue(mockStash as any);
+    });
+
+    it("does not sync when syncToStash is disabled", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ syncToStash: false } as any);
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 50 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockInstanceManager.getForSync).not.toHaveBeenCalled();
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("does not sync when getForSync returns null (no stash client)", async () => {
+      mockInstanceManager.getForSync.mockReturnValue(null as any);
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 50 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(mockStash.sceneUpdate).not.toHaveBeenCalled();
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("succeeds even when Stash sync throws (non-blocking)", async () => {
+      mockStash.sceneUpdate.mockRejectedValue(new Error("Stash down"));
+      mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      const req = mockReq({ rating: 50 }, { sceneId: "1" });
+      const res = mockRes();
+      await updateSceneRating(req, res);
+
+      expect(res._getBody().success).toBe(true);
+    });
+
+    // Scene: syncs rating only, NOT favorite
+    describe("scene sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.sceneRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs rating to Stash as rating100", async () => {
+        const req = mockReq({ rating: 85 }, { sceneId: "42" });
+        const res = mockRes();
+        await updateSceneRating(req, res);
+
+        expect(mockStash.sceneUpdate).toHaveBeenCalledWith({
+          input: { id: "42", rating100: 85 },
+        });
+      });
+
+      it("does NOT sync favorite to Stash (scene policy)", async () => {
+        const req = mockReq({ favorite: true }, { sceneId: "42" });
+        const res = mockRes();
+        await updateSceneRating(req, res);
+
+        expect(mockStash.sceneUpdate).not.toHaveBeenCalled();
+      });
+    });
+
+    // Performer: syncs both rating AND favorite
+    describe("performer sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.performerRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs rating to Stash", async () => {
+        const req = mockReq({ rating: 90 }, { performerId: "10" });
+        const res = mockRes();
+        await updatePerformerRating(req, res);
+
+        expect(mockStash.performerUpdate).toHaveBeenCalledWith({
+          input: { id: "10", rating100: 90 },
+        });
+      });
+
+      it("syncs favorite to Stash", async () => {
+        const req = mockReq({ favorite: true }, { performerId: "10" });
+        const res = mockRes();
+        await updatePerformerRating(req, res);
+
+        expect(mockStash.performerUpdate).toHaveBeenCalledWith({
+          input: { id: "10", favorite: true },
+        });
+      });
+
+      it("syncs both rating and favorite together", async () => {
+        const req = mockReq({ rating: 95, favorite: true }, { performerId: "10" });
+        const res = mockRes();
+        await updatePerformerRating(req, res);
+
+        expect(mockStash.performerUpdate).toHaveBeenCalledWith({
+          input: { id: "10", rating100: 95, favorite: true },
+        });
+      });
+    });
+
+    // Studio: syncs both rating AND favorite
+    describe("studio sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.studioRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs both rating and favorite", async () => {
+        const req = mockReq({ rating: 80, favorite: true }, { studioId: "5" });
+        const res = mockRes();
+        await updateStudioRating(req, res);
+
+        expect(mockStash.studioUpdate).toHaveBeenCalledWith({
+          input: { id: "5", rating100: 80, favorite: true },
+        });
+      });
+    });
+
+    // Tag: syncs favorite ONLY (no rating in Stash)
+    describe("tag sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.tagRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs favorite to Stash", async () => {
+        const req = mockReq({ favorite: true }, { tagId: "7" });
+        const res = mockRes();
+        await updateTagRating(req, res);
+
+        expect(mockStash.tagUpdate).toHaveBeenCalledWith({
+          input: { id: "7", favorite: true },
+        });
+      });
+
+      it("does NOT sync rating to Stash (tag policy)", async () => {
+        const req = mockReq({ rating: 60 }, { tagId: "7" });
+        const res = mockRes();
+        await updateTagRating(req, res);
+
+        expect(mockStash.tagUpdate).not.toHaveBeenCalled();
+      });
+    });
+
+    // Gallery: syncs rating ONLY (no favorite in Stash)
+    describe("gallery sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.galleryRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs rating to Stash", async () => {
+        const req = mockReq({ rating: 70 }, { galleryId: "3" });
+        const res = mockRes();
+        await updateGalleryRating(req, res);
+
+        expect(mockStash.galleryUpdate).toHaveBeenCalledWith({
+          input: { id: "3", rating100: 70 },
+        });
+      });
+
+      it("does NOT sync favorite to Stash (gallery policy)", async () => {
+        const req = mockReq({ favorite: true }, { galleryId: "3" });
+        const res = mockRes();
+        await updateGalleryRating(req, res);
+
+        expect(mockStash.galleryUpdate).not.toHaveBeenCalled();
+      });
+    });
+
+    // Group: syncs rating ONLY
+    describe("group sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.groupRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs rating to Stash", async () => {
+        const req = mockReq({ rating: 55 }, { groupId: "8" });
+        const res = mockRes();
+        await updateGroupRating(req, res);
+
+        expect(mockStash.groupUpdate).toHaveBeenCalledWith({
+          input: { id: "8", rating100: 55 },
+        });
+      });
+
+      it("does NOT sync favorite to Stash (group policy)", async () => {
+        const req = mockReq({ favorite: true }, { groupId: "8" });
+        const res = mockRes();
+        await updateGroupRating(req, res);
+
+        expect(mockStash.groupUpdate).not.toHaveBeenCalled();
+      });
+    });
+
+    // Image: syncs rating ONLY
+    describe("image sync policy", () => {
+      beforeEach(() => {
+        mockPrisma.imageRating.upsert.mockResolvedValue(UPSERT_RESULT as any);
+      });
+
+      it("syncs rating to Stash", async () => {
+        const req = mockReq({ rating: 40 }, { imageId: "99" });
+        const res = mockRes();
+        await updateImageRating(req, res);
+
+        expect(mockStash.imageUpdate).toHaveBeenCalledWith({
+          input: { id: "99", rating100: 40 },
+        });
+      });
+
+      it("does NOT sync favorite to Stash (image policy)", async () => {
+        const req = mockReq({ favorite: true }, { imageId: "99" });
+        const res = mockRes();
+        await updateImageRating(req, res);
+
+        expect(mockStash.imageUpdate).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ─── All entity endpoints: missing ID validation ───
+
+  describe("per-entity missing ID validation", () => {
+    const cases: [string, typeof updateSceneRating, string][] = [
+      ["performer", updatePerformerRating, "Missing performerId"],
+      ["studio", updateStudioRating, "Missing studioId"],
+      ["tag", updateTagRating, "Missing tagId"],
+      ["gallery", updateGalleryRating, "Missing galleryId"],
+      ["group", updateGroupRating, "Missing groupId"],
+      ["image", updateImageRating, "Missing imageId"],
+    ];
+
+    it.each(cases)(
+      "returns 400 for missing %sId",
+      async (_entity, handler, expectedError) => {
+        const req = mockReq({ rating: 50 }, {});
+        const res = mockRes();
+        await handler(req as any, res);
+        expect(res._getStatus()).toBe(400);
+        expect(res._getBody().error).toBe(expectedError);
+      }
+    );
+  });
+
+  // ─── All entity endpoints: successful upsert ───
+
+  describe("per-entity successful operations", () => {
+    const cases: [
+      string,
+      typeof updateSceneRating,
+      string,
+      keyof typeof mockPrisma,
+    ][] = [
+      ["performer", updatePerformerRating, "performerId", "performerRating"],
+      ["studio", updateStudioRating, "studioId", "studioRating"],
+      ["tag", updateTagRating, "tagId", "tagRating"],
+      ["gallery", updateGalleryRating, "galleryId", "galleryRating"],
+      ["group", updateGroupRating, "groupId", "groupRating"],
+      ["image", updateImageRating, "imageId", "imageRating"],
+    ];
+
+    it.each(cases)(
+      "successfully upserts %s rating",
+      async (_entity, handler, paramKey, modelKey) => {
+        const model = mockPrisma[modelKey] as any;
+        model.upsert.mockResolvedValue(UPSERT_RESULT);
+        const req = mockReq({ rating: 50 }, { [paramKey]: "1" });
+        const res = mockRes();
+        await handler(req as any, res);
+        expect(res._getBody().success).toBe(true);
+        expect(model.upsert).toHaveBeenCalledTimes(1);
+      }
+    );
+  });
+});

--- a/server/tests/controllers/user.test.ts
+++ b/server/tests/controllers/user.test.ts
@@ -1,0 +1,810 @@
+/**
+ * Unit Tests for User Controller — Settings, Password, and Admin Operations
+ *
+ * Tests getUserSettings, updateUserSettings, changePassword, getRecoveryKey,
+ * regenerateRecoveryKey, adminResetPassword, adminRegenerateRecoveryKey,
+ * getAllUsers, createUser, deleteUser, updateUserRole.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock prisma
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+// Mock logger
+vi.mock("../../utils/logger.js", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock bcryptjs
+vi.mock("bcryptjs", () => ({
+  default: {
+    hash: vi.fn().mockResolvedValue("hashed-password"),
+    compare: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+// Mock recoveryKey utils
+vi.mock("../../utils/recoveryKey.js", () => ({
+  generateRecoveryKey: vi.fn().mockReturnValue("ABCD1234EFGH5678"),
+  formatRecoveryKey: vi.fn().mockReturnValue("ABCD-1234-EFGH-5678"),
+}));
+
+// Mock passwordValidation
+vi.mock("../../utils/passwordValidation.js", () => ({
+  validatePassword: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+}));
+
+// Mock PermissionService (imported by user.ts but not used by settings/password/admin ops directly)
+vi.mock("../../services/PermissionService.js", () => ({
+  resolveUserPermissions: vi.fn(),
+}));
+
+// Mock ExclusionComputationService
+vi.mock("../../services/ExclusionComputationService.js", () => ({
+  exclusionComputationService: {
+    recomputeForUser: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import prisma from "../../prisma/singleton.js";
+import bcrypt from "bcryptjs";
+import { validatePassword } from "../../utils/passwordValidation.js";
+import { formatRecoveryKey } from "../../utils/recoveryKey.js";
+import {
+  getUserSettings,
+  updateUserSettings,
+  changePassword,
+  getRecoveryKey,
+  regenerateRecoveryKey,
+  adminResetPassword,
+  adminRegenerateRecoveryKey,
+  getAllUsers,
+  createUser,
+  deleteUser,
+  updateUserRole,
+} from "../../controllers/user.js";
+
+const mockPrisma = vi.mocked(prisma);
+const mockBcrypt = vi.mocked(bcrypt);
+const mockValidatePassword = vi.mocked(validatePassword);
+
+const ADMIN = { id: 1, username: "admin", role: "ADMIN" };
+const USER = { id: 2, username: "testuser", role: "USER" };
+
+function mockReq(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  user: typeof ADMIN | typeof USER | Record<string, unknown> = USER,
+  query: Record<string, string> = {}
+) {
+  return { body, params, user, query } as any;
+}
+
+function mockRes() {
+  const res: any = {
+    json: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+    _getStatus: () => res.status.mock.calls[0]?.[0] ?? 200,
+    _getBody: () => {
+      const jsonCalls = res.json.mock.calls;
+      return jsonCalls[jsonCalls.length - 1]?.[0];
+    },
+  };
+  return res;
+}
+
+describe("User Controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── getUserSettings ───
+
+  describe("getUserSettings", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getUserSettings(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserSettings(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns user settings with defaults for null fields", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 2,
+        username: "testuser",
+        role: "USER",
+        preferredQuality: "1080p",
+        preferredPlaybackMode: null,
+        preferredPreviewQuality: null,
+        enableCast: false,
+        theme: "dark",
+        carouselPreferences: null,
+        navPreferences: null,
+        filterPresets: null,
+        minimumPlayPercent: null,
+        syncToStash: false,
+        hideConfirmationDisabled: false,
+        unitPreference: null,
+        wallPlayback: null,
+        tableColumnDefaults: null,
+        cardDisplaySettings: null,
+        landingPagePreference: null,
+        lightboxDoubleTapAction: null,
+      } as any);
+
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserSettings(req, res);
+
+      const body = res._getBody();
+      expect(body.settings.preferredQuality).toBe("1080p");
+      expect(body.settings.unitPreference).toBe("metric"); // default
+      expect(body.settings.wallPlayback).toBe("autoplay"); // default
+      expect(body.settings.lightboxDoubleTapAction).toBe("favorite"); // default
+      expect(body.settings.landingPagePreference).toEqual({ pages: ["home"], randomize: false }); // default
+      expect(body.settings.carouselPreferences).toBeInstanceOf(Array); // default carousel prefs
+      expect(body.settings.carouselPreferences.length).toBeGreaterThan(0);
+    });
+
+    it("returns 500 on database error", async () => {
+      mockPrisma.user.findUnique.mockRejectedValue(new Error("DB error"));
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserSettings(req, res);
+      expect(res._getStatus()).toBe(500);
+    });
+  });
+
+  // ─── updateUserSettings ───
+
+  describe("updateUserSettings", () => {
+    const mockUpdatedUser = {
+      id: 2,
+      preferredQuality: "720p",
+      preferredPlaybackMode: null,
+      theme: null,
+      carouselPreferences: null,
+      navPreferences: null,
+      minimumPlayPercent: null,
+      syncToStash: false,
+      wallPlayback: null,
+      tableColumnDefaults: null,
+      cardDisplaySettings: null,
+      landingPagePreference: null,
+      lightboxDoubleTapAction: null,
+    };
+
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 403 when non-admin updates another user", async () => {
+      const req = mockReq({}, { userId: "3" }, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("allows admin to update another user's settings", async () => {
+      mockPrisma.user.update.mockResolvedValue(mockUpdatedUser as any);
+      const req = mockReq({ preferredQuality: "720p" }, { userId: "2" }, ADMIN);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 2 } })
+      );
+    });
+
+    it("updates own settings successfully", async () => {
+      mockPrisma.user.update.mockResolvedValue(mockUpdatedUser as any);
+      const req = mockReq({ preferredQuality: "720p" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    // Validation tests
+    it("rejects invalid quality", async () => {
+      const req = mockReq({ preferredQuality: "4k" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid quality/);
+    });
+
+    it("rejects invalid playback mode", async () => {
+      const req = mockReq({ preferredPlaybackMode: "turbo" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid playback mode/);
+    });
+
+    it("rejects invalid preview quality", async () => {
+      const req = mockReq({ preferredPreviewQuality: "gif" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid preview quality/);
+    });
+
+    it("rejects minimumPlayPercent out of range", async () => {
+      const req = mockReq({ minimumPlayPercent: 150 }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects non-number minimumPlayPercent", async () => {
+      const req = mockReq({ minimumPlayPercent: "half" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects non-boolean syncToStash", async () => {
+      const req = mockReq({ syncToStash: "yes" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects invalid unitPreference", async () => {
+      const req = mockReq({ unitPreference: "kelvin" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects invalid wallPlayback", async () => {
+      const req = mockReq({ wallPlayback: "loop" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects non-array carouselPreferences", async () => {
+      const req = mockReq({ carouselPreferences: "bad" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects invalid carousel preference format", async () => {
+      const req = mockReq(
+        { carouselPreferences: [{ id: 123, enabled: "yes", order: "first" }] },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects non-array navPreferences", async () => {
+      const req = mockReq({ navPreferences: {} }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects invalid tableColumnDefaults entity type", async () => {
+      const req = mockReq(
+        { tableColumnDefaults: { invalid: { visible: [], order: [] } } },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects tableColumnDefaults with missing arrays", async () => {
+      const req = mockReq(
+        { tableColumnDefaults: { scene: { visible: "not-array" } } },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("accepts null tableColumnDefaults (clearing)", async () => {
+      mockPrisma.user.update.mockResolvedValue(mockUpdatedUser as any);
+      const req = mockReq({ tableColumnDefaults: null }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("rejects landingPagePreference with no pages", async () => {
+      const req = mockReq(
+        { landingPagePreference: { pages: [], randomize: false } },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("rejects randomize mode with fewer than 2 pages", async () => {
+      const req = mockReq(
+        { landingPagePreference: { pages: ["home"], randomize: true } },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/at least 2 pages/);
+    });
+
+    it("rejects invalid landing page key", async () => {
+      const req = mockReq(
+        { landingPagePreference: { pages: ["home", "invalid-page"], randomize: false } },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid landing page key/);
+    });
+
+    it("rejects invalid lightboxDoubleTapAction", async () => {
+      const req = mockReq({ lightboxDoubleTapAction: "zoom" }, {}, USER);
+      const res = mockRes();
+      await updateUserSettings(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("accepts valid lightboxDoubleTapAction values", async () => {
+      mockPrisma.user.update.mockResolvedValue(mockUpdatedUser as any);
+      for (const action of ["favorite", "o_counter", "fullscreen"]) {
+        const req = mockReq({ lightboxDoubleTapAction: action }, {}, USER);
+        const res = mockRes();
+        await updateUserSettings(req, res);
+        expect(res._getBody().success).toBe(true);
+      }
+    });
+  });
+
+  // ─── changePassword ───
+
+  describe("changePassword", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({ currentPassword: "old", newPassword: "New1pass" }, {}, {} as any);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 400 when passwords missing", async () => {
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/required/);
+    });
+
+    it("returns 400 when new password fails validation", async () => {
+      mockValidatePassword.mockReturnValue({ valid: false, errors: ["Too short"] });
+      const req = mockReq({ currentPassword: "old", newPassword: "bad" }, {}, USER);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Too short/);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockValidatePassword.mockReturnValue({ valid: true, errors: [] });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({ currentPassword: "old", newPassword: "NewPass1" }, {}, USER);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns 401 when current password is incorrect", async () => {
+      mockValidatePassword.mockReturnValue({ valid: true, errors: [] });
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 2, password: "hashed" } as any);
+      mockBcrypt.compare.mockResolvedValue(false as any);
+      const req = mockReq({ currentPassword: "wrong", newPassword: "NewPass1" }, {}, USER);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getStatus()).toBe(401);
+      expect(res._getBody().error).toMatch(/incorrect/);
+    });
+
+    it("changes password successfully", async () => {
+      mockValidatePassword.mockReturnValue({ valid: true, errors: [] });
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 2, password: "hashed" } as any);
+      mockBcrypt.compare.mockResolvedValue(true as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ currentPassword: "OldPass1", newPassword: "NewPass1" }, {}, USER);
+      const res = mockRes();
+      await changePassword(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockBcrypt.hash).toHaveBeenCalledWith("NewPass1", 10);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 2 },
+          data: { password: "hashed-password" },
+        })
+      );
+    });
+  });
+
+  // ─── getRecoveryKey ───
+
+  describe("getRecoveryKey", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getRecoveryKey(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getRecoveryKey(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns formatted recovery key", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ recoveryKey: "ABCD1234EFGH5678" } as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getRecoveryKey(req, res);
+      expect(res._getBody().recoveryKey).toBe("ABCD-1234-EFGH-5678");
+    });
+
+    it("returns null when no recovery key exists", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ recoveryKey: null } as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getRecoveryKey(req, res);
+      expect(res._getBody().recoveryKey).toBeNull();
+    });
+  });
+
+  // ─── regenerateRecoveryKey ───
+
+  describe("regenerateRecoveryKey", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await regenerateRecoveryKey(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("generates and returns new formatted key", async () => {
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await regenerateRecoveryKey(req, res);
+      expect(res._getBody().recoveryKey).toBe("ABCD-1234-EFGH-5678");
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 2 },
+          data: { recoveryKey: "ABCD1234EFGH5678" },
+        })
+      );
+    });
+  });
+
+  // ─── adminResetPassword ───
+
+  describe("adminResetPassword", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({ newPassword: "NewPass1" }, { userId: "3" }, USER);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({ newPassword: "NewPass1" }, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid user ID/);
+    });
+
+    it("returns 400 when password missing", async () => {
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when password fails validation", async () => {
+      mockValidatePassword.mockReturnValue({ valid: false, errors: ["Weak"] });
+      const req = mockReq({ newPassword: "bad" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockValidatePassword.mockReturnValue({ valid: true, errors: [] });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({ newPassword: "NewPass1" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("resets password successfully", async () => {
+      mockValidatePassword.mockReturnValue({ valid: true, errors: [] });
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 3 } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ newPassword: "NewPass1" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminResetPassword(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  // ─── adminRegenerateRecoveryKey ───
+
+  describe("adminRegenerateRecoveryKey", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "3" }, USER);
+      const res = mockRes();
+      await adminRegenerateRecoveryKey(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminRegenerateRecoveryKey(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("regenerates key successfully", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 3 } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await adminRegenerateRecoveryKey(req, res);
+      expect(res._getBody().recoveryKey).toBe("ABCD-1234-EFGH-5678");
+    });
+  });
+
+  // ─── getAllUsers ───
+
+  describe("getAllUsers", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getAllUsers(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns users with group memberships mapped", async () => {
+      mockPrisma.user.findMany.mockResolvedValue([
+        {
+          id: 1,
+          username: "admin",
+          role: "ADMIN",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          syncToStash: false,
+          groupMemberships: [{ group: { id: 1, name: "Group A" } }],
+        },
+      ] as any);
+      const req = mockReq({}, {}, ADMIN);
+      const res = mockRes();
+      await getAllUsers(req, res);
+      const body = res._getBody();
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0].groups).toEqual([{ id: 1, name: "Group A" }]);
+      expect(body.users[0].groupMemberships).toBeUndefined();
+    });
+  });
+
+  // ─── createUser ───
+
+  describe("createUser", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({ username: "new", password: "Pass123" }, {}, USER);
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 when username or password missing", async () => {
+      const req = mockReq({ username: "new" }, {}, ADMIN);
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when password too short", async () => {
+      const req = mockReq({ username: "new", password: "12345" }, {}, ADMIN);
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/6 characters/);
+    });
+
+    it("returns 400 for invalid role", async () => {
+      const req = mockReq(
+        { username: "new", password: "Pass123", role: "SUPERADMIN" },
+        {},
+        ADMIN
+      );
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/ADMIN or USER/);
+    });
+
+    it("returns 409 when username already exists", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 5 } as any);
+      const req = mockReq({ username: "existing", password: "Pass123" }, {}, ADMIN);
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(409);
+    });
+
+    it("creates user with default USER role", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({
+        id: 5,
+        username: "new",
+        role: "USER",
+        createdAt: new Date(),
+      } as any);
+      const req = mockReq({ username: "new", password: "Pass123" }, {}, ADMIN);
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(201);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().user.username).toBe("new");
+      expect(mockPrisma.user.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ role: "USER" }),
+        })
+      );
+    });
+
+    it("creates user with explicit ADMIN role", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({
+        id: 5,
+        username: "admin2",
+        role: "ADMIN",
+        createdAt: new Date(),
+      } as any);
+      const req = mockReq(
+        { username: "admin2", password: "Pass123", role: "ADMIN" },
+        {},
+        ADMIN
+      );
+      const res = mockRes();
+      await createUser(req, res);
+      expect(res._getStatus()).toBe(201);
+    });
+  });
+
+  // ─── deleteUser ───
+
+  describe("deleteUser", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "3" }, USER);
+      const res = mockRes();
+      await deleteUser(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({}, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await deleteUser(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when trying to delete self", async () => {
+      const req = mockReq({}, { userId: "1" }, ADMIN);
+      const res = mockRes();
+      await deleteUser(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/own account/);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, { userId: "99" }, ADMIN);
+      const res = mockRes();
+      await deleteUser(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("deletes user successfully", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 3 } as any);
+      mockPrisma.user.delete.mockResolvedValue({} as any);
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await deleteUser(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: 3 } });
+    });
+  });
+
+  // ─── updateUserRole ───
+
+  describe("updateUserRole", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({ role: "ADMIN" }, { userId: "3" }, USER);
+      const res = mockRes();
+      await updateUserRole(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({ role: "USER" }, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await updateUserRole(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid role", async () => {
+      const req = mockReq({ role: "SUPERADMIN" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserRole(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when changing own role", async () => {
+      const req = mockReq({ role: "USER" }, { userId: "1" }, ADMIN);
+      const res = mockRes();
+      await updateUserRole(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/own role/);
+    });
+
+    it("updates role successfully", async () => {
+      mockPrisma.user.update.mockResolvedValue({
+        id: 3,
+        username: "user3",
+        role: "ADMIN",
+        updatedAt: new Date(),
+      } as any);
+      const req = mockReq({ role: "ADMIN" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserRole(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().user.role).toBe("ADMIN");
+    });
+  });
+});

--- a/server/tests/controllers/userFeatures.test.ts
+++ b/server/tests/controllers/userFeatures.test.ts
@@ -1,0 +1,1003 @@
+/**
+ * Unit Tests for User Controller — Filter Presets, Restrictions, Hidden Entities,
+ * Permissions, Instance Selection, and Setup
+ *
+ * Tests getFilterPresets, saveFilterPreset, deleteFilterPreset,
+ * getDefaultFilterPresets, setDefaultFilterPreset, getUserRestrictions,
+ * updateUserRestrictions, deleteUserRestrictions, hideEntity, unhideEntity,
+ * unhideAllEntities, getHiddenEntities, getHiddenEntityIds, hideEntities,
+ * updateHideConfirmation, getUserPermissions, getAnyUserPermissions,
+ * updateUserPermissionOverrides, getUserGroupMemberships,
+ * getUserStashInstances, updateUserStashInstances, getSetupStatus,
+ * completeSetup, syncFromStash (auth/validation only).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock prisma
+vi.mock("../../prisma/singleton.js", () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    userContentRestriction: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    userGroupMembership: {
+      findMany: vi.fn(),
+    },
+    userStashInstance: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    stashInstance: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+// Mock logger
+vi.mock("../../utils/logger.js", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock bcryptjs (imported by user.ts)
+vi.mock("bcryptjs", () => ({
+  default: { hash: vi.fn(), compare: vi.fn() },
+}));
+
+// Mock recoveryKey utils (imported by user.ts)
+vi.mock("../../utils/recoveryKey.js", () => ({
+  generateRecoveryKey: vi.fn(),
+  formatRecoveryKey: vi.fn(),
+}));
+
+// Mock passwordValidation (imported by user.ts)
+vi.mock("../../utils/passwordValidation.js", () => ({
+  validatePassword: vi.fn(),
+}));
+
+// Mock PermissionService
+vi.mock("../../services/PermissionService.js", () => ({
+  resolveUserPermissions: vi.fn(),
+}));
+
+// Mock ExclusionComputationService
+vi.mock("../../services/ExclusionComputationService.js", () => ({
+  exclusionComputationService: {
+    recomputeForUser: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock UserHiddenEntityService (dynamically imported)
+vi.mock("../../services/UserHiddenEntityService.js", () => ({
+  userHiddenEntityService: {
+    hideEntity: vi.fn().mockResolvedValue(undefined),
+    unhideEntity: vi.fn().mockResolvedValue(undefined),
+    unhideAll: vi.fn().mockResolvedValue(5),
+    getHiddenEntities: vi.fn().mockResolvedValue([]),
+    getHiddenEntityIds: vi.fn().mockResolvedValue({
+      scenes: new Set(),
+      performers: new Set(),
+      studios: new Set(),
+      tags: new Set(),
+      groups: new Set(),
+      galleries: new Set(),
+      images: new Set(),
+    }),
+  },
+}));
+
+// Mock StashInstanceManager (dynamically imported by hideEntity/unhideEntity)
+vi.mock("../../services/StashInstanceManager.js", () => ({
+  stashInstanceManager: {
+    getConfig: vi.fn().mockReturnValue({ id: "inst-1" }),
+    getAll: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import prisma from "../../prisma/singleton.js";
+import { resolveUserPermissions } from "../../services/PermissionService.js";
+import { exclusionComputationService } from "../../services/ExclusionComputationService.js";
+import {
+  getFilterPresets,
+  saveFilterPreset,
+  deleteFilterPreset,
+  getDefaultFilterPresets,
+  setDefaultFilterPreset,
+  getUserRestrictions,
+  updateUserRestrictions,
+  deleteUserRestrictions,
+  hideEntity,
+  unhideEntity,
+  unhideAllEntities,
+  getHiddenEntities,
+  getHiddenEntityIds,
+  hideEntities,
+  updateHideConfirmation,
+  getUserPermissions,
+  getAnyUserPermissions,
+  updateUserPermissionOverrides,
+  getUserGroupMemberships,
+  getUserStashInstances,
+  updateUserStashInstances,
+  getSetupStatus,
+  completeSetup,
+  syncFromStash,
+} from "../../controllers/user.js";
+
+const mockPrisma = vi.mocked(prisma);
+const mockResolvePermissions = vi.mocked(resolveUserPermissions);
+const mockExclusionService = vi.mocked(exclusionComputationService);
+
+const ADMIN = { id: 1, username: "admin", role: "ADMIN" };
+const USER = { id: 2, username: "testuser", role: "USER" };
+
+function mockReq(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  user: typeof ADMIN | typeof USER | Record<string, unknown> = USER,
+  query: Record<string, string> = {}
+) {
+  return { body, params, user, query } as any;
+}
+
+function mockRes() {
+  const res: any = {
+    json: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+    _getStatus: () => res.status.mock.calls[0]?.[0] ?? 200,
+    _getBody: () => {
+      const jsonCalls = res.json.mock.calls;
+      return jsonCalls[jsonCalls.length - 1]?.[0];
+    },
+  };
+  return res;
+}
+
+describe("User Controller — Features", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Filter Presets ───
+
+  describe("getFilterPresets", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getFilterPresets(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getFilterPresets(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns empty preset structure when none exist", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ filterPresets: null } as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getFilterPresets(req, res);
+      const body = res._getBody();
+      expect(body.presets).toEqual({
+        scene: [],
+        performer: [],
+        studio: [],
+        tag: [],
+      });
+    });
+
+    it("returns existing presets", async () => {
+      const presets = { scene: [{ id: "1", name: "Test" }] };
+      mockPrisma.user.findUnique.mockResolvedValue({ filterPresets: presets } as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getFilterPresets(req, res);
+      expect(res._getBody().presets).toEqual(presets);
+    });
+  });
+
+  describe("saveFilterPreset", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 400 when required fields missing", async () => {
+      const req = mockReq({ artifactType: "scene" }, {}, USER);
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Missing required/);
+    });
+
+    it("returns 400 for invalid artifact type", async () => {
+      const req = mockReq(
+        {
+          artifactType: "invalid",
+          name: "Test",
+          filters: {},
+          sort: "title",
+          direction: "ASC",
+        },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid artifact type/);
+    });
+
+    it("returns 400 for invalid context", async () => {
+      const req = mockReq(
+        {
+          artifactType: "scene",
+          context: "invalid_context",
+          name: "Test",
+          filters: {},
+          sort: "title",
+          direction: "ASC",
+        },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Invalid context/);
+    });
+
+    it("saves preset with defaults for optional fields", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        filterPresets: {},
+        defaultFilterPresets: {},
+      } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+
+      const req = mockReq(
+        {
+          artifactType: "scene",
+          name: "My Filter",
+          filters: { rating: 80 },
+          sort: "rating",
+          direction: "DESC",
+        },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+      const body = res._getBody();
+      expect(body.success).toBe(true);
+      expect(body.preset.name).toBe("My Filter");
+      expect(body.preset.viewMode).toBe("grid");
+      expect(body.preset.zoomLevel).toBe("medium");
+      expect(body.preset.gridDensity).toBe("comfortable");
+      expect(body.preset.id).toBeDefined();
+      expect(body.preset.createdAt).toBeDefined();
+    });
+
+    it("sets preset as default when setAsDefault is true", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        filterPresets: {},
+        defaultFilterPresets: {},
+      } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+
+      const req = mockReq(
+        {
+          artifactType: "scene",
+          context: "scene_performer",
+          name: "Fav Filter",
+          filters: {},
+          sort: "name",
+          direction: "ASC",
+          setAsDefault: true,
+        },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await saveFilterPreset(req, res);
+
+      // Check that defaultFilterPresets was updated in the prisma call
+      const updateCall = mockPrisma.user.update.mock.calls[0][0];
+      const defaults = updateCall.data.defaultFilterPresets as Record<string, unknown>;
+      expect(defaults.scene_performer).toBeDefined();
+    });
+  });
+
+  describe("deleteFilterPreset", () => {
+    it("returns 400 for invalid artifact type", async () => {
+      const req = mockReq({}, { artifactType: "invalid", presetId: "1" }, USER);
+      const res = mockRes();
+      await deleteFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, { artifactType: "scene", presetId: "1" }, USER);
+      const res = mockRes();
+      await deleteFilterPreset(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("deletes preset and clears default if it was default", async () => {
+      const presetId = "preset-to-delete";
+      mockPrisma.user.findUnique.mockResolvedValue({
+        filterPresets: { scene: [{ id: presetId, name: "Test" }] },
+        defaultFilterPresets: { scene: presetId },
+      } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+
+      const req = mockReq({}, { artifactType: "scene", presetId }, USER);
+      const res = mockRes();
+      await deleteFilterPreset(req, res);
+      expect(res._getBody().success).toBe(true);
+
+      const updateCall = mockPrisma.user.update.mock.calls[0][0];
+      const presets = updateCall.data.filterPresets as Record<string, unknown[]>;
+      const defaults = updateCall.data.defaultFilterPresets as Record<string, unknown>;
+      expect(presets.scene).toEqual([]);
+      expect(defaults.scene).toBeUndefined();
+    });
+  });
+
+  describe("getDefaultFilterPresets", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getDefaultFilterPresets(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns empty object when no defaults set", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ defaultFilterPresets: null } as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getDefaultFilterPresets(req, res);
+      expect(res._getBody().defaults).toEqual({});
+    });
+  });
+
+  describe("setDefaultFilterPreset", () => {
+    it("returns 400 when context missing", async () => {
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await setDefaultFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Missing context/);
+    });
+
+    it("returns 400 for invalid context", async () => {
+      const req = mockReq({ context: "bogus" }, {}, USER);
+      const res = mockRes();
+      await setDefaultFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when preset not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        defaultFilterPresets: {},
+        filterPresets: { scene: [] },
+      } as any);
+      const req = mockReq({ context: "scene", presetId: "nonexistent" }, {}, USER);
+      const res = mockRes();
+      await setDefaultFilterPreset(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/Preset not found/);
+    });
+
+    it("clears default when presetId is null", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        defaultFilterPresets: { scene: "some-id" },
+        filterPresets: {},
+      } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ context: "scene" }, {}, USER);
+      const res = mockRes();
+      await setDefaultFilterPreset(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+
+    it("validates scene grid contexts against scene presets", async () => {
+      const presetId = "existing-preset";
+      mockPrisma.user.findUnique.mockResolvedValue({
+        defaultFilterPresets: {},
+        filterPresets: { scene: [{ id: presetId, name: "Test" }] },
+      } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ context: "scene_performer", presetId }, {}, USER);
+      const res = mockRes();
+      await setDefaultFilterPreset(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  // ─── Content Restrictions ───
+
+  describe("getUserRestrictions", () => {
+    it("returns 401 when user missing", async () => {
+      const req = { params: { userId: "2" }, user: undefined } as any;
+      const res = mockRes();
+      await getUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "2" }, USER);
+      const res = mockRes();
+      await getUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns restrictions for user", async () => {
+      const restrictions = [{ id: 1, entityType: "tags", mode: "EXCLUDE", entityIds: "[]" }];
+      mockPrisma.userContentRestriction.findMany.mockResolvedValue(restrictions as any);
+      const req = mockReq({}, { userId: "2" }, ADMIN);
+      const res = mockRes();
+      await getUserRestrictions(req, res);
+      expect(res._getBody().restrictions).toEqual(restrictions);
+    });
+  });
+
+  describe("updateUserRestrictions", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({ restrictions: [] }, { userId: "2" }, USER);
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 when restrictions not an array", async () => {
+      const req = mockReq({ restrictions: "bad" }, { userId: "2" }, ADMIN);
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid entity type", async () => {
+      const req = mockReq(
+        { restrictions: [{ entityType: "users", mode: "EXCLUDE", entityIds: [] }] },
+        { userId: "2" },
+        ADMIN
+      );
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid mode", async () => {
+      const req = mockReq(
+        { restrictions: [{ entityType: "tags", mode: "BLOCK", entityIds: [] }] },
+        { userId: "2" },
+        ADMIN
+      );
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when entityIds not an array", async () => {
+      const req = mockReq(
+        { restrictions: [{ entityType: "tags", mode: "EXCLUDE", entityIds: "1,2" }] },
+        { userId: "2" },
+        ADMIN
+      );
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("replaces all restrictions and recomputes exclusions", async () => {
+      mockPrisma.userContentRestriction.deleteMany.mockResolvedValue({ count: 1 } as any);
+      mockPrisma.userContentRestriction.create.mockResolvedValue({ id: 1 } as any);
+      const req = mockReq(
+        {
+          restrictions: [
+            { entityType: "tags", mode: "EXCLUDE", entityIds: ["1", "2"] },
+          ],
+        },
+        { userId: "2" },
+        ADMIN
+      );
+      const res = mockRes();
+      await updateUserRestrictions(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockPrisma.userContentRestriction.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 2 },
+      });
+      expect(mockExclusionService.recomputeForUser).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe("deleteUserRestrictions", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "2" }, USER);
+      const res = mockRes();
+      await deleteUserRestrictions(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("deletes all restrictions and recomputes exclusions", async () => {
+      mockPrisma.userContentRestriction.deleteMany.mockResolvedValue({ count: 3 } as any);
+      const req = mockReq({}, { userId: "2" }, ADMIN);
+      const res = mockRes();
+      await deleteUserRestrictions(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockExclusionService.recomputeForUser).toHaveBeenCalledWith(2);
+    });
+  });
+
+  // ─── Hidden Entities ───
+
+  describe("hideEntity", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({ entityType: "scene", entityId: "1" }, {}, {} as any);
+      const res = mockRes();
+      await hideEntity(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 400 when entityType or entityId missing", async () => {
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await hideEntity(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid entity type", async () => {
+      const req = mockReq({ entityType: "user", entityId: "1" }, {}, USER);
+      const res = mockRes();
+      await hideEntity(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("hides entity successfully", async () => {
+      const req = mockReq({ entityType: "scene", entityId: "42" }, {}, USER);
+      const res = mockRes();
+      await hideEntity(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  describe("unhideEntity", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, { entityType: "scene", entityId: "1" }, {} as any);
+      const res = mockRes();
+      await unhideEntity(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 400 for invalid entity type", async () => {
+      const req = mockReq({}, { entityType: "invalid", entityId: "1" }, USER, {});
+      const res = mockRes();
+      await unhideEntity(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("unhides entity successfully", async () => {
+      const req = mockReq({}, { entityType: "scene", entityId: "42" }, USER, {});
+      const res = mockRes();
+      await unhideEntity(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  describe("unhideAllEntities", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any, {});
+      const res = mockRes();
+      await unhideAllEntities(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 400 for invalid entity type filter", async () => {
+      const req = mockReq({}, {}, USER, { entityType: "invalid" });
+      const res = mockRes();
+      await unhideAllEntities(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("unhides all and returns count", async () => {
+      const req = mockReq({}, {}, USER, {});
+      const res = mockRes();
+      await unhideAllEntities(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().count).toBe(5);
+    });
+  });
+
+  describe("getHiddenEntities", () => {
+    it("returns hidden entities list", async () => {
+      const req = mockReq({}, {}, USER, {});
+      const res = mockRes();
+      await getHiddenEntities(req, res);
+      expect(res._getBody().hiddenEntities).toEqual([]);
+    });
+  });
+
+  describe("getHiddenEntityIds", () => {
+    it("returns hidden IDs organized by type", async () => {
+      const req = mockReq({}, {}, USER, {});
+      const res = mockRes();
+      await getHiddenEntityIds(req, res);
+      const ids = res._getBody().hiddenIds;
+      expect(ids.scenes).toEqual([]);
+      expect(ids.performers).toEqual([]);
+    });
+  });
+
+  describe("hideEntities (bulk)", () => {
+    it("returns 400 when entities not an array", async () => {
+      const req = mockReq({ entities: "bad" }, {}, USER);
+      const res = mockRes();
+      await hideEntities(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when entities is empty", async () => {
+      const req = mockReq({ entities: [] }, {}, USER);
+      const res = mockRes();
+      await hideEntities(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for missing entityType/entityId", async () => {
+      const req = mockReq({ entities: [{ entityType: "scene" }] }, {}, USER);
+      const res = mockRes();
+      await hideEntities(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid entity type in bulk", async () => {
+      const req = mockReq(
+        { entities: [{ entityType: "invalid", entityId: "1" }] },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await hideEntities(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("hides multiple entities and reports counts", async () => {
+      const req = mockReq(
+        {
+          entities: [
+            { entityType: "scene", entityId: "1" },
+            { entityType: "performer", entityId: "2" },
+          ],
+        },
+        {},
+        USER
+      );
+      const res = mockRes();
+      await hideEntities(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().successCount).toBe(2);
+      expect(res._getBody().failCount).toBe(0);
+    });
+  });
+
+  describe("updateHideConfirmation", () => {
+    it("returns 400 when value not boolean", async () => {
+      const req = mockReq({ hideConfirmationDisabled: "yes" }, {}, USER);
+      const res = mockRes();
+      await updateHideConfirmation(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("updates preference successfully", async () => {
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ hideConfirmationDisabled: true }, {}, USER);
+      const res = mockRes();
+      await updateHideConfirmation(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().hideConfirmationDisabled).toBe(true);
+    });
+  });
+
+  // ─── Permissions ───
+
+  describe("getUserPermissions", () => {
+    it("returns 401 when user missing", async () => {
+      const req = { user: undefined } as any;
+      const res = mockRes();
+      await getUserPermissions(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 404 when permissions null", async () => {
+      mockResolvePermissions.mockResolvedValue(null as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserPermissions(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns resolved permissions", async () => {
+      const perms = { canShare: true, canDownloadFiles: false };
+      mockResolvePermissions.mockResolvedValue(perms as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserPermissions(req, res);
+      expect(res._getBody().permissions).toEqual(perms);
+    });
+  });
+
+  describe("getAnyUserPermissions", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "3" }, USER);
+      const res = mockRes();
+      await getAnyUserPermissions(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({}, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await getAnyUserPermissions(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns permissions for specified user", async () => {
+      const perms = { canShare: false };
+      mockResolvePermissions.mockResolvedValue(perms as any);
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await getAnyUserPermissions(req, res);
+      expect(res._getBody().permissions).toEqual(perms);
+    });
+  });
+
+  describe("updateUserPermissionOverrides", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({ canShareOverride: true }, { userId: "3" }, USER);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({ canShareOverride: true }, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 when no valid updates", async () => {
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/No valid updates/);
+    });
+
+    it("returns 400 for invalid override value", async () => {
+      const req = mockReq({ canShareOverride: "yes" }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("updates overrides and returns permissions", async () => {
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockResolvePermissions.mockResolvedValue({ canShare: true } as any);
+      const req = mockReq({ canShareOverride: true }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().permissions).toEqual({ canShare: true });
+    });
+
+    it("accepts null to clear overrides", async () => {
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      mockResolvePermissions.mockResolvedValue({} as any);
+      const req = mockReq({ canShareOverride: null }, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await updateUserPermissionOverrides(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  describe("getUserGroupMemberships", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "3" }, USER);
+      const res = mockRes();
+      await getUserGroupMemberships(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns mapped groups", async () => {
+      mockPrisma.userGroupMembership.findMany.mockResolvedValue([
+        { group: { id: 1, name: "Group A", description: null, canShare: true, canDownloadFiles: false, canDownloadPlaylists: false } },
+      ] as any);
+      const req = mockReq({}, { userId: "3" }, ADMIN);
+      const res = mockRes();
+      await getUserGroupMemberships(req, res);
+      expect(res._getBody().groups).toHaveLength(1);
+      expect(res._getBody().groups[0].name).toBe("Group A");
+    });
+  });
+
+  // ─── Stash Instance Selection ───
+
+  describe("getUserStashInstances", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getUserStashInstances(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns selected and available instances", async () => {
+      mockPrisma.userStashInstance.findMany.mockResolvedValue([
+        { instanceId: "inst-1" },
+      ] as any);
+      mockPrisma.stashInstance.findMany.mockResolvedValue([
+        { id: "inst-1", name: "Stash 1", description: null },
+        { id: "inst-2", name: "Stash 2", description: null },
+      ] as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getUserStashInstances(req, res);
+      const body = res._getBody();
+      expect(body.selectedInstanceIds).toEqual(["inst-1"]);
+      expect(body.availableInstances).toHaveLength(2);
+    });
+  });
+
+  describe("updateUserStashInstances", () => {
+    it("returns 400 when instanceIds not an array", async () => {
+      const req = mockReq({ instanceIds: "inst-1" }, {}, USER);
+      const res = mockRes();
+      await updateUserStashInstances(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+
+    it("returns 400 for invalid instance IDs", async () => {
+      mockPrisma.stashInstance.findMany.mockResolvedValue([{ id: "inst-1" }] as any);
+      const req = mockReq({ instanceIds: ["inst-1", "inst-99"] }, {}, USER);
+      const res = mockRes();
+      await updateUserStashInstances(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().invalidIds).toEqual(["inst-99"]);
+    });
+
+    it("clears selections when empty array", async () => {
+      mockPrisma.userStashInstance.deleteMany.mockResolvedValue({ count: 1 } as any);
+      const req = mockReq({ instanceIds: [] }, {}, USER);
+      const res = mockRes();
+      await updateUserStashInstances(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(res._getBody().selectedInstanceIds).toEqual([]);
+      expect(mockPrisma.userStashInstance.createMany).not.toHaveBeenCalled();
+    });
+
+    it("replaces selections with valid IDs", async () => {
+      mockPrisma.stashInstance.findMany.mockResolvedValue([{ id: "inst-2" }] as any);
+      mockPrisma.userStashInstance.deleteMany.mockResolvedValue({ count: 0 } as any);
+      mockPrisma.userStashInstance.createMany.mockResolvedValue({ count: 1 } as any);
+      const req = mockReq({ instanceIds: ["inst-2"] }, {}, USER);
+      const res = mockRes();
+      await updateUserStashInstances(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockPrisma.userStashInstance.createMany).toHaveBeenCalledWith({
+        data: [{ userId: 2, instanceId: "inst-2" }],
+      });
+    });
+  });
+
+  // ─── Setup ───
+
+  describe("getSetupStatus", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await getSetupStatus(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("returns 404 when user not found", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getSetupStatus(req, res);
+      expect(res._getStatus()).toBe(404);
+    });
+
+    it("returns setup status with instances", async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        setupCompleted: false,
+        recoveryKey: "KEY123",
+      } as any);
+      mockPrisma.stashInstance.findMany.mockResolvedValue([
+        { id: "inst-1", name: "Stash 1", description: null },
+      ] as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await getSetupStatus(req, res);
+      const body = res._getBody();
+      expect(body.setupCompleted).toBe(false);
+      expect(body.recoveryKey).toBe("KEY123");
+      expect(body.instances).toHaveLength(1);
+      expect(body.instanceCount).toBe(1);
+    });
+  });
+
+  describe("completeSetup", () => {
+    it("returns 401 when user has no id", async () => {
+      const req = mockReq({}, {}, {} as any);
+      const res = mockRes();
+      await completeSetup(req, res);
+      expect(res._getStatus()).toBe(401);
+    });
+
+    it("completes setup for single instance without selections", async () => {
+      mockPrisma.stashInstance.count.mockResolvedValue(1);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await completeSetup(req, res);
+      expect(res._getBody().success).toBe(true);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ setupCompleted: true }),
+        })
+      );
+    });
+
+    it("returns 400 for multi-instance with no selections", async () => {
+      mockPrisma.stashInstance.count.mockResolvedValue(3);
+      const req = mockReq({}, {}, USER);
+      const res = mockRes();
+      await completeSetup(req, res);
+      expect(res._getStatus()).toBe(400);
+      expect(res._getBody().error).toMatch(/At least one/);
+    });
+
+    it("completes setup for multi-instance with valid selections", async () => {
+      mockPrisma.stashInstance.count.mockResolvedValue(3);
+      mockPrisma.stashInstance.findMany.mockResolvedValue([{ id: "inst-1" }] as any);
+      mockPrisma.userStashInstance.deleteMany.mockResolvedValue({ count: 0 } as any);
+      mockPrisma.userStashInstance.createMany.mockResolvedValue({ count: 1 } as any);
+      mockPrisma.user.update.mockResolvedValue({} as any);
+      const req = mockReq({ selectedInstanceIds: ["inst-1"] }, {}, USER);
+      const res = mockRes();
+      await completeSetup(req, res);
+      expect(res._getBody().success).toBe(true);
+    });
+  });
+
+  // ─── syncFromStash (auth/validation only, not the complex pagination logic) ───
+
+  describe("syncFromStash", () => {
+    it("returns 403 when non-admin", async () => {
+      const req = mockReq({}, { userId: "2" }, USER);
+      const res = mockRes();
+      await syncFromStash(req, res);
+      expect(res._getStatus()).toBe(403);
+    });
+
+    it("returns 400 for invalid user ID", async () => {
+      const req = mockReq({}, { userId: "abc" }, ADMIN);
+      const res = mockRes();
+      await syncFromStash(req, res);
+      expect(res._getStatus()).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **192 unit tests** across 3 new test files covering the two highest-risk server controllers
- `ratings.ts` coverage: **0.67% → 81.86%** (lines), 100% functions — all 7 entity endpoints tested for validation, auth, instance ID resolution, upsert behavior, and sync-to-Stash policy
- `user.ts` coverage: **1.99% → 65.38%** (lines), 80.43% functions — 31 exported functions tested across settings, password/recovery, admin ops, filter presets, content restrictions, hidden entities, permissions, instance selection, and setup

## Test plan
- [x] All 1,382 server tests pass (0 failures)
- [x] Lint clean (0 errors)
- [x] TypeScript compiles (`tsc --noEmit` exit 0)
- [x] No changes to production code — test-only PR

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)