### PR TITLE
refactor: centralize and deduplicate API type definitions (#466)

### DIFF
--- a/server/controllers/carousel.ts
+++ b/server/controllers/carousel.ts
@@ -22,6 +22,7 @@ import type {
   PreviewCarouselResponse,
   ExecuteCarouselByIdParams,
   ExecuteCarouselByIdResponse,
+  CarouselPreference,
 } from "../types/api/index.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -99,12 +100,6 @@ export const getCarousel = async (
     res.status(500).json({ error: "Failed to get carousel" });
   }
 };
-
-interface CarouselPreference {
-  id: string;
-  enabled: boolean;
-  order: number;
-}
 
 /**
  * Create a new custom carousel

--- a/server/controllers/library/scenes.ts
+++ b/server/controllers/library/scenes.ts
@@ -13,6 +13,7 @@ import type {
   UpdateSceneResponse,
   ApiErrorResponse,
   AmbiguousLookupResponse,
+  ScoredSceneId,
 } from "../../types/api/index.js";
 import prisma from "../../prisma/singleton.js";
 import { stashEntityService } from "../../services/StashEntityService.js";
@@ -1562,12 +1563,6 @@ export const getRecommendedScenes = async (
     };
 
     // Phase 1: Score all scenes using lightweight data
-    interface ScoredSceneId {
-      id: string;
-      score: number;
-      oCounter: number;
-    }
-
     const scoredScenes: ScoredSceneId[] = [];
     const now = new Date();
 

--- a/server/controllers/proxy.ts
+++ b/server/controllers/proxy.ts
@@ -4,6 +4,7 @@ import https from "https";
 import { URL } from "url";
 import prisma from "../prisma/singleton.js";
 import { stashInstanceManager } from "../services/StashInstanceManager.js";
+import type { ProxyOptions } from "../types/api/proxy.js";
 import { logger } from "../utils/logger.js";
 
 // =============================================================================
@@ -91,14 +92,6 @@ function getInstanceCredentials(instanceId?: string): { baseUrl: string; apiKey:
 // =============================================================================
 // Shared proxy helper
 // =============================================================================
-
-interface ProxyOptions {
-  fullUrl: string;
-  res: Response;
-  label: string;
-  defaultCacheControl: string;
-  timeoutMs: number;
-}
 
 /**
  * Shared helper that makes an HTTP(S) request to Stash and pipes the response

--- a/server/controllers/setup.ts
+++ b/server/controllers/setup.ts
@@ -27,17 +27,9 @@ import type {
   UpdateStashInstanceResponse,
   DeleteStashInstanceParams,
   DeleteStashInstanceResponse,
+  CarouselPreference,
 } from "../types/api/index.js";
 import { logger } from "../utils/logger.js";
-
-/**
- * Carousel preference configuration for user home page
- */
-interface CarouselPreference {
-  id: string;
-  enabled: boolean;
-  order: number;
-}
 
 // Default carousel preferences for new users
 const getDefaultCarouselPreferences = (): CarouselPreference[] => [

--- a/server/controllers/user.ts
+++ b/server/controllers/user.ts
@@ -6,93 +6,20 @@ import prisma from "../prisma/singleton.js";
 import { exclusionComputationService } from "../services/ExclusionComputationService.js";
 import type { EntityType } from "../services/UserHiddenEntityService.js";
 import { resolveUserPermissions } from "../services/PermissionService.js";
+import type {
+  CarouselPreference,
+  TableColumnsConfig,
+  FilterPreset,
+  FilterPresets,
+  DefaultFilterPresets,
+  SyncUpdates,
+  UserRestriction,
+} from "../types/api/user.js";
 import { logger } from "../utils/logger.js";
 import { generateRecoveryKey, formatRecoveryKey } from "../utils/recoveryKey.js";
 import { validatePassword } from "../utils/passwordValidation.js";
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-dynamic-delete -- TODO(#467): migrate handlers to TypedAuthRequest with typed body */
-
-/**
- * Carousel preference configuration
- */
-interface CarouselPreference {
-  id: string;
-  enabled: boolean;
-  order: number;
-}
-
-/**
- * Table column configuration for a preset
- */
-interface TableColumnsConfig {
-  visible: string[];
-  order: string[];
-}
-
-/**
- * Filter preset for scene/performer/studio/tag filtering
- */
-interface FilterPreset {
-  id: string;
-  name: string;
-  filters: unknown;
-  sort?: string;
-  direction?: string;
-  viewMode?: string;
-  zoomLevel?: string;
-  tableColumns?: TableColumnsConfig | null;
-  createdAt?: string;
-  [key: string]: unknown;
-}
-
-/**
- * User filter presets collection
- */
-interface FilterPresets {
-  scene?: FilterPreset[];
-  performer?: FilterPreset[];
-  studio?: FilterPreset[];
-  tag?: FilterPreset[];
-  group?: FilterPreset[];
-  gallery?: FilterPreset[];
-  [key: string]: FilterPreset[] | undefined;
-}
-
-/**
- * Default filter presets (preset IDs for each artifact type)
- */
-interface DefaultFilterPresets {
-  scene?: string;
-  performer?: string;
-  studio?: string;
-  tag?: string;
-  group?: string;
-  gallery?: string;
-  [key: string]: string | undefined;
-}
-
-/**
- * Sync updates for entity ratings/favorites
- */
-interface SyncUpdates {
-  rating?: number | null;
-  rating100?: number | null;
-  favorite?: boolean;
-  [key: string]: unknown;
-}
-
-/**
- * User content restriction from database
- */
-interface UserRestriction {
-  id?: number;
-  userId?: string;
-  entityType: string;
-  mode: string;
-  entityIds: string[] | string;
-  restrictEmpty?: boolean;
-  [key: string]: unknown;
-}
 
 // Inline the default carousel preferences to avoid ESM loading issues
 const getDefaultCarouselPreferences = (): CarouselPreference[] => [

--- a/server/types/api/index.ts
+++ b/server/types/api/index.ts
@@ -25,6 +25,20 @@ export type {
   TypedResponse,
 } from "./express.js";
 
+// User settings & preferences types
+export type {
+  CarouselPreference,
+  TableColumnsConfig,
+  FilterPreset,
+  FilterPresets,
+  DefaultFilterPresets,
+  SyncUpdates,
+  UserRestriction,
+} from "./user.js";
+
+// Proxy controller types
+export type { ProxyOptions } from "./proxy.js";
+
 // Library endpoint types
 export type {
   // Scenes
@@ -38,6 +52,7 @@ export type {
   UpdateSceneParams,
   UpdateSceneRequest,
   UpdateSceneResponse,
+  ScoredSceneId,
   // Performers
   FindPerformersRequest,
   FindPerformersResponse,

--- a/server/types/api/library.ts
+++ b/server/types/api/library.ts
@@ -450,3 +450,12 @@ export interface GetImageParams extends Record<string, string> {
 export interface GetImageResponse extends NormalizedImage {
   stashUrl: string;
 }
+
+/**
+ * Scene recommendation scoring intermediate type
+ */
+export interface ScoredSceneId {
+  id: string;
+  score: number;
+  oCounter: number;
+}

--- a/server/types/api/proxy.ts
+++ b/server/types/api/proxy.ts
@@ -1,0 +1,19 @@
+// server/types/api/proxy.ts
+/**
+ * Proxy Controller Types
+ *
+ * Types for the internal HTTP proxy that forwards requests to Stash instances.
+ */
+
+import type { Response } from "express";
+
+/**
+ * Options for the shared proxy HTTP request helper
+ */
+export interface ProxyOptions {
+  fullUrl: string;
+  res: Response;
+  label: string;
+  defaultCacheControl: string;
+  timeoutMs: number;
+}

--- a/server/types/api/user.ts
+++ b/server/types/api/user.ts
@@ -1,0 +1,90 @@
+// server/types/api/user.ts
+/**
+ * User Settings & Preferences Types
+ *
+ * Centralized type definitions for user settings endpoints.
+ * Previously duplicated across controllers/user.ts, controllers/carousel.ts,
+ * and controllers/setup.ts.
+ */
+
+/**
+ * Carousel preference configuration for user home page
+ */
+export interface CarouselPreference {
+  id: string;
+  enabled: boolean;
+  order: number;
+}
+
+/**
+ * Table column configuration for a preset
+ */
+export interface TableColumnsConfig {
+  visible: string[];
+  order: string[];
+}
+
+/**
+ * Filter preset for scene/performer/studio/tag filtering
+ */
+export interface FilterPreset {
+  id: string;
+  name: string;
+  filters: unknown;
+  sort?: string;
+  direction?: string;
+  viewMode?: string;
+  zoomLevel?: string;
+  tableColumns?: TableColumnsConfig | null;
+  createdAt?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * User filter presets collection, keyed by entity type
+ */
+export interface FilterPresets {
+  scene?: FilterPreset[];
+  performer?: FilterPreset[];
+  studio?: FilterPreset[];
+  tag?: FilterPreset[];
+  group?: FilterPreset[];
+  gallery?: FilterPreset[];
+  [key: string]: FilterPreset[] | undefined;
+}
+
+/**
+ * Default filter presets (preset IDs for each entity type)
+ */
+export interface DefaultFilterPresets {
+  scene?: string;
+  performer?: string;
+  studio?: string;
+  tag?: string;
+  group?: string;
+  gallery?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Sync updates for entity ratings/favorites
+ */
+export interface SyncUpdates {
+  rating?: number | null;
+  rating100?: number | null;
+  favorite?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * User content restriction from database
+ */
+export interface UserRestriction {
+  id?: number;
+  userId?: string;
+  entityType: string;
+  mode: string;
+  entityIds: string[] | string;
+  restrictEmpty?: boolean;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary

- Create `types/api/user.ts` with 7 types extracted from `controllers/user.ts`: CarouselPreference, TableColumnsConfig, FilterPreset, FilterPresets, DefaultFilterPresets, SyncUpdates, UserRestriction
- Create `types/api/proxy.ts` with ProxyOptions from `controllers/proxy.ts`
- Move ScoredSceneId from `controllers/library/scenes.ts` to `types/api/library.ts`
- Deduplicate CarouselPreference (was defined identically in 3 controllers)
- Update `types/api/index.ts` barrel to re-export all new types
- Update all consumers to import from centralized locations

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx eslint .` — 0 errors, 0 warnings
- `npm test` — 69/69 test files pass (1402 tests pass, 19 skipped)

## Test plan

- [x] TypeScript compiles with zero errors
- [x] ESLint passes with zero errors/warnings
- [x] All 1402 unit tests pass
- [ ] Integration tests pass
- [ ] Client build unaffected (server-only changes)

**Note:** This PR targets `refactor/strict-eslint-465` (#482) — merge that first.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)