### PR TITLE
test: add client context and reducer tests (#463)

### DIFF
--- a/client/tests/contexts/AuthContext.test.jsx
+++ b/client/tests/contexts/AuthContext.test.jsx
@@ -1,0 +1,385 @@
+import { waitFor, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { AuthProvider } from "../../src/contexts/AuthContext.jsx";
+import { useAuth } from "../../src/hooks/useAuth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockUser = { id: "1", username: "testuser", role: "USER" };
+
+/**
+ * Renders the useAuth hook inside an AuthProvider so every test can
+ * interact with the context through `result.current`.
+ */
+function renderWithAuth() {
+  return renderHook(() => useAuth(), {
+    wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+  });
+}
+
+/**
+ * Creates a resolved Response-like object for mocking fetch.
+ */
+function okResponse(body) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  });
+}
+
+/**
+ * Creates a non-ok Response-like object for mocking fetch.
+ */
+function errorResponse(status = 401, body = {}) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Default: auth check succeeds with mockUser
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ user: mockUser }),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AuthProvider", () => {
+  // 1. Initial auth check on mount
+  it("calls /api/auth/check on mount and sets user on success", async () => {
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/auth/check", {
+      credentials: "include",
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  // 2. Auth check failure (non-ok response)
+  it("sets isAuthenticated=false and user=null when auth check returns non-ok", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(() => errorResponse(401));
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  // 3. Auth check network error
+  it("sets isAuthenticated=false and user=null when auth check throws", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  // 4. Loading state
+  it("starts with isLoading=true and transitions to false after auth check", async () => {
+    // Use a deferred promise so we can observe the loading state
+    let resolveAuth;
+    globalThis.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAuth = resolve;
+        }),
+    );
+
+    const { result } = renderWithAuth();
+
+    // While the auth check is in-flight, isLoading should be true
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+
+    // Resolve the auth check
+    await act(async () => {
+      resolveAuth({
+        ok: true,
+        json: () => Promise.resolve({ user: mockUser }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});
+
+describe("login()", () => {
+  // 5. Successful login
+  it("calls /api/auth/login, sets user and isAuthenticated, returns success", async () => {
+    const credentials = { username: "testuser", password: "secret" };
+    const loginUser = { id: "1", username: "testuser", role: "USER" };
+
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === "/api/auth/check") {
+        return errorResponse(401);
+      }
+      if (url === "/api/auth/login") {
+        return okResponse({ user: loginUser });
+      }
+      return errorResponse(404);
+    });
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Initially not authenticated (auth check failed)
+    expect(result.current.isAuthenticated).toBe(false);
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current.login(credentials);
+    });
+
+    expect(loginResult).toEqual({ success: true, user: loginUser });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(loginUser);
+
+    // Verify fetch was called with correct arguments
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(credentials),
+    });
+  });
+
+  // 6. Failed login
+  it("returns {success: false, error} on non-ok login response", async () => {
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === "/api/auth/check") {
+        return errorResponse(401);
+      }
+      if (url === "/api/auth/login") {
+        return errorResponse(401, { error: "Invalid credentials" });
+      }
+      return errorResponse(404);
+    });
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current.login({
+        username: "bad",
+        password: "wrong",
+      });
+    });
+
+    expect(loginResult).toEqual({
+      success: false,
+      error: "Invalid credentials",
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  // 7. Login with default error message
+  it('returns "Login failed" when server provides no error message', async () => {
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === "/api/auth/check") {
+        return errorResponse(401);
+      }
+      if (url === "/api/auth/login") {
+        // Response body has no `error` field
+        return errorResponse(401, { message: "something" });
+      }
+      return errorResponse(404);
+    });
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    let loginResult;
+    await act(async () => {
+      loginResult = await result.current.login({
+        username: "x",
+        password: "y",
+      });
+    });
+
+    expect(loginResult).toEqual({ success: false, error: "Login failed" });
+  });
+});
+
+describe("logout()", () => {
+  // 8. Successful logout
+  it("calls /api/auth/logout and clears user and isAuthenticated", async () => {
+    // Start authenticated
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(mockUser);
+
+    // Mock the logout call
+    globalThis.fetch = vi.fn().mockImplementation(() => okResponse({}));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  });
+
+  // 9. Logout with network error clears state regardless
+  it("clears auth state even when logout fetch throws", async () => {
+    // Start authenticated
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+
+    // Mock the logout call to throw
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+});
+
+describe("updateUser()", () => {
+  // 10. Partial update merges into existing user
+  it("merges partial data into existing user", async () => {
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toEqual(mockUser);
+
+    act(() => {
+      result.current.updateUser({ displayName: "New Name" });
+    });
+
+    expect(result.current.user).toEqual({
+      ...mockUser,
+      displayName: "New Name",
+    });
+  });
+
+  // 11. Update when user is null returns null
+  it("returns null when user is null (does not crash)", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(() => errorResponse(401));
+
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+
+    act(() => {
+      result.current.updateUser({ displayName: "New Name" });
+    });
+
+    expect(result.current.user).toBeNull();
+  });
+});
+
+describe("useAuth hook", () => {
+  // 12. Throws outside provider
+  it('throws "useAuth must be used within an AuthProvider" outside provider', () => {
+    // Suppress React error boundary console output
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow("useAuth must be used within an AuthProvider");
+
+    consoleSpy.mockRestore();
+  });
+
+  // 13. Returns context inside provider
+  it("returns context with all expected properties inside provider", async () => {
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toHaveProperty("isAuthenticated");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("user");
+    expect(result.current).toHaveProperty("login");
+    expect(result.current).toHaveProperty("logout");
+    expect(result.current).toHaveProperty("updateUser");
+  });
+});
+
+describe("Context shape", () => {
+  // 14. Provides all expected values with correct types
+  it("provides isAuthenticated, isLoading, user, login, logout, updateUser", async () => {
+    const { result } = renderWithAuth();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(typeof result.current.isAuthenticated).toBe("boolean");
+    expect(typeof result.current.isLoading).toBe("boolean");
+    expect(typeof result.current.login).toBe("function");
+    expect(typeof result.current.logout).toBe("function");
+    expect(typeof result.current.updateUser).toBe("function");
+    // user is an object when authenticated
+    expect(result.current.user).toBeTypeOf("object");
+    expect(result.current.user).not.toBeNull();
+  });
+});

--- a/client/tests/contexts/ConfigContext.test.jsx
+++ b/client/tests/contexts/ConfigContext.test.jsx
@@ -1,0 +1,203 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/services/api.js", () => ({
+  setupApi: {
+    getSetupStatus: vi.fn(),
+  },
+}));
+
+import { setupApi } from "../../src/services/api.js";
+import {
+  ConfigProvider,
+  useConfig,
+} from "../../src/contexts/ConfigContext.jsx";
+
+/**
+ * Helper component that renders config values as text for assertion.
+ */
+function ConfigDisplay() {
+  const { hasMultipleInstances, isLoading } = useConfig();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="multiple">{String(hasMultipleInstances)}</span>
+    </div>
+  );
+}
+
+describe("ConfigContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("ConfigProvider", () => {
+    it("has isLoading=true and hasMultipleInstances=false before fetch resolves", () => {
+      // Never-resolving promise to keep the provider in loading state
+      setupApi.getSetupStatus.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      expect(screen.getByTestId("loading").textContent).toBe("true");
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+    });
+
+    it("sets hasMultipleInstances=false when stashInstanceCount is 1", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({ stashInstanceCount: 1 });
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+    });
+
+    it("sets hasMultipleInstances=true when stashInstanceCount > 1", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({ stashInstanceCount: 3 });
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("true");
+    });
+
+    it("sets hasMultipleInstances=false when stashInstanceCount is 0", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({ stashInstanceCount: 0 });
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+    });
+
+    it("sets hasMultipleInstances=false when stashInstanceCount is undefined", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({});
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+    });
+
+    it("sets hasMultipleInstances=false when stashInstanceCount is null", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({
+        stashInstanceCount: null,
+      });
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+    });
+
+    it("handles API error gracefully and sets isLoading=false", async () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      setupApi.getSetupStatus.mockRejectedValue(new Error("Network error"));
+
+      render(
+        <ConfigProvider>
+          <ConfigDisplay />
+        </ConfigProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loading").textContent).toBe("false");
+      });
+
+      expect(screen.getByTestId("multiple").textContent).toBe("false");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to fetch config:",
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("renders children correctly", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({ stashInstanceCount: 1 });
+
+      render(
+        <ConfigProvider>
+          <div data-testid="child">Hello</div>
+        </ConfigProvider>
+      );
+
+      expect(screen.getByTestId("child").textContent).toBe("Hello");
+
+      // Wait for the async fetch to settle to avoid act() warning
+      await waitFor(() => {
+        expect(setupApi.getSetupStatus).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("useConfig hook", () => {
+    it("returns default context values when used outside a provider", () => {
+      const { result } = renderHook(() => useConfig());
+
+      expect(result.current.hasMultipleInstances).toBe(false);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("returns fetched config values when used inside a provider", async () => {
+      setupApi.getSetupStatus.mockResolvedValue({ stashInstanceCount: 2 });
+
+      const wrapper = ({ children }) => (
+        <ConfigProvider>{children}</ConfigProvider>
+      );
+
+      const { result } = renderHook(() => useConfig(), { wrapper });
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.hasMultipleInstances).toBe(false);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasMultipleInstances).toBe(true);
+    });
+  });
+});

--- a/client/tests/contexts/ScenePlayerContext.test.jsx
+++ b/client/tests/contexts/ScenePlayerContext.test.jsx
@@ -1,0 +1,736 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks (must be defined before imports that use them)
+// ---------------------------------------------------------------------------
+
+vi.mock("axios", () => {
+  const mockPost = vi.fn();
+  return {
+    default: { create: vi.fn(() => ({ post: mockPost })) },
+    __mockPost: mockPost,
+  };
+});
+
+vi.mock("@/contexts/ConfigContext.jsx", () => ({
+  useConfig: vi.fn(() => ({ hasMultipleInstances: false })),
+}));
+
+vi.mock("@/utils/entityLinks.js", () => ({
+  getEntityPath: vi.fn(() => "/scene/123"),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { __mockPost } from "axios";
+import { useConfig } from "@/contexts/ConfigContext.jsx";
+import { getEntityPath } from "@/utils/entityLinks.js";
+import {
+  ScenePlayerProvider,
+  useScenePlayer,
+} from "@/contexts/ScenePlayerContext.jsx";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockScene = {
+  id: "scene-42",
+  title: "Test Scene",
+  o_counter: 5,
+  instanceId: "inst-1",
+};
+
+const mockApiResponse = (scene = mockScene) => ({
+  data: { findScenes: { scenes: [scene] } },
+});
+
+/**
+ * Wrapper factory that provides ScenePlayerProvider with configurable props.
+ */
+function createWrapper(props = {}) {
+  const defaults = {
+    sceneId: "scene-42",
+    instanceId: "inst-1",
+    playlist: null,
+    shouldResume: false,
+    compatibility: null,
+    initialQuality: "direct",
+    initialShouldAutoplay: false,
+  };
+  const merged = { ...defaults, ...props };
+
+  return function Wrapper({ children }) {
+    return <ScenePlayerProvider {...merged}>{children}</ScenePlayerProvider>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ScenePlayerContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: API returns a scene
+    __mockPost.mockResolvedValue(mockApiResponse());
+    // Suppress console.error from intentional error tests
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Spy on window.history.replaceState
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  // =========================================================================
+  // useScenePlayer hook
+  // =========================================================================
+
+  describe("useScenePlayer hook", () => {
+    it("throws when used outside ScenePlayerProvider", () => {
+      expect(() => {
+        renderHook(() => useScenePlayer());
+      }).toThrow("useScenePlayer must be used within ScenePlayerProvider");
+    });
+
+    it("returns context value when used inside ScenePlayerProvider", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      // Wait for the initial scene load triggered by the effect
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // State properties from initialState
+      expect(result.current).toHaveProperty("scene");
+      expect(result.current).toHaveProperty("sceneLoading");
+      expect(result.current).toHaveProperty("sceneError");
+      expect(result.current).toHaveProperty("quality");
+      expect(result.current).toHaveProperty("playlist");
+      expect(result.current).toHaveProperty("currentIndex");
+      expect(result.current).toHaveProperty("autoplayNext");
+      expect(result.current).toHaveProperty("shuffle");
+      expect(result.current).toHaveProperty("repeat");
+      expect(result.current).toHaveProperty("oCounter");
+
+      // Action creators
+      expect(typeof result.current.loadScene).toBe("function");
+      expect(typeof result.current.incrementOCounter).toBe("function");
+      expect(typeof result.current.nextScene).toBe("function");
+      expect(typeof result.current.prevScene).toBe("function");
+      expect(typeof result.current.gotoSceneIndex).toBe("function");
+      expect(typeof result.current.toggleAutoplayNext).toBe("function");
+      expect(typeof result.current.toggleShuffle).toBe("function");
+      expect(typeof result.current.toggleRepeat).toBe("function");
+
+      // dispatch is exposed
+      expect(typeof result.current.dispatch).toBe("function");
+    });
+  });
+
+  // =========================================================================
+  // ScenePlayerProvider initialization
+  // =========================================================================
+
+  describe("ScenePlayerProvider", () => {
+    it("initializes with default props", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.quality).toBe("direct");
+      expect(result.current.currentIndex).toBe(0);
+      expect(result.current.compatibility).toBeNull();
+      expect(result.current.playlist).toBeNull();
+    });
+
+    it("initializes with playlist props", async () => {
+      const playlist = {
+        id: "pl-1",
+        scenes: [
+          { sceneId: "s-1", instanceId: "i-1" },
+          { sceneId: "s-2", instanceId: "i-2" },
+        ],
+        currentIndex: 1,
+      };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.playlist).not.toBeNull();
+      expect(result.current.currentIndex).toBe(1);
+    });
+
+    it("initializes with compatibility and quality props", async () => {
+      const compatibility = { hevc: false, av1: false };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({
+          compatibility,
+          initialQuality: "720p",
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.compatibility).toEqual(compatibility);
+      expect(result.current.quality).toBe("720p");
+    });
+
+    it("passes shouldResume prop through to context value", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ shouldResume: true }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.shouldResume).toBe(true);
+    });
+
+    it("passes shouldResume=false by default", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.shouldResume).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // loadScene
+  // =========================================================================
+
+  describe("loadScene", () => {
+    it("loads a scene from the API and updates state", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.scene).toEqual(mockScene);
+      expect(result.current.oCounter).toBe(5);
+      expect(__mockPost).toHaveBeenCalledWith("/library/scenes", {
+        ids: ["scene-42"],
+        scene_filter: { instance_id: "inst-1" },
+      });
+    });
+
+    it("dispatches LOAD_SCENE_ERROR when scene is not found", async () => {
+      __mockPost.mockResolvedValue({
+        data: { findScenes: { scenes: [] } },
+      });
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.scene).toBeNull();
+      expect(result.current.sceneError).toBeTruthy();
+      expect(result.current.sceneError.message).toBe("Scene not found");
+    });
+
+    it("dispatches LOAD_SCENE_ERROR on API network failure", async () => {
+      const networkError = new Error("Network error");
+      __mockPost.mockRejectedValue(networkError);
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.scene).toBeNull();
+      expect(result.current.sceneError).toBe(networkError);
+    });
+
+    it("includes scene_filter with instance_id when instanceId is provided", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ instanceId: "inst-abc" }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(__mockPost).toHaveBeenCalledWith("/library/scenes", {
+        ids: ["scene-42"],
+        scene_filter: { instance_id: "inst-abc" },
+      });
+    });
+
+    it("omits scene_filter when instanceId is null", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ instanceId: null }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(__mockPost).toHaveBeenCalledWith("/library/scenes", {
+        ids: ["scene-42"],
+      });
+    });
+
+    it("sets oCounter to 0 when scene has no o_counter", async () => {
+      const sceneNoCounter = { id: "s-1", title: "No Counter" };
+      __mockPost.mockResolvedValue(mockApiResponse(sceneNoCounter));
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(result.current.oCounter).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Scene loading effect
+  // =========================================================================
+
+  describe("scene loading effect", () => {
+    it("loads scene on mount using sceneId prop", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ sceneId: "scene-99" }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      expect(__mockPost).toHaveBeenCalledWith(
+        "/library/scenes",
+        expect.objectContaining({ ids: ["scene-99"] })
+      );
+    });
+
+    it("uses playlist scene ID over prop sceneId", async () => {
+      const playlist = {
+        scenes: [
+          { sceneId: "playlist-scene-1", instanceId: "pl-inst-1" },
+          { sceneId: "playlist-scene-2", instanceId: "pl-inst-2" },
+        ],
+        currentIndex: 0,
+      };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({
+          sceneId: "prop-scene-id",
+          instanceId: "prop-inst-id",
+          playlist,
+        }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // Should use playlist scene ID, not prop sceneId
+      expect(__mockPost).toHaveBeenCalledWith("/library/scenes", {
+        ids: ["playlist-scene-1"],
+        scene_filter: { instance_id: "pl-inst-1" },
+      });
+    });
+  });
+
+  // =========================================================================
+  // incrementOCounter
+  // =========================================================================
+
+  describe("incrementOCounter", () => {
+    it("sends increment request and updates counter on success", async () => {
+      __mockPost.mockImplementation((url) => {
+        if (url === "/library/scenes") {
+          return Promise.resolve(mockApiResponse());
+        }
+        if (url === "/watch-history/increment-o") {
+          return Promise.resolve({});
+        }
+        return Promise.resolve({});
+      });
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      // Wait for scene to load
+      await waitFor(() => {
+        expect(result.current.scene).not.toBeNull();
+      });
+
+      const prevCounter = result.current.oCounter;
+
+      await act(async () => {
+        await result.current.incrementOCounter();
+      });
+
+      expect(__mockPost).toHaveBeenCalledWith("/watch-history/increment-o", {
+        sceneId: "scene-42",
+      });
+      expect(result.current.oCounter).toBe(prevCounter + 1);
+      expect(result.current.oCounterLoading).toBe(false);
+    });
+
+    it("handles increment error gracefully", async () => {
+      __mockPost.mockImplementation((url) => {
+        if (url === "/library/scenes") {
+          return Promise.resolve(mockApiResponse());
+        }
+        if (url === "/watch-history/increment-o") {
+          return Promise.reject(new Error("Server error"));
+        }
+        return Promise.resolve({});
+      });
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      // Wait for scene to load
+      await waitFor(() => {
+        expect(result.current.scene).not.toBeNull();
+      });
+
+      const prevCounter = result.current.oCounter;
+
+      await act(async () => {
+        await result.current.incrementOCounter();
+      });
+
+      // Counter should not change on error
+      expect(result.current.oCounter).toBe(prevCounter);
+      expect(result.current.oCounterLoading).toBe(false);
+    });
+
+    it("does not call API when scene is null", async () => {
+      __mockPost.mockResolvedValue({
+        data: { findScenes: { scenes: [] } },
+      });
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ sceneId: null }),
+      });
+
+      // Wait for any effects to settle
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      __mockPost.mockClear();
+
+      await act(async () => {
+        await result.current.incrementOCounter();
+      });
+
+      // Should not have called any API since scene is null
+      expect(__mockPost).not.toHaveBeenCalledWith(
+        "/watch-history/increment-o",
+        expect.anything()
+      );
+    });
+  });
+
+  // =========================================================================
+  // Navigation helpers
+  // =========================================================================
+
+  describe("navigation helpers", () => {
+    it("nextScene dispatches NEXT_SCENE", async () => {
+      const playlist = {
+        scenes: [
+          { sceneId: "s-1", instanceId: "i-1" },
+          { sceneId: "s-2", instanceId: "i-2" },
+        ],
+        currentIndex: 0,
+      };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      act(() => {
+        result.current.nextScene();
+      });
+
+      // After NEXT_SCENE, currentIndex should advance
+      expect(result.current.currentIndex).toBe(1);
+    });
+
+    it("prevScene dispatches PREV_SCENE", async () => {
+      const playlist = {
+        scenes: [
+          { sceneId: "s-1", instanceId: "i-1" },
+          { sceneId: "s-2", instanceId: "i-2" },
+        ],
+        currentIndex: 1,
+      };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      act(() => {
+        result.current.prevScene();
+      });
+
+      // After PREV_SCENE, currentIndex should go back
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("gotoSceneIndex dispatches with index and shouldAutoplay", async () => {
+      const playlist = {
+        scenes: [
+          { sceneId: "s-1", instanceId: "i-1" },
+          { sceneId: "s-2", instanceId: "i-2" },
+          { sceneId: "s-3", instanceId: "i-3" },
+        ],
+        currentIndex: 0,
+      };
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      act(() => {
+        result.current.gotoSceneIndex(2, true);
+      });
+
+      expect(result.current.currentIndex).toBe(2);
+      expect(result.current.shouldAutoplay).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Toggle controls
+  // =========================================================================
+
+  describe("toggle controls", () => {
+    it("toggleAutoplayNext dispatches TOGGLE_AUTOPLAY_NEXT", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // Default autoplayNext is true
+      expect(result.current.autoplayNext).toBe(true);
+
+      act(() => {
+        result.current.toggleAutoplayNext();
+      });
+
+      expect(result.current.autoplayNext).toBe(false);
+
+      act(() => {
+        result.current.toggleAutoplayNext();
+      });
+
+      expect(result.current.autoplayNext).toBe(true);
+    });
+
+    it("toggleShuffle dispatches TOGGLE_SHUFFLE", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // Default shuffle is false
+      expect(result.current.shuffle).toBe(false);
+
+      act(() => {
+        result.current.toggleShuffle();
+      });
+
+      expect(result.current.shuffle).toBe(true);
+
+      act(() => {
+        result.current.toggleShuffle();
+      });
+
+      expect(result.current.shuffle).toBe(false);
+    });
+
+    it("toggleRepeat cycles through none -> all -> one -> none", async () => {
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // Default repeat is "none"
+      expect(result.current.repeat).toBe("none");
+
+      act(() => {
+        result.current.toggleRepeat();
+      });
+      expect(result.current.repeat).toBe("all");
+
+      act(() => {
+        result.current.toggleRepeat();
+      });
+      expect(result.current.repeat).toBe("one");
+
+      act(() => {
+        result.current.toggleRepeat();
+      });
+      expect(result.current.repeat).toBe("none");
+    });
+  });
+
+  // =========================================================================
+  // URL update effect
+  // =========================================================================
+
+  describe("URL update effect", () => {
+    it("updates URL via replaceState when playlist scene changes", async () => {
+      const playlist = {
+        scenes: [
+          { sceneId: "s-1", instanceId: "i-1" },
+          { sceneId: "s-2", instanceId: "i-2" },
+        ],
+        currentIndex: 0,
+      };
+
+      getEntityPath.mockReturnValue("/scene/scene-42");
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.scene).not.toBeNull();
+      });
+
+      // The URL update effect fires when state.playlist and state.scene are set
+      await waitFor(() => {
+        expect(getEntityPath).toHaveBeenCalledWith(
+          "scene",
+          expect.objectContaining({ id: "scene-42" }),
+          false
+        );
+      });
+
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        "/scene/scene-42"
+      );
+    });
+
+    it("does not update URL when there is no playlist", async () => {
+      window.history.replaceState.mockClear();
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist: null }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.sceneLoading).toBe(false);
+      });
+
+      // replaceState should not have been called because playlist is null
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
+
+    it("passes hasMultipleInstances to getEntityPath", async () => {
+      useConfig.mockReturnValue({ hasMultipleInstances: true });
+
+      const playlist = {
+        scenes: [{ sceneId: "s-1", instanceId: "i-1" }],
+        currentIndex: 0,
+      };
+
+      getEntityPath.mockReturnValue("/scene/scene-42?instance=inst-1");
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.scene).not.toBeNull();
+      });
+
+      await waitFor(() => {
+        expect(getEntityPath).toHaveBeenCalledWith(
+          "scene",
+          expect.any(Object),
+          true // hasMultipleInstances
+        );
+      });
+    });
+
+    it("does not call replaceState when URL already matches", async () => {
+      const playlist = {
+        scenes: [{ sceneId: "s-1", instanceId: "i-1" }],
+        currentIndex: 0,
+      };
+
+      // Make getEntityPath return the current location
+      const currentPath = window.location.pathname + window.location.search;
+      getEntityPath.mockReturnValue(currentPath);
+
+      const { result } = renderHook(() => useScenePlayer(), {
+        wrapper: createWrapper({ playlist }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.scene).not.toBeNull();
+      });
+
+      // replaceState should not be called when URL already matches
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/tests/contexts/scenePlayerReducer.test.js
+++ b/client/tests/contexts/scenePlayerReducer.test.js
@@ -1,0 +1,1594 @@
+import { describe, it, expect } from "vitest";
+import {
+  scenePlayerReducer,
+  initialState,
+} from "@/contexts/scenePlayerReducer.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a minimal playlist with N scenes for navigation tests. */
+function makePlaylist(count, overrides = {}) {
+  return {
+    scenes: Array.from({ length: count }, (_, i) => ({ id: `scene-${i}` })),
+    autoplayNext: true,
+    shuffle: false,
+    repeat: "none",
+    shuffleHistory: [],
+    ...overrides,
+  };
+}
+
+/** Deep-clone a plain object so we can later assert the original was not mutated. */
+function snapshot(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe("scenePlayerReducer", () => {
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+  describe("initialState", () => {
+    it("has the expected shape and defaults", () => {
+      expect(initialState).toEqual({
+        scene: null,
+        sceneLoading: false,
+        sceneError: null,
+
+        video: null,
+        videoLoading: false,
+        videoError: null,
+        sessionId: null,
+        quality: "direct",
+
+        isInitializing: false,
+        isAutoFallback: false,
+        isSwitchingMode: false,
+        ready: false,
+        shouldAutoplay: false,
+
+        playlist: null,
+        currentIndex: 0,
+
+        autoplayNext: true,
+        shuffle: false,
+        repeat: "none",
+        shuffleHistory: [],
+
+        compatibility: null,
+
+        oCounter: 0,
+        oCounterLoading: false,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scene loading lifecycle
+  // -------------------------------------------------------------------------
+  describe("Scene loading lifecycle", () => {
+    it("LOAD_SCENE_START sets sceneLoading true and clears error", () => {
+      const state = { ...initialState, sceneError: "old error" };
+      const result = scenePlayerReducer(state, { type: "LOAD_SCENE_START" });
+
+      expect(result.sceneLoading).toBe(true);
+      expect(result.sceneError).toBeNull();
+    });
+
+    it("LOAD_SCENE_SUCCESS sets scene, oCounter, clears loading", () => {
+      const scene = { id: "1", isStreamable: true, files: [] };
+      const state = { ...initialState, sceneLoading: true };
+      const result = scenePlayerReducer(state, {
+        type: "LOAD_SCENE_SUCCESS",
+        payload: { scene, oCounter: 5 },
+      });
+
+      expect(result.scene).toBe(scene);
+      expect(result.oCounter).toBe(5);
+      expect(result.sceneLoading).toBe(false);
+      expect(result.sceneError).toBeNull();
+    });
+
+    it("LOAD_SCENE_SUCCESS defaults oCounter to 0 if not provided", () => {
+      const scene = { id: "1", isStreamable: true, files: [] };
+      const result = scenePlayerReducer(initialState, {
+        type: "LOAD_SCENE_SUCCESS",
+        payload: { scene },
+      });
+
+      expect(result.oCounter).toBe(0);
+    });
+
+    it("LOAD_SCENE_ERROR sets error and clears loading", () => {
+      const state = { ...initialState, sceneLoading: true };
+      const result = scenePlayerReducer(state, {
+        type: "LOAD_SCENE_ERROR",
+        payload: "Something went wrong",
+      });
+
+      expect(result.sceneLoading).toBe(false);
+      expect(result.sceneError).toBe("Something went wrong");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // LOAD_SCENE_SUCCESS quality auto-selection
+  // -------------------------------------------------------------------------
+  describe("LOAD_SCENE_SUCCESS quality auto-selection", () => {
+    it("keeps 'direct' when scene.isStreamable is true", () => {
+      const scene = { id: "1", isStreamable: true, files: [{ height: 1080 }] };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("direct");
+    });
+
+    it("selects '1080p' when isStreamable=false and height=1080", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 1080 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("1080p");
+    });
+
+    it("selects '2160p' when isStreamable=false and height=2160", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 2160 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("2160p");
+    });
+
+    it("selects '720p' when isStreamable=false and height=720", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 720 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("720p");
+    });
+
+    it("selects '360p' when isStreamable=false and height=400 (between 480 and 360)", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 400 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("360p");
+    });
+
+    it("selects '480p' when isStreamable=false and height=480", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 480 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("480p");
+    });
+
+    it("selects '360p' as fallback when height is very small", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 240 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("360p");
+    });
+
+    it("defaults to 1080p source height when files array is missing", () => {
+      const scene = { id: "1", isStreamable: false };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("1080p");
+    });
+
+    it("defaults to 1080p source height when files array is empty", () => {
+      const scene = { id: "1", isStreamable: false, files: [] };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      expect(result.quality).toBe("1080p");
+    });
+
+    it("does NOT auto-select when isStreamable is undefined", () => {
+      const scene = { id: "1", files: [{ height: 720 }] };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      // isStreamable is undefined so the condition `scene.isStreamable !== undefined`
+      // is false, quality stays at the current state value
+      expect(result.quality).toBe("direct");
+    });
+
+    it("does NOT auto-select when quality has already been changed from 'direct'", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 1080 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "720p" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      // Quality is already "720p" (not "direct"), so no auto-selection
+      expect(result.quality).toBe("720p");
+    });
+
+    it("selects best quality for heights between presets (1440p -> 1080p)", () => {
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 1440 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+
+      // 1440 is less than 2160 but >= 1080, so 1080p is the best <= sourceHeight
+      expect(result.quality).toBe("1080p");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Video loading lifecycle
+  // -------------------------------------------------------------------------
+  describe("Video loading lifecycle", () => {
+    it("LOAD_VIDEO_START sets videoLoading true and clears error", () => {
+      const state = { ...initialState, videoError: "old error" };
+      const result = scenePlayerReducer(state, { type: "LOAD_VIDEO_START" });
+
+      expect(result.videoLoading).toBe(true);
+      expect(result.videoError).toBeNull();
+    });
+
+    it("LOAD_VIDEO_SUCCESS sets video, sessionId, clears loading/error/isInitializing", () => {
+      const state = {
+        ...initialState,
+        videoLoading: true,
+        videoError: "stale",
+        isInitializing: true,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "LOAD_VIDEO_SUCCESS",
+        payload: { video: { url: "test.m3u8" }, sessionId: "sess-123" },
+      });
+
+      expect(result.video).toEqual({ url: "test.m3u8" });
+      expect(result.sessionId).toBe("sess-123");
+      expect(result.videoLoading).toBe(false);
+      expect(result.videoError).toBeNull();
+      expect(result.isInitializing).toBe(false);
+    });
+
+    it("LOAD_VIDEO_ERROR sets error, clears loading and isInitializing", () => {
+      const state = {
+        ...initialState,
+        videoLoading: true,
+        isInitializing: true,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "LOAD_VIDEO_ERROR",
+        payload: "Failed to load",
+      });
+
+      expect(result.videoLoading).toBe(false);
+      expect(result.videoError).toBe("Failed to load");
+      expect(result.isInitializing).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Simple setters
+  // -------------------------------------------------------------------------
+  describe("Simple setters", () => {
+    it("SET_QUALITY updates quality", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_QUALITY",
+        payload: "720p",
+      });
+      expect(result.quality).toBe("720p");
+    });
+
+    it("SET_VIDEO updates video", () => {
+      const video = { url: "test.m3u8" };
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_VIDEO",
+        payload: video,
+      });
+      expect(result.video).toBe(video);
+    });
+
+    it("SET_SESSION_ID updates sessionId", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_SESSION_ID",
+        payload: "sess-abc",
+      });
+      expect(result.sessionId).toBe("sess-abc");
+    });
+
+    it("CLEAR_VIDEO nulls video and sessionId, clears loading/error", () => {
+      const state = {
+        ...initialState,
+        video: { url: "test" },
+        sessionId: "sess-1",
+        videoLoading: true,
+        videoError: "err",
+      };
+      const result = scenePlayerReducer(state, { type: "CLEAR_VIDEO" });
+
+      expect(result.video).toBeNull();
+      expect(result.sessionId).toBeNull();
+      expect(result.videoLoading).toBe(false);
+      expect(result.videoError).toBeNull();
+    });
+
+    it("SET_CURRENT_INDEX updates currentIndex", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_CURRENT_INDEX",
+        payload: 5,
+      });
+      expect(result.currentIndex).toBe(5);
+    });
+
+    it("SET_INITIALIZING updates isInitializing", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_INITIALIZING",
+        payload: true,
+      });
+      expect(result.isInitializing).toBe(true);
+    });
+
+    it("SET_AUTO_FALLBACK updates isAutoFallback", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_AUTO_FALLBACK",
+        payload: true,
+      });
+      expect(result.isAutoFallback).toBe(true);
+    });
+
+    it("SET_SWITCHING_MODE updates isSwitchingMode", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_SWITCHING_MODE",
+        payload: true,
+      });
+      expect(result.isSwitchingMode).toBe(true);
+    });
+
+    it("SET_READY updates ready", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_READY",
+        payload: true,
+      });
+      expect(result.ready).toBe(true);
+    });
+
+    it("SET_SHOULD_AUTOPLAY updates shouldAutoplay", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_SHOULD_AUTOPLAY",
+        payload: true,
+      });
+      expect(result.shouldAutoplay).toBe(true);
+    });
+
+    it("SET_O_COUNTER updates oCounter", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "SET_O_COUNTER",
+        payload: 42,
+      });
+      expect(result.oCounter).toBe(42);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // O Counter lifecycle
+  // -------------------------------------------------------------------------
+  describe("O Counter lifecycle", () => {
+    it("INCREMENT_O_COUNTER_START sets oCounterLoading true", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "INCREMENT_O_COUNTER_START",
+      });
+      expect(result.oCounterLoading).toBe(true);
+    });
+
+    it("INCREMENT_O_COUNTER_SUCCESS increments oCounter by 1 and clears loading", () => {
+      const state = { ...initialState, oCounter: 3, oCounterLoading: true };
+      const result = scenePlayerReducer(state, {
+        type: "INCREMENT_O_COUNTER_SUCCESS",
+      });
+
+      expect(result.oCounter).toBe(4);
+      expect(result.oCounterLoading).toBe(false);
+    });
+
+    it("INCREMENT_O_COUNTER_ERROR clears loading without changing counter", () => {
+      const state = { ...initialState, oCounter: 3, oCounterLoading: true };
+      const result = scenePlayerReducer(state, {
+        type: "INCREMENT_O_COUNTER_ERROR",
+      });
+
+      expect(result.oCounter).toBe(3);
+      expect(result.oCounterLoading).toBe(false);
+    });
+
+    it("full cycle: START -> SUCCESS increments correctly", () => {
+      let state = { ...initialState, oCounter: 0 };
+
+      state = scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_START" });
+      expect(state.oCounterLoading).toBe(true);
+
+      state = scenePlayerReducer(state, {
+        type: "INCREMENT_O_COUNTER_SUCCESS",
+      });
+      expect(state.oCounter).toBe(1);
+      expect(state.oCounterLoading).toBe(false);
+
+      state = scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_START" });
+      state = scenePlayerReducer(state, {
+        type: "INCREMENT_O_COUNTER_SUCCESS",
+      });
+      expect(state.oCounter).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Playlist controls
+  // -------------------------------------------------------------------------
+  describe("Playlist controls", () => {
+    describe("TOGGLE_AUTOPLAY_NEXT", () => {
+      it("toggles autoplayNext from true to false", () => {
+        const state = {
+          ...initialState,
+          autoplayNext: true,
+          playlist: makePlaylist(3),
+        };
+        const result = scenePlayerReducer(state, {
+          type: "TOGGLE_AUTOPLAY_NEXT",
+        });
+
+        expect(result.autoplayNext).toBe(false);
+        expect(result.playlist.autoplayNext).toBe(false);
+      });
+
+      it("toggles autoplayNext from false to true", () => {
+        const state = {
+          ...initialState,
+          autoplayNext: false,
+          playlist: makePlaylist(3),
+        };
+        const result = scenePlayerReducer(state, {
+          type: "TOGGLE_AUTOPLAY_NEXT",
+        });
+
+        expect(result.autoplayNext).toBe(true);
+        expect(result.playlist.autoplayNext).toBe(true);
+      });
+
+      it("sets playlist to null when playlist is null", () => {
+        const state = { ...initialState, autoplayNext: true, playlist: null };
+        const result = scenePlayerReducer(state, {
+          type: "TOGGLE_AUTOPLAY_NEXT",
+        });
+
+        expect(result.autoplayNext).toBe(false);
+        expect(result.playlist).toBeNull();
+      });
+    });
+
+    describe("TOGGLE_SHUFFLE", () => {
+      it("enables shuffle and resets shuffleHistory", () => {
+        const state = {
+          ...initialState,
+          shuffle: false,
+          shuffleHistory: [1, 2, 3],
+          playlist: makePlaylist(5),
+        };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_SHUFFLE" });
+
+        expect(result.shuffle).toBe(true);
+        expect(result.shuffleHistory).toEqual([]);
+        expect(result.playlist.shuffle).toBe(true);
+        expect(result.playlist.shuffleHistory).toEqual([]);
+      });
+
+      it("disables shuffle and preserves shuffleHistory", () => {
+        const state = {
+          ...initialState,
+          shuffle: true,
+          shuffleHistory: [1, 2],
+          playlist: makePlaylist(5),
+        };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_SHUFFLE" });
+
+        expect(result.shuffle).toBe(false);
+        // When disabling, shuffleHistory is kept from state (not reset)
+        expect(result.shuffleHistory).toEqual([1, 2]);
+        expect(result.playlist.shuffle).toBe(false);
+      });
+
+      it("handles null playlist gracefully", () => {
+        const state = { ...initialState, shuffle: false, playlist: null };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_SHUFFLE" });
+
+        expect(result.shuffle).toBe(true);
+        expect(result.playlist).toBeNull();
+      });
+    });
+
+    describe("TOGGLE_REPEAT", () => {
+      it("cycles none -> all", () => {
+        const state = {
+          ...initialState,
+          repeat: "none",
+          playlist: makePlaylist(3),
+        };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+
+        expect(result.repeat).toBe("all");
+        expect(result.playlist.repeat).toBe("all");
+      });
+
+      it("cycles all -> one", () => {
+        const state = {
+          ...initialState,
+          repeat: "all",
+          playlist: makePlaylist(3),
+        };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+
+        expect(result.repeat).toBe("one");
+        expect(result.playlist.repeat).toBe("one");
+      });
+
+      it("cycles one -> none", () => {
+        const state = {
+          ...initialState,
+          repeat: "one",
+          playlist: makePlaylist(3),
+        };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+
+        expect(result.repeat).toBe("none");
+        expect(result.playlist.repeat).toBe("none");
+      });
+
+      it("full cycle: none -> all -> one -> none", () => {
+        let state = {
+          ...initialState,
+          repeat: "none",
+          playlist: makePlaylist(3),
+        };
+
+        state = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+        expect(state.repeat).toBe("all");
+
+        state = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+        expect(state.repeat).toBe("one");
+
+        state = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+        expect(state.repeat).toBe("none");
+      });
+
+      it("handles null playlist gracefully", () => {
+        const state = { ...initialState, repeat: "none", playlist: null };
+        const result = scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+
+        expect(result.repeat).toBe("all");
+        expect(result.playlist).toBeNull();
+      });
+    });
+
+    describe("SET_SHUFFLE_HISTORY", () => {
+      it("sets shuffleHistory and updates playlist", () => {
+        const state = {
+          ...initialState,
+          shuffleHistory: [],
+          playlist: makePlaylist(5),
+        };
+        const result = scenePlayerReducer(state, {
+          type: "SET_SHUFFLE_HISTORY",
+          payload: [0, 2, 4],
+        });
+
+        expect(result.shuffleHistory).toEqual([0, 2, 4]);
+        expect(result.playlist.shuffleHistory).toEqual([0, 2, 4]);
+      });
+
+      it("handles null playlist", () => {
+        const state = { ...initialState, playlist: null };
+        const result = scenePlayerReducer(state, {
+          type: "SET_SHUFFLE_HISTORY",
+          payload: [1, 3],
+        });
+
+        expect(result.shuffleHistory).toEqual([1, 3]);
+        expect(result.playlist).toBeNull();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // NEXT_SCENE
+  // -------------------------------------------------------------------------
+  describe("NEXT_SCENE", () => {
+    describe("without playlist", () => {
+      it("returns state unchanged when playlist is null", () => {
+        const state = { ...initialState, playlist: null };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result).toBe(state);
+      });
+
+      it("returns state unchanged when playlist.scenes is missing", () => {
+        const state = { ...initialState, playlist: {} };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result).toBe(state);
+      });
+    });
+
+    describe("sequential mode", () => {
+      it("advances to next scene", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 1,
+          video: { url: "old" },
+          sessionId: "old-sess",
+          quality: "720p",
+          oCounter: 5,
+          ready: true,
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        expect(result.currentIndex).toBe(2);
+        expect(result.video).toBeNull();
+        expect(result.sessionId).toBeNull();
+        expect(result.quality).toBe("direct");
+        expect(result.oCounter).toBe(0);
+        expect(result.ready).toBe(false);
+        expect(result.isInitializing).toBe(false);
+      });
+
+      it("stays on last scene when repeat is 'none'", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 2,
+          repeat: "none",
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result).toBe(state);
+      });
+
+      it("wraps to index 0 when repeat is 'all' and at last scene", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 2,
+          repeat: "all",
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        expect(result.currentIndex).toBe(0);
+        expect(result.quality).toBe("direct");
+        expect(result.oCounter).toBe(0);
+      });
+
+      it("does not modify shuffleHistory in sequential mode", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 0,
+          shuffle: false,
+          shuffleHistory: [4, 5],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        expect(result.shuffleHistory).toEqual([4, 5]);
+      });
+    });
+
+    describe("shuffle mode", () => {
+      it("picks from unplayed scenes", () => {
+        // 3 scenes, currently at 0, history has 1 -> only scene 2 is unplayed
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 0,
+          shuffle: true,
+          shuffleHistory: [1],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        expect(result.currentIndex).toBe(2);
+        expect(result.shuffleHistory).toEqual([1, 0]); // current added to history
+      });
+
+      it("adds current index to shuffleHistory", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 2,
+          shuffle: true,
+          shuffleHistory: [0],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        // shuffleHistory should end with the previous currentIndex (2)
+        expect(result.shuffleHistory[result.shuffleHistory.length - 1]).toBe(2);
+      });
+
+      it("updates playlist.shuffleHistory as well", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 0,
+          shuffle: true,
+          shuffleHistory: [],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        expect(result.playlist.shuffleHistory).toEqual(result.shuffleHistory);
+      });
+
+      it("stays when no unplayed scenes remain and repeat is not 'all'", () => {
+        // 3 scenes, at index 0, history=[1,2] -> no unplayed (excluding current)
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 0,
+          shuffle: true,
+          repeat: "none",
+          shuffleHistory: [1, 2],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result).toBe(state);
+      });
+
+      it("resets history and picks new scene when all played and repeat is 'all'", () => {
+        // 3 scenes, at index 0, history=[1,2] -> all played
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 0,
+          shuffle: true,
+          repeat: "all",
+          shuffleHistory: [1, 2],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        // Should reset history to [currentIndex] (the previous scene)
+        expect(result.shuffleHistory).toEqual([0]);
+        expect(result.playlist.shuffleHistory).toEqual([0]);
+        // New index should not be current
+        expect(result.currentIndex).not.toBe(0);
+        // State resets
+        expect(result.video).toBeNull();
+        expect(result.ready).toBe(false);
+      });
+
+      it("excludes current index from unplayed candidates", () => {
+        // Run this multiple times to ensure current index is never picked as "unplayed"
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(2),
+          currentIndex: 0,
+          shuffle: true,
+          shuffleHistory: [],
+        };
+        // Only scene 1 is available (scene 0 is current)
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result.currentIndex).toBe(1);
+      });
+
+      it("selects from all non-current scenes when all unplayed (large playlist)", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(10),
+          currentIndex: 5,
+          shuffle: true,
+          shuffleHistory: [],
+        };
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+        // Should pick something other than 5
+        expect(result.currentIndex).not.toBe(5);
+        expect(result.currentIndex).toBeGreaterThanOrEqual(0);
+        expect(result.currentIndex).toBeLessThan(10);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PREV_SCENE
+  // -------------------------------------------------------------------------
+  describe("PREV_SCENE", () => {
+    describe("without playlist", () => {
+      it("returns state unchanged when playlist is null", () => {
+        const state = { ...initialState, playlist: null };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+        expect(result).toBe(state);
+      });
+
+      it("returns state unchanged when playlist.scenes is missing", () => {
+        const state = { ...initialState, playlist: {} };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+        expect(result).toBe(state);
+      });
+    });
+
+    describe("sequential mode", () => {
+      it("goes to previous scene", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 3,
+          video: { url: "old" },
+          sessionId: "old-sess",
+          quality: "720p",
+          oCounter: 5,
+          ready: true,
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        expect(result.currentIndex).toBe(2);
+        expect(result.video).toBeNull();
+        expect(result.sessionId).toBeNull();
+        expect(result.quality).toBe("direct");
+        expect(result.oCounter).toBe(0);
+        expect(result.ready).toBe(false);
+      });
+
+      it("stays on first scene when repeat is 'none'", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 0,
+          repeat: "none",
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+        expect(result).toBe(state);
+      });
+
+      it("wraps to last scene when repeat is 'all' and at first scene", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 0,
+          repeat: "all",
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        expect(result.currentIndex).toBe(4);
+        expect(result.quality).toBe("direct");
+        expect(result.oCounter).toBe(0);
+      });
+    });
+
+    describe("shuffle mode", () => {
+      it("pops last entry from shuffleHistory", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 3,
+          shuffle: true,
+          shuffleHistory: [0, 2, 1],
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        // Should go to last history entry (1)
+        expect(result.currentIndex).toBe(1);
+        // History should have last item removed
+        expect(result.shuffleHistory).toEqual([0, 2]);
+        expect(result.playlist.shuffleHistory).toEqual([0, 2]);
+        // State resets
+        expect(result.video).toBeNull();
+        expect(result.quality).toBe("direct");
+        expect(result.oCounter).toBe(0);
+        expect(result.ready).toBe(false);
+      });
+
+      it("picks random scene when history is empty and multiple scenes exist", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(5),
+          currentIndex: 2,
+          shuffle: true,
+          shuffleHistory: [],
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        // Should pick a random scene that is not the current one
+        expect(result.currentIndex).not.toBe(2);
+        expect(result.currentIndex).toBeGreaterThanOrEqual(0);
+        expect(result.currentIndex).toBeLessThan(5);
+      });
+
+      it("picks random scene when history is empty and repeat is 'all'", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 1,
+          shuffle: true,
+          repeat: "all",
+          shuffleHistory: [],
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        expect(result.currentIndex).not.toBe(1);
+      });
+
+      it("stays when history is empty, single scene, and repeat is not 'all'", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(1),
+          currentIndex: 0,
+          shuffle: true,
+          repeat: "none",
+          shuffleHistory: [],
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+        // Only 1 scene and totalScenes > 1 is false, repeat is not "all"
+        expect(result).toBe(state);
+      });
+
+      it("correctly pops single-entry history", () => {
+        const state = {
+          ...initialState,
+          playlist: makePlaylist(3),
+          currentIndex: 2,
+          shuffle: true,
+          shuffleHistory: [0],
+        };
+        const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+
+        expect(result.currentIndex).toBe(0);
+        expect(result.shuffleHistory).toEqual([]);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GOTO_SCENE_INDEX
+  // -------------------------------------------------------------------------
+  describe("GOTO_SCENE_INDEX", () => {
+    it("sets currentIndex to the given index", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 0,
+        video: { url: "old" },
+        sessionId: "old",
+        quality: "720p",
+        oCounter: 3,
+        ready: true,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 3 },
+      });
+
+      expect(result.currentIndex).toBe(3);
+      expect(result.video).toBeNull();
+      expect(result.sessionId).toBeNull();
+      expect(result.quality).toBe("direct");
+      expect(result.oCounter).toBe(0);
+      expect(result.ready).toBe(false);
+      expect(result.isInitializing).toBe(false);
+      expect(result.shouldAutoplay).toBe(false);
+    });
+
+    it("supports payload as a plain number (legacy format)", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 0,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: 2,
+      });
+
+      expect(result.currentIndex).toBe(2);
+    });
+
+    it("sets shouldAutoplay when payload.shouldAutoplay is true", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 0,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 1, shouldAutoplay: true },
+      });
+
+      expect(result.currentIndex).toBe(1);
+      expect(result.shouldAutoplay).toBe(true);
+    });
+
+    it("returns state unchanged for negative index", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 2,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: -1 },
+      });
+      expect(result).toBe(state);
+    });
+
+    it("returns state unchanged for index >= scenes.length", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 2,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 5 },
+      });
+      expect(result).toBe(state);
+    });
+
+    it("returns state unchanged for index equal to scenes.length", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(3),
+        currentIndex: 0,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 3 },
+      });
+      expect(result).toBe(state);
+    });
+
+    it("returns state unchanged when playlist is null", () => {
+      const state = { ...initialState, playlist: null };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 0 },
+      });
+      expect(result).toBe(state);
+    });
+
+    it("accepts index 0 as a valid target", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(3),
+        currentIndex: 2,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 0 },
+      });
+      expect(result.currentIndex).toBe(0);
+    });
+
+    it("accepts last valid index", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 0,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 4 },
+      });
+      expect(result.currentIndex).toBe(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // INITIALIZE
+  // -------------------------------------------------------------------------
+  describe("INITIALIZE", () => {
+    it("sets playlist, currentIndex, compatibility, quality, shouldAutoplay", () => {
+      const playlist = makePlaylist(3, {
+        autoplayNext: false,
+        shuffle: true,
+        repeat: "one",
+        shuffleHistory: [0, 1],
+      });
+      const compatibility = { hevc: false, av1: true };
+
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: {
+          playlist,
+          currentIndex: 1,
+          compatibility,
+          initialQuality: "720p",
+          initialShouldAutoplay: true,
+        },
+      });
+
+      expect(result.playlist).toBe(playlist);
+      expect(result.currentIndex).toBe(1);
+      expect(result.compatibility).toBe(compatibility);
+      expect(result.quality).toBe("720p");
+      expect(result.shouldAutoplay).toBe(true);
+    });
+
+    it("inherits playlist controls from playlist object", () => {
+      const playlist = makePlaylist(3, {
+        autoplayNext: false,
+        shuffle: true,
+        repeat: "all",
+        shuffleHistory: [2],
+      });
+
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist },
+      });
+
+      expect(result.autoplayNext).toBe(false);
+      expect(result.shuffle).toBe(true);
+      expect(result.repeat).toBe("all");
+      expect(result.shuffleHistory).toEqual([2]);
+    });
+
+    it("uses defaults when playlist is null", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist: null },
+      });
+
+      expect(result.playlist).toBeNull();
+      expect(result.currentIndex).toBe(0);
+      expect(result.compatibility).toBeNull();
+      expect(result.quality).toBe("direct");
+      expect(result.autoplayNext).toBe(true);
+      expect(result.shuffle).toBe(false);
+      expect(result.repeat).toBe("none");
+      expect(result.shuffleHistory).toEqual([]);
+    });
+
+    it("uses defaults when playlist has no control properties", () => {
+      const playlist = { scenes: [{ id: "1" }] };
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist },
+      });
+
+      expect(result.autoplayNext).toBe(true);
+      expect(result.shuffle).toBe(false);
+      expect(result.repeat).toBe("none");
+      expect(result.shuffleHistory).toEqual([]);
+    });
+
+    it("defaults currentIndex to 0 when not provided", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist: makePlaylist(3) },
+      });
+
+      expect(result.currentIndex).toBe(0);
+    });
+
+    it("defaults quality to 'direct' when initialQuality is not provided", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist: makePlaylist(3) },
+      });
+
+      expect(result.quality).toBe("direct");
+    });
+
+    it("preserves existing shouldAutoplay if already set and no initialShouldAutoplay", () => {
+      const state = { ...initialState, shouldAutoplay: true };
+      const result = scenePlayerReducer(state, {
+        type: "INITIALIZE",
+        payload: { playlist: makePlaylist(3) },
+      });
+
+      // state.shouldAutoplay is true, no initialShouldAutoplay -> preserves true
+      expect(result.shouldAutoplay).toBe(true);
+    });
+
+    it("defaults shouldAutoplay to false when nothing is set", () => {
+      const result = scenePlayerReducer(initialState, {
+        type: "INITIALIZE",
+        payload: { playlist: makePlaylist(3) },
+      });
+
+      expect(result.shouldAutoplay).toBe(false);
+    });
+
+    it("preserves other state fields not set by INITIALIZE", () => {
+      const state = {
+        ...initialState,
+        scene: { id: "existing" },
+        video: { url: "existing" },
+        sessionId: "existing-sess",
+        oCounter: 5,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "INITIALIZE",
+        payload: { playlist: makePlaylist(3) },
+      });
+
+      expect(result.scene).toEqual({ id: "existing" });
+      expect(result.video).toEqual({ url: "existing" });
+      expect(result.sessionId).toBe("existing-sess");
+      expect(result.oCounter).toBe(5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Default case
+  // -------------------------------------------------------------------------
+  describe("Default case", () => {
+    it("returns state unchanged for an unknown action type", () => {
+      const state = { ...initialState, quality: "720p" };
+      const result = scenePlayerReducer(state, { type: "UNKNOWN_ACTION" });
+      expect(result).toBe(state);
+    });
+
+    it("returns state unchanged for an action with no type", () => {
+      const state = { ...initialState };
+      const result = scenePlayerReducer(state, {});
+      expect(result).toBe(state);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reducer purity (input state is not mutated)
+  // -------------------------------------------------------------------------
+  describe("Reducer purity", () => {
+    it("does not mutate state on LOAD_SCENE_START", () => {
+      const state = { ...initialState };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "LOAD_SCENE_START" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on LOAD_SCENE_SUCCESS", () => {
+      const state = { ...initialState, quality: "direct" };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, {
+        type: "LOAD_SCENE_SUCCESS",
+        payload: {
+          scene: { id: "1", isStreamable: false, files: [{ height: 720 }] },
+          oCounter: 3,
+        },
+      });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on TOGGLE_AUTOPLAY_NEXT", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(3),
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "TOGGLE_AUTOPLAY_NEXT" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on TOGGLE_SHUFFLE", () => {
+      const state = {
+        ...initialState,
+        shuffle: false,
+        shuffleHistory: [1, 2],
+        playlist: makePlaylist(3),
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "TOGGLE_SHUFFLE" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on TOGGLE_REPEAT", () => {
+      const state = {
+        ...initialState,
+        repeat: "none",
+        playlist: makePlaylist(3),
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "TOGGLE_REPEAT" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on NEXT_SCENE (sequential)", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 1,
+        shuffle: false,
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "NEXT_SCENE" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on NEXT_SCENE (shuffle)", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 1,
+        shuffle: true,
+        shuffleHistory: [0],
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "NEXT_SCENE" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on PREV_SCENE (shuffle with history)", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 3,
+        shuffle: true,
+        shuffleHistory: [0, 1, 2],
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "PREV_SCENE" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on GOTO_SCENE_INDEX", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(5),
+        currentIndex: 0,
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 3 },
+      });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on INITIALIZE", () => {
+      const state = { ...initialState };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, {
+        type: "INITIALIZE",
+        payload: {
+          playlist: makePlaylist(3),
+          currentIndex: 1,
+          compatibility: { hevc: false },
+          initialQuality: "1080p",
+        },
+      });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on INCREMENT_O_COUNTER_SUCCESS", () => {
+      const state = { ...initialState, oCounter: 5, oCounterLoading: true };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_SUCCESS" });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+
+    it("does not mutate state on SET_SHUFFLE_HISTORY", () => {
+      const state = {
+        ...initialState,
+        shuffleHistory: [0, 1],
+        playlist: makePlaylist(5),
+      };
+      const frozen = snapshot(state);
+      scenePlayerReducer(state, {
+        type: "SET_SHUFFLE_HISTORY",
+        payload: [0, 1, 2, 3],
+      });
+      expect(snapshot(state)).toEqual(frozen);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+  describe("Edge cases", () => {
+    it("NEXT_SCENE with single-scene playlist in sequential mode stays", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(1),
+        currentIndex: 0,
+        repeat: "none",
+      };
+      const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+      expect(result).toBe(state);
+    });
+
+    it("NEXT_SCENE with single-scene playlist and repeat='all' wraps to 0", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(1),
+        currentIndex: 0,
+        repeat: "all",
+      };
+      const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+      expect(result.currentIndex).toBe(0);
+    });
+
+    it("PREV_SCENE with single-scene playlist in sequential mode stays", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(1),
+        currentIndex: 0,
+        repeat: "none",
+      };
+      const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+      expect(result).toBe(state);
+    });
+
+    it("PREV_SCENE with single-scene playlist and repeat='all' wraps to 0", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(1),
+        currentIndex: 0,
+        repeat: "all",
+      };
+      const result = scenePlayerReducer(state, { type: "PREV_SCENE" });
+      expect(result.currentIndex).toBe(0);
+    });
+
+    it("NEXT_SCENE shuffle with 2 scenes always picks the other one", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(2),
+        currentIndex: 0,
+        shuffle: true,
+        shuffleHistory: [],
+      };
+
+      // Run 10 times to increase confidence
+      for (let i = 0; i < 10; i++) {
+        const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+        expect(result.currentIndex).toBe(1);
+      }
+    });
+
+    it("NEXT_SCENE shuffle with repeat='all' on 2-scene playlist resets and picks other", () => {
+      // All played: history has [1], current is 0 -> no unplayed
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(2),
+        currentIndex: 0,
+        shuffle: true,
+        repeat: "all",
+        shuffleHistory: [1],
+      };
+      const result = scenePlayerReducer(state, { type: "NEXT_SCENE" });
+
+      // Should reset history and pick non-current scene
+      expect(result.currentIndex).toBe(1);
+      expect(result.shuffleHistory).toEqual([0]);
+    });
+
+    it("LOAD_SCENE_SUCCESS with isStreamable=false and height exactly at preset boundary", () => {
+      // Height exactly at 2160 should match 2160p
+      const scene = {
+        id: "1",
+        isStreamable: false,
+        files: [{ height: 2160 }],
+      };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+      expect(result.quality).toBe("2160p");
+    });
+
+    it("LOAD_SCENE_SUCCESS with isStreamable=false and height 0 falls back to default 1080", () => {
+      const scene = { id: "1", isStreamable: false, files: [{ height: 0 }] };
+      const result = scenePlayerReducer(
+        { ...initialState, quality: "direct" },
+        { type: "LOAD_SCENE_SUCCESS", payload: { scene } },
+      );
+      // height 0 is falsy, so `|| 1080` kicks in -> sourceHeight=1080 -> "1080p"
+      expect(result.quality).toBe("1080p");
+    });
+
+    it("multiple rapid scene loads maintain correct state", () => {
+      let state = { ...initialState };
+
+      // Start loading scene 1
+      state = scenePlayerReducer(state, { type: "LOAD_SCENE_START" });
+      expect(state.sceneLoading).toBe(true);
+
+      // Scene 1 succeeds
+      state = scenePlayerReducer(state, {
+        type: "LOAD_SCENE_SUCCESS",
+        payload: {
+          scene: { id: "1", isStreamable: true },
+          oCounter: 2,
+        },
+      });
+      expect(state.scene.id).toBe("1");
+      expect(state.oCounter).toBe(2);
+      expect(state.sceneLoading).toBe(false);
+
+      // Start loading scene 2
+      state = scenePlayerReducer(state, { type: "LOAD_SCENE_START" });
+      expect(state.sceneLoading).toBe(true);
+      // Old scene is still there during loading
+      expect(state.scene.id).toBe("1");
+
+      // Scene 2 succeeds
+      state = scenePlayerReducer(state, {
+        type: "LOAD_SCENE_SUCCESS",
+        payload: {
+          scene: { id: "2", isStreamable: false, files: [{ height: 480 }] },
+          oCounter: 0,
+        },
+      });
+      expect(state.scene.id).toBe("2");
+      expect(state.oCounter).toBe(0);
+      // Quality was reset to "direct" by default, so auto-selection kicks in
+      expect(state.quality).toBe("480p");
+    });
+
+    it("GOTO_SCENE_INDEX with payload.index of 0 when currentIndex is also 0", () => {
+      const state = {
+        ...initialState,
+        playlist: makePlaylist(3),
+        currentIndex: 0,
+        video: { url: "something" },
+        ready: true,
+      };
+      const result = scenePlayerReducer(state, {
+        type: "GOTO_SCENE_INDEX",
+        payload: { index: 0 },
+      });
+
+      // Should still reset video state even though index didn't change
+      expect(result.currentIndex).toBe(0);
+      expect(result.video).toBeNull();
+      expect(result.ready).toBe(false);
+    });
+  });
+});

--- a/client/tests/hooks/useAuth.test.jsx
+++ b/client/tests/hooks/useAuth.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { AuthContext } from "@/contexts/AuthContextProvider.jsx";
+import { useAuth } from "@/hooks/useAuth.js";
+
+describe("useAuth", () => {
+  it("throws when used outside AuthProvider", () => {
+    expect(() => renderHook(() => useAuth())).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
+  });
+
+  it("returns context value when inside provider", () => {
+    const mockValue = {
+      user: { id: 1, username: "testuser", role: "USER" },
+      login: () => {},
+      logout: () => {},
+      isAuthenticated: true,
+    };
+
+    const wrapper = ({ children }) => (
+      <AuthContext.Provider value={mockValue}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current).toBe(mockValue);
+    expect(result.current.user.username).toBe("testuser");
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("returns updated context on re-render", () => {
+    const initialValue = { user: null, isAuthenticated: false };
+    const updatedValue = {
+      user: { id: 1, username: "testuser" },
+      isAuthenticated: true,
+    };
+
+    let providerValue = initialValue;
+
+    const wrapper = ({ children }) => (
+      <AuthContext.Provider value={providerValue}>
+        {children}
+      </AuthContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current).toBe(initialValue);
+    expect(result.current.isAuthenticated).toBe(false);
+
+    providerValue = updatedValue;
+    rerender();
+
+    expect(result.current).toBe(updatedValue);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add **168 tests** across 5 new test files for client contexts and hooks
- `scenePlayerReducer` (113 tests): all action types, playlist navigation with shuffle/repeat, quality auto-selection, reducer purity verification
- `AuthContext` (14 tests): login/logout/checkAuth lifecycle, loading state, updateUser
- `ConfigContext` (10 tests): multi-instance detection, API error handling, default values
- `ScenePlayerContext` (28 tests): action creators with side effects, scene loading effects, URL update, toggle controls
- `useAuth` hook (3 tests): error outside provider, context consumption

## Test plan
- [x] All 1377 client tests pass
- [x] Client lint clean (0 errors)
- [x] Client build succeeds
- [x] Server tests unaffected (1633 pass)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)