### PR TITLE
chore: add CI check for server/shared type sync (#435)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
       - name: TypeScript Compile
         run: npx tsc --noEmit
 
+      - name: Check type sync (server ↔ shared)
+        working-directory: .
+        run: bash scripts/check-type-sync.sh
+
       - name: Test with coverage
         run: npm run test:coverage
         env:

--- a/scripts/check-type-sync.sh
+++ b/scripts/check-type-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Check that server/types/entities.ts and shared/types/entities.ts stay in sync.
+# Compares only the type definitions (from first "export" line onwards), ignoring
+# header comments which intentionally differ between the two files.
+#
+# See: https://github.com/carrotwaxr/peek-stash-browser/issues/435
+
+set -euo pipefail
+
+SERVER_FILE="server/types/entities.ts"
+SHARED_FILE="shared/types/entities.ts"
+
+if [[ ! -f "$SERVER_FILE" ]]; then
+  echo "ERROR: $SERVER_FILE not found"
+  exit 1
+fi
+
+if [[ ! -f "$SHARED_FILE" ]]; then
+  echo "ERROR: $SHARED_FILE not found"
+  exit 1
+fi
+
+# Extract from first "export" line to end of file
+server_types=$(sed -n '/^export/,$ p' "$SERVER_FILE")
+shared_types=$(sed -n '/^export/,$ p' "$SHARED_FILE")
+
+if [[ "$server_types" != "$shared_types" ]]; then
+  echo "ERROR: Type definitions have drifted between server and shared!"
+  echo ""
+  echo "  $SERVER_FILE"
+  echo "  $SHARED_FILE"
+  echo ""
+  echo "These files must stay in sync. Diff:"
+  echo ""
+  diff <(echo "$server_types") <(echo "$shared_types") || true
+  echo ""
+  echo "Update both files to match, then re-run this check."
+  exit 1
+fi
+
+echo "OK: server/types/entities.ts and shared/types/entities.ts are in sync"


### PR DESCRIPTION
## Summary
- Adds `scripts/check-type-sync.sh` that compares type definitions between `server/types/entities.ts` and `shared/types/entities.ts` (ignoring header comments)
- Adds a CI step in the server job to run this check, catching drift before merge

## Test plan
- [x] Script passes locally (`OK: server/types/entities.ts and shared/types/entities.ts are in sync`)
- [x] CI workflow syntax validated
- [ ] CI run passes on this PR

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)