### PR TITLE
fix(docker): copy shared-types into production image

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -92,6 +92,10 @@ COPY server/package*.json ./
 # Copy pruned node_modules from build stage (already has prisma client generated)
 COPY --from=backend-build /app/server/node_modules ./node_modules
 
+# Replace file: symlink with actual shared-types package
+# (npm ci creates a symlink to ../../../shared which resolves differently between stages)
+COPY --from=backend-build /app/shared ./node_modules/@peek/shared-types
+
 # Copy Prisma schema and migrations (for runtime migrations)
 COPY server/prisma/schema.prisma ./prisma/
 COPY server/prisma/migrations ./prisma/migrations


### PR DESCRIPTION
## Summary
- The `file:` dependency for `@peek/shared-types` creates a symlink in `node_modules` that resolves differently between Docker build stages
- Production image crashes with `ERR_MODULE_NOT_FOUND: Cannot find package '@peek/shared-types'`
- Fix: overwrite the symlink with the actual built package via `COPY --from=backend-build`

## Test plan
- [x] `docker build -f Dockerfile.production -t peek:test .` succeeds
- [x] `node -e "import('@peek/shared-types/instanceAwareId.js')"` resolves in container
- [x] Server starts cleanly in container (no import errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)