### PR TITLE
fix(client): eliminate unsafe type casts in utility functions and components

### DIFF
--- a/client/src/components/cards/ClipCard.tsx
+++ b/client/src/components/cards/ClipCard.tsx
@@ -172,7 +172,7 @@ const ClipCard = forwardRef<HTMLDivElement, Props>(
     );
 
     // Handle navigation - navigate with autoplay state
-    const clipUrl = getScenePathWithTime({ id: clip.sceneId, instanceId: clip.instanceId } as unknown as Record<string, unknown>, clip.seconds ?? 0, hasMultipleInstances);
+    const clipUrl = getScenePathWithTime({ id: clip.sceneId, instanceId: clip.instanceId }, clip.seconds ?? 0, hasMultipleInstances);
     const handleNavigate = () => {
       if (onClick) {
         onClick(clip);

--- a/client/src/components/cards/GalleryCard.tsx
+++ b/client/src/components/cards/GalleryCard.tsx
@@ -76,7 +76,7 @@ const GalleryCard = forwardRef<HTMLDivElement, Props>(
         count: gallery.image_count,
         // Config says 'nav' for gallery->images
         onClick: getIndicatorBehavior('gallery', 'images') === 'nav' && gallery.image_count > 0
-          ? () => navigate(appendInstanceParam(`/images?galleryId=${gallery.id}`, gallery as unknown as Record<string, unknown>, hasMultipleInstances))
+          ? () => navigate(appendInstanceParam(`/images?galleryId=${gallery.id}`, gallery, hasMultipleInstances))
           : undefined,
       },
       {
@@ -85,7 +85,7 @@ const GalleryCard = forwardRef<HTMLDivElement, Props>(
         tooltipContent: scenesTooltip,
         // Config says 'nav' for gallery->scenes
         onClick: getIndicatorBehavior('gallery', 'scenes') === 'nav' && gallery.scenes?.length > 0
-          ? () => navigate(appendInstanceParam(`/scenes?galleryId=${gallery.id}`, gallery as unknown as Record<string, unknown>, hasMultipleInstances))
+          ? () => navigate(appendInstanceParam(`/scenes?galleryId=${gallery.id}`, gallery, hasMultipleInstances))
           : undefined,
       },
       {
@@ -93,7 +93,7 @@ const GalleryCard = forwardRef<HTMLDivElement, Props>(
         count: gallery.performers?.length || 0,
         tooltipContent: performersTooltip,
         onClick: getIndicatorBehavior('gallery', 'performers') === 'nav' && gallery.performers?.length > 0
-          ? () => navigate(appendInstanceParam(`/performers?galleryId=${gallery.id}`, gallery as unknown as Record<string, unknown>, hasMultipleInstances))
+          ? () => navigate(appendInstanceParam(`/performers?galleryId=${gallery.id}`, gallery, hasMultipleInstances))
           : undefined,
       },
       {
@@ -101,7 +101,7 @@ const GalleryCard = forwardRef<HTMLDivElement, Props>(
         count: gallery.tags?.length || 0,
         tooltipContent: tagsTooltip,
         onClick: getIndicatorBehavior('gallery', 'tags') === 'nav' && gallery.tags?.length > 0
-          ? () => navigate(appendInstanceParam(`/tags?galleryId=${gallery.id}`, gallery as unknown as Record<string, unknown>, hasMultipleInstances))
+          ? () => navigate(appendInstanceParam(`/tags?galleryId=${gallery.id}`, gallery, hasMultipleInstances))
           : undefined,
       },
     ];
@@ -114,10 +114,10 @@ const GalleryCard = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         entityType="gallery"
         imagePath={gallery.cover}
-        title={galleryTitle(gallery as unknown as Record<string, unknown>) as React.ReactNode}
+        title={galleryTitle(gallery)}
         subtitle={subtitle}
         description={gallery.details}
-        linkTo={getEntityPath('gallery', gallery as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={getEntityPath('gallery', gallery, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={tabIndex}
         indicators={indicatorsToShow}

--- a/client/src/components/cards/GroupCard.tsx
+++ b/client/src/components/cards/GroupCard.tsx
@@ -59,7 +59,7 @@ const GroupCard = forwardRef<HTMLDivElement, Props>(
           count: group.scene_count,
           onClick:
             group.scene_count > 0
-              ? () => navigate(appendInstanceParam(`/scenes?groupIds=${group.id}`, group as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/scenes?groupIds=${group.id}`, group, hasMultipleInstances))
               : undefined,
         },
         {
@@ -67,7 +67,7 @@ const GroupCard = forwardRef<HTMLDivElement, Props>(
           count: group.sub_group_count,
           onClick:
             (group.sub_group_count ?? 0) > 0
-              ? () => navigate(appendInstanceParam(`/collections?groupIds=${group.id}`, group as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/collections?groupIds=${group.id}`, group, hasMultipleInstances))
               : undefined,
         },
         {
@@ -99,7 +99,7 @@ const GroupCard = forwardRef<HTMLDivElement, Props>(
         title={group.name}
         subtitle={subtitle}
         description={group.description}
-        linkTo={getEntityPath('group', group as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={getEntityPath('group', group, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={tabIndex}
         indicators={indicatorsToShow}

--- a/client/src/components/cards/ImageCard.tsx
+++ b/client/src/components/cards/ImageCard.tsx
@@ -39,7 +39,7 @@ const ImageCard = forwardRef<HTMLDivElement, Props>(
     const imageSettings = getSettings("image");
     const { hasMultipleInstances } = useConfig();
     // Get effective metadata (inherits from galleries if image doesn't have its own)
-    const { effectivePerformers, effectiveTags, effectiveStudio, effectiveDate } = getEffectiveImageMetadata(image as unknown as Record<string, unknown>);
+    const { effectivePerformers, effectiveTags, effectiveStudio, effectiveDate } = getEffectiveImageMetadata(image);
 
     // Build subtitle from studio and date (respecting settings)
     const subtitle = (() => {
@@ -148,11 +148,11 @@ const ImageCard = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         entityType="image"
         imagePath={image.paths?.thumbnail || image.paths?.image}
-        title={getImageTitle(image as unknown as Record<string, unknown>) as React.ReactNode}
+        title={getImageTitle(image)}
         subtitle={subtitle}
         description={image.details}
         onClick={handleClick}
-        linkTo={onClick ? undefined : getEntityPath('image', image as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={onClick ? undefined : getEntityPath('image', image, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={tabIndex}
         indicators={indicatorsToShow}

--- a/client/src/components/cards/PerformerCard.tsx
+++ b/client/src/components/cards/PerformerCard.tsx
@@ -50,7 +50,7 @@ const PerformerCard = forwardRef<HTMLDivElement, Props>(
         {
           type: "SCENES",
           count: performer.scene_count,
-          onClick: performer.scene_count > 0 ? () => navigate(appendInstanceParam(`/scenes?performerId=${performer.id}`, performer as unknown as Record<string, unknown>, hasMultipleInstances)) : undefined,
+          onClick: performer.scene_count > 0 ? () => navigate(appendInstanceParam(`/scenes?performerId=${performer.id}`, performer, hasMultipleInstances)) : undefined,
         },
         {
           type: "GROUPS",
@@ -60,7 +60,7 @@ const PerformerCard = forwardRef<HTMLDivElement, Props>(
         {
           type: "IMAGES",
           count: performer.image_count,
-          onClick: performer.image_count > 0 ? () => navigate(appendInstanceParam(`/images?performerId=${performer.id}`, performer as unknown as Record<string, unknown>, hasMultipleInstances)) : undefined,
+          onClick: performer.image_count > 0 ? () => navigate(appendInstanceParam(`/images?performerId=${performer.id}`, performer, hasMultipleInstances)) : undefined,
         },
         {
           type: "GALLERIES",
@@ -94,7 +94,7 @@ const PerformerCard = forwardRef<HTMLDivElement, Props>(
             <GenderIcon gender={performer.gender} size={16} />
           </div>
         }
-        linkTo={getEntityPath('performer', performer as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={getEntityPath('performer', performer, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={isTVMode ? tabIndex : -1}
         description={performer.details}

--- a/client/src/components/cards/StudioCard.tsx
+++ b/client/src/components/cards/StudioCard.tsx
@@ -50,7 +50,7 @@ const StudioCard = forwardRef<HTMLDivElement, Props>(
           count: studio.scene_count,
           onClick:
             studio.scene_count > 0
-              ? () => navigate(appendInstanceParam(`/scenes?studioId=${studio.id}`, studio as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/scenes?studioId=${studio.id}`, studio, hasMultipleInstances))
               : undefined,
         },
         {
@@ -58,7 +58,7 @@ const StudioCard = forwardRef<HTMLDivElement, Props>(
           count: studio.image_count,
           onClick:
             studio.image_count > 0
-              ? () => navigate(appendInstanceParam(`/images?studioId=${studio.id}`, studio as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/images?studioId=${studio.id}`, studio, hasMultipleInstances))
               : undefined,
         },
         {
@@ -94,7 +94,7 @@ const StudioCard = forwardRef<HTMLDivElement, Props>(
         imagePath={studio.image_path}
         title={studio.name}
         description={studio.details}
-        linkTo={getEntityPath('studio', studio as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={getEntityPath('studio', studio, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={tabIndex}
         indicators={indicatorsToShow}

--- a/client/src/components/cards/TagCard.tsx
+++ b/client/src/components/cards/TagCard.tsx
@@ -56,7 +56,7 @@ const TagCard = forwardRef<HTMLDivElement, Props>(
           count: tag.scene_count,
           onClick:
             tag.scene_count > 0
-              ? () => navigate(appendInstanceParam(`/scenes?tagIds=${tag.id}`, tag as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/scenes?tagIds=${tag.id}`, tag, hasMultipleInstances))
               : undefined,
         },
         {
@@ -64,7 +64,7 @@ const TagCard = forwardRef<HTMLDivElement, Props>(
           count: tag.image_count,
           onClick:
             tag.image_count > 0
-              ? () => navigate(appendInstanceParam(`/images?tagIds=${tag.id}`, tag as unknown as Record<string, unknown>, hasMultipleInstances))
+              ? () => navigate(appendInstanceParam(`/images?tagIds=${tag.id}`, tag, hasMultipleInstances))
               : undefined,
         },
         {
@@ -101,7 +101,7 @@ const TagCard = forwardRef<HTMLDivElement, Props>(
         title={tag.name}
         subtitle={subtitle}
         description={tag.description}
-        linkTo={getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances)}
+        linkTo={getEntityPath('tag', tag, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         tabIndex={tabIndex}
         indicators={indicatorsToShow}

--- a/client/src/components/carousel-builder/CarouselPreview.tsx
+++ b/client/src/components/carousel-builder/CarouselPreview.tsx
@@ -154,9 +154,9 @@ const PreviewCard = ({ scene }: PreviewCardProps) => {
         <p
           className="text-xs line-clamp-2"
           style={{ color: "var(--text-primary)" }}
-          title={getSceneTitle(scene as unknown as Record<string, unknown>)}
+          title={getSceneTitle(scene)}
         >
-          {getSceneTitle(scene as unknown as Record<string, unknown>)}
+          {getSceneTitle(scene)}
         </p>
       </div>
     </div>

--- a/client/src/components/scene/SceneDescription.tsx
+++ b/client/src/components/scene/SceneDescription.tsx
@@ -18,7 +18,7 @@ const SceneDescription = ({
   lineClamp = 2,
   className = "",
 }: Props) => {
-  const description = getSceneDescription(scene as unknown as Record<string, unknown>);
+  const description = getSceneDescription(scene);
 
   if (!description) return null;
 

--- a/client/src/components/scene/SceneMetadata.tsx
+++ b/client/src/components/scene/SceneMetadata.tsx
@@ -34,7 +34,7 @@ const TagThumbnailLink = ({ tag, hasMultipleInstances }: TagThumbnailLinkProps) 
 
   return (
     <Link
-      to={getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances)}
+      to={getEntityPath('tag', tag, hasMultipleInstances)}
       className="flex items-center gap-3 p-2 rounded hover:bg-white/10 transition-colors"
       onClick={(e) => e.stopPropagation()}
     >
@@ -78,7 +78,7 @@ const SceneMetadata = ({ scene }: Props) => {
         {scene.performers.map((performer) => (
           <Link
             key={performer.id}
-            to={getEntityPath('performer', performer as unknown as Record<string, unknown>, hasMultipleInstances)}
+            to={getEntityPath('performer', performer, hasMultipleInstances)}
             className="flex items-center gap-3 p-2 rounded hover:bg-white/10 transition-colors"
             onClick={(e) => e.stopPropagation()}
           >
@@ -123,7 +123,7 @@ const SceneMetadata = ({ scene }: Props) => {
         {scene.groups.map((group) => (
           <Link
             key={group.id}
-            to={getEntityPath('group', group as unknown as Record<string, unknown>, hasMultipleInstances)}
+            to={getEntityPath('group', group, hasMultipleInstances)}
             className="flex items-center gap-3 p-2 rounded hover:bg-white/10 transition-colors"
             onClick={(e) => e.stopPropagation()}
           >

--- a/client/src/components/scene/SceneTitle.tsx
+++ b/client/src/components/scene/SceneTitle.tsx
@@ -29,7 +29,7 @@ const SceneTitle = ({
   maxLines = null,
 }: Props) => {
   const { hasMultipleInstances } = useConfig();
-  const title = getSceneTitle(scene as unknown as Record<string, unknown>);
+  const title = getSceneTitle(scene);
   const date = scene.date ? formatRelativeTime(scene.date) : null;
 
   // Build subtitle with studio, code, and date (like SceneCard)
@@ -98,7 +98,7 @@ const SceneTitle = ({
   return (
     <div>
       <Link
-        to={getEntityPath('scene', scene as unknown as Record<string, unknown>, hasMultipleInstances)}
+        to={getEntityPath('scene', scene, hasMultipleInstances)}
         state={linkState}
         onClick={handleClick}
         className={`font-semibold hover:underline block ${titleClassName}`}

--- a/client/src/components/tags/TagTreeNode.tsx
+++ b/client/src/components/tags/TagTreeNode.tsx
@@ -109,7 +109,7 @@ const TagTreeNode = forwardRef<HTMLDivElement, TagTreeNodeProps>(
     const handleDoubleClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        navigate(getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
+        navigate(getEntityPath('tag', tag, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
       },
       [navigate, tag, hasMultipleInstances]
     );
@@ -117,7 +117,7 @@ const TagTreeNode = forwardRef<HTMLDivElement, TagTreeNodeProps>(
     const handleNavigateClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        navigate(getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
+        navigate(getEntityPath('tag', tag, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
       },
       [navigate, tag, hasMultipleInstances]
     );
@@ -126,7 +126,7 @@ const TagTreeNode = forwardRef<HTMLDivElement, TagTreeNodeProps>(
       (e: React.KeyboardEvent) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          navigate(getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
+          navigate(getEntityPath('tag', tag, hasMultipleInstances), { state: { fromPageTitle: "Tags" } });
         }
       },
       [navigate, tag, hasMultipleInstances]

--- a/client/src/components/ui/RecommendedSidebar.tsx
+++ b/client/src/components/ui/RecommendedSidebar.tsx
@@ -127,7 +127,7 @@ const RecommendedSidebar = ({ sceneId, maxHeight }: Props) => {
                 {/* Thumbnail with lazy loading */}
                 <SidebarThumbnail
                   thumbnail={thumbnail}
-                  alt={getSceneTitle(scene as unknown as Record<string, unknown>)}
+                  alt={getSceneTitle(scene)}
                   duration={duration}
                 />
 
@@ -138,7 +138,7 @@ const RecommendedSidebar = ({ sceneId, maxHeight }: Props) => {
                     className="text-sm font-medium line-clamp-2 mb-1 group-hover:underline"
                     style={{ color: "var(--text-primary)" }}
                   >
-                    {getSceneTitle(scene as unknown as Record<string, unknown>)}
+                    {getSceneTitle(scene)}
                   </h4>
 
                   {/* Studio */}

--- a/client/src/components/ui/SceneCard.tsx
+++ b/client/src/components/ui/SceneCard.tsx
@@ -107,9 +107,8 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
     const sceneSettings = getSettings("scene");
     const { hasMultipleInstances } = useConfig();
 
-    const sceneRecord = scene as unknown as Record<string, unknown>;
-    const title = getSceneTitle(sceneRecord);
-    const description = getSceneDescription(sceneRecord);
+    const title = getSceneTitle(scene);
+    const description = getSceneDescription(scene);
     const subtitle = buildSceneSubtitle(scene, {
       showCodeOnCard: sceneSettings.showCodeOnCard as boolean,
       showStudio: sceneSettings.showStudio as boolean,
@@ -180,7 +179,7 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
           tooltipContent: performersTooltip,
           // 'rich' behavior: tooltip only, no onClick (users navigate via entities in tooltip)
           onClick: getIndicatorBehavior('scene', 'performers') === 'nav' && scene.performers?.length > 0
-            ? () => navigate(appendInstanceParam(`/performers?sceneId=${scene.id}`, sceneRecord as Parameters<typeof appendInstanceParam>[1], hasMultipleInstances))
+            ? () => navigate(appendInstanceParam(`/performers?sceneId=${scene.id}`, scene, hasMultipleInstances))
             : undefined,
         },
         {
@@ -188,7 +187,7 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
           count: scene.groups?.length,
           tooltipContent: groupsTooltip,
           onClick: getIndicatorBehavior('scene', 'groups') === 'nav' && scene.groups?.length > 0
-            ? () => navigate(appendInstanceParam(`/collections?sceneId=${scene.id}`, sceneRecord as Parameters<typeof appendInstanceParam>[1], hasMultipleInstances))
+            ? () => navigate(appendInstanceParam(`/collections?sceneId=${scene.id}`, scene, hasMultipleInstances))
             : undefined,
         },
         {
@@ -196,7 +195,7 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
           count: scene.galleries?.length,
           tooltipContent: galleriesTooltip,
           onClick: getIndicatorBehavior('scene', 'galleries') === 'nav' && scene.galleries?.length > 0
-            ? () => navigate(appendInstanceParam(`/galleries?sceneId=${scene.id}`, sceneRecord as Parameters<typeof appendInstanceParam>[1], hasMultipleInstances))
+            ? () => navigate(appendInstanceParam(`/galleries?sceneId=${scene.id}`, scene, hasMultipleInstances))
             : undefined,
         },
         {
@@ -204,11 +203,11 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
           count: allTags?.length,
           tooltipContent: tagsTooltip,
           onClick: getIndicatorBehavior('scene', 'tags') === 'nav' && allTags?.length > 0
-            ? () => navigate(appendInstanceParam(`/tags?sceneId=${scene.id}`, sceneRecord as Parameters<typeof appendInstanceParam>[1], hasMultipleInstances))
+            ? () => navigate(appendInstanceParam(`/tags?sceneId=${scene.id}`, scene, hasMultipleInstances))
             : undefined,
         },
       ];
-    }, [scene, sceneRecord, allTags, navigate, hasMultipleInstances]);
+    }, [scene, allTags, navigate, hasMultipleInstances]);
 
     // Only show indicators if setting is enabled
     const indicatorsToShow = sceneSettings.showRelationshipIndicators ? indicators : [];
@@ -305,7 +304,7 @@ const SceneCard = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         entityType="scene"
         entity={scene as unknown as Record<string, unknown>}
-        linkTo={getEntityPath('scene', sceneRecord as Parameters<typeof getEntityPath>[1], hasMultipleInstances)}
+        linkTo={getEntityPath('scene', scene, hasMultipleInstances)}
         fromPageTitle={fromPageTitle}
         // Selection mode - BaseCard handles all gesture/keyboard logic
         selectionMode={selectionMode}

--- a/client/src/components/ui/SceneListItem.tsx
+++ b/client/src/components/ui/SceneListItem.tsx
@@ -307,10 +307,10 @@ const SceneListItem = ({
                       </div>
 
                       {/* Description */}
-                      {getSceneDescription(scene as unknown as Record<string, unknown>) && (
+                      {getSceneDescription(scene) && (
                         <div className="mb-2">
                           <ExpandableDescription
-                            description={getSceneDescription(scene as unknown as Record<string, unknown>)}
+                            description={getSceneDescription(scene)}
                             maxLines={2}
                           />
                         </div>

--- a/client/src/components/ui/TagChips.tsx
+++ b/client/src/components/ui/TagChips.tsx
@@ -30,7 +30,7 @@ const TagChips = ({ tags }: Props) => {
         return (
           <Link
             key={tag.id}
-            to={getEntityPath('tag', tag as unknown as Record<string, unknown>, hasMultipleInstances)}
+            to={getEntityPath('tag', tag, hasMultipleInstances)}
             className="px-3 py-1 rounded-full text-sm font-medium transition-opacity hover:opacity-80"
             style={{
               backgroundColor: `hsl(${hue}, 70%, 45%)`,

--- a/client/src/components/video-player/PlaybackControls.tsx
+++ b/client/src/components/video-player/PlaybackControls.tsx
@@ -21,12 +21,12 @@ const PlaybackControls = () => {
   const sceneSettings = getSettings("scene") as any;
 
   // Rating and favorite state
-  const [rating, setRating] = useState<any>(null);
+  const [rating, setRating] = useState<number | null>(null);
   const [isFavorite, setIsFavorite] = useState(false);
 
   // Download state
   const [downloading, setDownloading] = useState(false);
-  const [permissions, setPermissions] = useState<any>(null);
+  const [permissions, setPermissions] = useState<Record<string, unknown> | null>(null);
 
   // Sync state when scene changes
   const sceneId = scene?.id;
@@ -54,7 +54,7 @@ const PlaybackControls = () => {
   }, []);
 
   // Handle rating change
-  const handleRatingChange = async (newRating: any) => {
+  const handleRatingChange = async (newRating: number | null) => {
     if (!scene?.id) return;
 
     const previousRating = rating;
@@ -69,7 +69,7 @@ const PlaybackControls = () => {
   };
 
   // Handle favorite change
-  const handleFavoriteChange = async (newFavorite: any) => {
+  const handleFavoriteChange = async (newFavorite: boolean) => {
     if (!scene?.id) return;
 
     const previousFavorite = isFavorite;
@@ -94,7 +94,7 @@ const PlaybackControls = () => {
   const handleDownload = async () => {
     try {
       setDownloading(true);
-      const response: any = await apiPost(`/downloads/scene/${scene.id}`);
+      const response = await apiPost<{ download: { id: string; status: string } }>(`/downloads/scene/${scene.id}`);
       const download = response.download;
 
       // For scenes, download is immediate - redirect to file endpoint
@@ -170,7 +170,7 @@ const PlaybackControls = () => {
               />
             )}
             <AddToPlaylistButton sceneId={scene?.id as string} disabled={isLoading} compact />
-            {permissions?.canDownloadFiles && (
+            {!!permissions?.canDownloadFiles && (
               <Button
                 variant="secondary"
                 onClick={handleDownload}
@@ -228,7 +228,7 @@ const PlaybackControls = () => {
           {/* Row 2: Add to Playlist + Download */}
           <div className="flex items-center justify-end gap-4">
             <AddToPlaylistButton sceneId={scene?.id as string} disabled={isLoading} compact />
-            {permissions?.canDownloadFiles && (
+            {!!permissions?.canDownloadFiles && (
               <Button
                 variant="secondary"
                 onClick={handleDownload}
@@ -266,7 +266,7 @@ const PlaybackControls = () => {
               />
             )}
             <AddToPlaylistButton sceneId={scene?.id as string} disabled={isLoading} compact />
-            {permissions?.canDownloadFiles && (
+            {!!permissions?.canDownloadFiles && (
               <Button
                 variant="secondary"
                 onClick={handleDownload}

--- a/client/src/hooks/useFilterState.ts
+++ b/client/src/hooks/useFilterState.ts
@@ -77,19 +77,19 @@ export const useFilterState = ({
 
         // Load presets
         const [presetsRes, defaultsRes] = await Promise.all([
-          apiGet("/user/filter-presets"),
-          apiGet("/user/default-presets"),
+          apiGet<{ presets: Record<string, Array<{ id: string; name: string; filters: Record<string, unknown>; sort?: string; direction?: string; perPage?: number; viewMode?: string; zoomLevel?: string; gridDensity?: string; tableColumns?: Record<string, unknown> | null }>> }>("/user/filter-presets"),
+          apiGet<{ defaults: Record<string, string> }>("/user/default-presets"),
         ]);
 
-        const allPresets = (presetsRes as any)?.presets || {};
-        const defaults = (defaultsRes as any)?.defaults || {};
+        const allPresets = presetsRes?.presets || {};
+        const defaults = defaultsRes?.defaults || {};
         const defaultPresetId = defaults[effectiveContext];
 
         const presetArtifactType = effectiveContext.startsWith("scene_")
           ? "scene"
           : effectiveContext;
         const presets = allPresets[presetArtifactType] || [];
-        const defaultPreset = presets.find((p: any) => p.id === defaultPresetId);
+        const defaultPreset = presets.find((p) => p.id === defaultPresetId);
 
         // Parse URL params
         const urlState = parseSearchParams(searchParams, filterOptions, {
@@ -151,7 +151,7 @@ export const useFilterState = ({
 
         // Set state
         setFiltersState(finalState.filters);
-        setSortState({ field: finalState.sortField, direction: finalState.sortDirection });
+        setSortState({ field: finalState.sortField ?? initialSort ?? "random", direction: finalState.sortDirection ?? "DESC" });
         setPaginationState({ page: finalState.currentPage, perPage: finalState.perPage });
         setSearchTextState(finalState.searchText);
         setViewModeState(finalState.viewMode as string);

--- a/client/src/hooks/useFolderViewTags.ts
+++ b/client/src/hooks/useFolderViewTags.ts
@@ -47,12 +47,12 @@ export function useFolderViewTags(isActive: boolean, filters: FolderViewFilters 
 
         // Use filtered endpoint if filters are provided
         if (filters && (filters.performerId || filters.tagId || filters.studioId || filters.groupId)) {
-          const result = await apiPost("/library/tags/for-scenes", {
+          const result = await apiPost<{ tags: Array<{ id: string; name: string }> }>("/library/tags/for-scenes", {
             performerId: filters.performerId,
             tagId: filters.tagId,
             studioId: filters.studioId,
             groupId: filters.groupId,
-          }) as any;
+          });
           fetchedTags = result?.tags || [];
         } else {
           // Fetch all tags (existing behavior)
@@ -62,8 +62,8 @@ export function useFolderViewTags(isActive: boolean, filters: FolderViewFilters 
               sort: "name",
               direction: "ASC",
             },
-          }) as any;
-          fetchedTags = result?.findTags?.tags || [];
+          });
+          fetchedTags = (result as { findTags?: { tags?: Array<{ id: string; name: string }> } })?.findTags?.tags || [];
         }
 
         setTags(fetchedTags);

--- a/client/src/hooks/useHiddenEntities.ts
+++ b/client/src/hooks/useHiddenEntities.ts
@@ -63,7 +63,7 @@ export const useHiddenEntities = () => {
     async ({ entities, skipConfirmation = false }: { entities: Array<{ entityType: string; entityId: string }>; skipConfirmation?: boolean }) => {
       setIsHiding(true);
       try {
-        const response = await apiPost("/user/hidden-entities/bulk", {
+        const response = await apiPost<{ successCount: number; failCount: number }>("/user/hidden-entities/bulk", {
           entities,
         });
 
@@ -77,8 +77,8 @@ export const useHiddenEntities = () => {
 
         return {
           success: true,
-          successCount: (response as any).successCount,
-          failCount: (response as any).failCount,
+          successCount: response.successCount,
+          failCount: response.failCount,
         };
       } catch (error) {
         console.error("Failed to hide entities:", error);
@@ -122,7 +122,7 @@ export const useHiddenEntities = () => {
       const endpoint = entityType
         ? `/user/hidden-entities?entityType=${entityType}`
         : "/user/hidden-entities";
-      const response = await apiGet(endpoint) as any;
+      const response = await apiGet<{ hiddenEntities: Array<{ entityType: string; entityId: string }> }>(endpoint);
       return response.hiddenEntities;
     } catch (error) {
       console.error("Failed to get hidden entities:", error);

--- a/client/src/utils/entityLinks.ts
+++ b/client/src/utils/entityLinks.ts
@@ -27,7 +27,6 @@ const ENTITY_PATHS: Record<string, string> = {
 interface EntityLike {
   id?: string | number;
   instanceId?: string;
-  [key: string]: unknown;
 }
 
 export function getEntityPath(entityType: string, entity: EntityLike | string, hasMultipleInstances: boolean) {

--- a/client/src/utils/format.ts
+++ b/client/src/utils/format.ts
@@ -31,19 +31,22 @@ export function formatBitRate(bitsPerSecond: number) {
 /**
  * Get scene display title - uses title if available, otherwise falls back to first file basename
  */
-export function getSceneTitle(scene: Record<string, unknown> | null) {
+interface SceneTitleInput {
+  title?: string | null;
+  files?: Array<{ basename?: string; path?: string }>;
+}
+
+export function getSceneTitle(scene: SceneTitleInput | null) {
   if (!scene) return "Unknown Scene";
 
   // Use title if it exists and is not empty
-  const title = scene.title as string | undefined;
-  if (title && title.trim()) {
-    return title.trim();
+  if (scene.title && scene.title.trim()) {
+    return scene.title.trim();
   }
 
   // Fallback to first file basename
-  const files = scene.files as Array<Record<string, unknown>> | undefined;
-  if (files && files.length > 0 && files[0].basename) {
-    return (files[0].basename as string).replace(/\.[^/.]+$/, ""); // Remove file extension
+  if (scene.files && scene.files.length > 0 && scene.files[0].basename) {
+    return scene.files[0].basename.replace(/\.[^/.]+$/, ""); // Remove file extension
   }
 
   return "Unknown Scene";
@@ -52,9 +55,13 @@ export function getSceneTitle(scene: Record<string, unknown> | null) {
 /**
  * Get scene description, handling empty cases
  */
-export function getSceneDescription(scene: Record<string, unknown> | null) {
+interface SceneDetailsInput {
+  details?: string | null;
+}
+
+export function getSceneDescription(scene: SceneDetailsInput | null) {
   if (!scene || !scene.details) return "";
-  return (scene.details as string).trim();
+  return scene.details.trim();
 }
 
 /**

--- a/client/src/utils/gallery.ts
+++ b/client/src/utils/gallery.ts
@@ -24,7 +24,13 @@ function fileNameFromPath(path: string) {
  * @param {Object} gallery - Gallery object
  * @returns {string} Display title
  */
-export function galleryTitle(gallery: Record<string, unknown> | null) {
+interface GalleryTitleInput {
+  title?: string | null;
+  files?: Array<{ basename?: string; path?: string }>;
+  folder?: { path: string } | null;
+}
+
+export function galleryTitle(gallery: GalleryTitleInput | null): string {
   if (!gallery) return "Untitled Gallery";
 
   // Use title if available
@@ -33,25 +39,23 @@ export function galleryTitle(gallery: Record<string, unknown> | null) {
   }
 
   // Try to get basename from files
-  const files = gallery.files as Array<Record<string, unknown>> | undefined;
-  if (files && files.length > 0) {
-    const firstFile = files[0];
+  if (gallery.files && gallery.files.length > 0) {
+    const firstFile = gallery.files[0];
 
     // Prefer basename if available
     if (firstFile.basename) {
-      return firstFile.basename as string;
+      return firstFile.basename;
     }
 
     // Fall back to extracting from path
     if (firstFile.path) {
-      return fileNameFromPath(firstFile.path as string);
+      return fileNameFromPath(firstFile.path);
     }
   }
 
   // Try folder path if available
-  const folder = gallery.folder as Record<string, unknown> | undefined;
-  if (folder && folder.path) {
-    return fileNameFromPath(folder.path as string);
+  if (gallery.folder?.path) {
+    return fileNameFromPath(gallery.folder.path);
   }
 
   return "Untitled Gallery";

--- a/client/src/utils/imageGalleryInheritance.ts
+++ b/client/src/utils/imageGalleryInheritance.ts
@@ -13,36 +13,40 @@
 interface Entity {
   id: string;
   name?: string | null;
-  [key: string]: any;
+  image_path?: string | null;
+  gender?: string | null;
+}
+
+interface StudioLike {
+  id: string;
+  name?: string | null;
 }
 
 interface Gallery {
   id?: string;
   performers?: Entity[];
   tags?: Entity[];
-  studio?: any;
-  studioId?: string;
-  studioName?: string;
-  date?: string;
-  details?: string;
-  photographer?: string;
+  studio?: StudioLike | null;
+  studioId?: string | null;
+  studioName?: string | null;
+  date?: string | null;
+  details?: string | null;
+  photographer?: string | null;
   urls?: string[];
-  [key: string]: any;
 }
 
 interface ImageObject {
   id?: string;
-  title?: string;
-  filePath?: string;
+  title?: string | null;
+  filePath?: string | null;
   galleries?: Gallery[];
   performers?: Entity[];
   tags?: Entity[];
-  studio?: any;
-  date?: string;
-  details?: string;
-  photographer?: string;
+  studio?: StudioLike | null;
+  date?: string | null;
+  details?: string | null;
+  photographer?: string | null;
   urls?: string[];
-  [key: string]: any;
 }
 
 function mergeEntitiesById(primary: Entity[] = [], inherited: Entity[] = []): Entity[] {
@@ -103,7 +107,7 @@ function getInheritedTags(galleries: Gallery[] = []): Entity[] {
  * @param {Array} galleries - Array of gallery objects
  * @returns {Object|null} Studio object or null
  */
-function getInheritedStudio(galleries: Gallery[] = []): any {
+function getInheritedStudio(galleries: Gallery[] = []): StudioLike | null {
   for (const gallery of galleries) {
     if (gallery?.studio) {
       return gallery.studio;


### PR DESCRIPTION
## Summary

- Type utility functions (`getSceneTitle`, `getSceneDescription`, `galleryTitle`, `getEntityPath`, `appendInstanceParam`, `getEffectiveImageMetadata`) to accept proper entity types instead of `Record<string, unknown>`
- Remove ~40 `as unknown as Record<string, unknown>` casts at call sites across 16 component files
- Replace `as any` casts in hooks with typed API response generics (`useFilterState`, `useFolderViewTags`, `useHiddenEntities`, `PlaybackControls`)
- Also closes stale issues #501-#505 (Props interfaces already completed in PR #508)

## Approach

**Root cause fix**: The utility functions accepted `Record<string, unknown>` or had index signatures (`[key: string]: unknown`) that prevented structural assignability from `NormalizedScene`, `NormalizedPerformer`, etc. Fixing the function signatures eliminates the need for casts at all call sites.

**Remaining (separate ticket)**: BaseCard/useCardSelection entity prop needs generics, Video.js plugin types are unfixable, scene player reducer state needs `NormalizedScene` typing.

## Test plan

- [x] `tsc --noEmit` — clean (source files)
- [x] `npm run build` — passes
- [x] `npm run lint` — clean
- [x] `npm test` — 1784/1784 pass
- [x] Coverage thresholds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)