### PR TITLE
refactor(client): migrate OCounterButton to useIncrementOCounter (#515)

### DIFF
--- a/client/src/components/ui/OCounterButton.tsx
+++ b/client/src/components/ui/OCounterButton.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { LucideDroplets } from "lucide-react";
-import { apiPost } from "../../api";
+import { useIncrementOCounter } from "../../api/hooks";
 
 /**
  * Interactive O Counter button component
@@ -36,8 +36,8 @@ const OCounterButton = ({
   interactive = true,
 }: Props) => {
   const [count, setCount] = useState(initialCount ?? 0);
-  const [isUpdating, setIsUpdating] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const incrementMutation = useIncrementOCounter();
 
   // Sync count when initialCount changes
   useEffect(() => {
@@ -63,34 +63,28 @@ const OCounterButton = ({
     e.stopPropagation();
 
     // Only allow incrementing for scenes/images with interactive mode
-    if (!interactive || isUpdating || !entityId) {
+    if (!interactive || incrementMutation.isPending || !entityId) {
       return;
     }
 
+    const previousCount = count;
     const newCount = count + 1;
     setCount(newCount); // Optimistic update
     setIsAnimating(true);
-    setIsUpdating(true);
 
     try {
-      let response: { success?: boolean; oCount?: number } | undefined;
-      if (sceneId) {
-        response = await apiPost("/watch-history/increment-o", { sceneId }) as { success?: boolean; oCount?: number };
-      } else if (imageId) {
-        response = await apiPost("/image-view-history/increment-o", { imageId }) as { success?: boolean; oCount?: number };
-      }
+      const response = await incrementMutation.mutateAsync({ sceneId, imageId });
 
       if (response?.success) {
-        setCount(response.oCount ?? count); // Update with server value
-        onChange?.(response.oCount ?? count);
+        setCount(response.oCount ?? newCount); // Update with server value
+        onChange?.(response.oCount ?? newCount);
       }
     } catch (err) {
       console.error(`Error incrementing O counter for ${entityType}:`, err);
-      setCount(count); // Revert on error
+      setCount(previousCount); // Revert on error
     } finally {
       setTimeout(() => {
         setIsAnimating(false);
-        setIsUpdating(false);
       }, 600);
     }
   };
@@ -98,7 +92,7 @@ const OCounterButton = ({
   return (
     <button
       onClick={handleClick}
-      disabled={isUpdating}
+      disabled={incrementMutation.isPending}
       className={`flex items-center ${config.gap} ${config.padding} rounded transition-all hover:scale-105 active:scale-95 relative ${
         isAnimating ? "animate-pulse" : ""
       }`}
@@ -108,11 +102,11 @@ const OCounterButton = ({
         border: variant === "card" || variant === "lightbox" ? "none" : "1px solid var(--border-color)",
         cursor:
           interactive && entityId
-            ? isUpdating
+            ? incrementMutation.isPending
               ? "not-allowed"
               : "pointer"
             : "default",
-        opacity: isUpdating ? 0.7 : 1,
+        opacity: incrementMutation.isPending ? 0.7 : 1,
       }}
       aria-label={
         interactive && entityId

--- a/client/src/contexts/ScenePlayerContext.tsx
+++ b/client/src/contexts/ScenePlayerContext.tsx
@@ -19,7 +19,6 @@ interface ScenePlayerContextValue extends ScenePlayerState {
   shouldResume: boolean;
   dispatch: Dispatch<{ type: string; payload?: unknown }>;
   loadScene: (sceneId: string, instanceId?: string | null) => Promise<void>;
-  incrementOCounter: () => Promise<void>;
   nextScene: () => void;
   prevScene: () => void;
   gotoSceneIndex: (index: number, shouldAutoplay?: boolean) => void;
@@ -109,20 +108,6 @@ export function ScenePlayerProvider({
     }
   }, []);
 
-  // Complex action creators (with side effects or logic)
-  const incrementOCounter = useCallback(async () => {
-    if (!state.scene?.id) return;
-
-    dispatch({ type: "INCREMENT_O_COUNTER_START" });
-    try {
-      await apiPost("/watch-history/increment-o", { sceneId: state.scene.id });
-      dispatch({ type: "INCREMENT_O_COUNTER_SUCCESS" });
-    } catch (error) {
-      console.error("Error incrementing O counter:", error);
-      dispatch({ type: "INCREMENT_O_COUNTER_ERROR" });
-    }
-  }, [state.scene?.id]);
-
   // Playlist navigation helpers (kept for convenience)
   const nextScene = useCallback(() => {
     dispatch({ type: "NEXT_SCENE" });
@@ -194,7 +179,6 @@ export function ScenePlayerProvider({
 
     // Complex actions (with side effects)
     loadScene,
-    incrementOCounter,
 
     // Playlist navigation helpers (kept for convenience)
     nextScene,

--- a/client/src/contexts/scenePlayerReducer.ts
+++ b/client/src/contexts/scenePlayerReducer.ts
@@ -60,7 +60,6 @@ export interface ScenePlayerReducerState {
   shuffleHistory: number[];
   compatibility: Record<string, unknown> | null;
   oCounter: number;
-  oCounterLoading: boolean;
 }
 
 interface ScenePlayerAction {
@@ -107,7 +106,6 @@ export const initialState: ScenePlayerReducerState = {
 
   // O Counter
   oCounter: 0,
-  oCounterLoading: false,
 };
 
 // ============================================================================
@@ -442,25 +440,6 @@ export function scenePlayerReducer(state: ScenePlayerReducerState, action: Scene
       };
 
     // O Counter
-    case "INCREMENT_O_COUNTER_START":
-      return {
-        ...state,
-        oCounterLoading: true,
-      };
-
-    case "INCREMENT_O_COUNTER_SUCCESS":
-      return {
-        ...state,
-        oCounter: state.oCounter + 1,
-        oCounterLoading: false,
-      };
-
-    case "INCREMENT_O_COUNTER_ERROR":
-      return {
-        ...state,
-        oCounterLoading: false,
-      };
-
     case "SET_O_COUNTER":
       return {
         ...state,

--- a/client/src/hooks/useWatchHistory.ts
+++ b/client/src/hooks/useWatchHistory.ts
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { apiGet, apiPost } from "../api";
+import { apiGet } from "../api";
 import { useAuth } from "./useAuth";
 
 /**
- * Hook for watch history state and O counter
+ * Hook for watch history state
  *
  * Note: Playback tracking (play duration, play count) is now handled by the
  * track-activity Video.js plugin in useVideoPlayer.js. This hook only provides:
  * - Watch history state (for resume time display)
- * - O counter increment
  * - Quality tracking
  *
  * @param {string} sceneId - Stash scene ID
@@ -18,11 +17,6 @@ import { useAuth } from "./useAuth";
 interface WatchHistoryData {
   oCount?: number;
   [key: string]: unknown;
-}
-
-interface IncrementOResponse {
-  success: boolean;
-  oCount: number;
 }
 
 export function useWatchHistory(sceneId: string, _playerRef = { current: null }) {
@@ -63,32 +57,6 @@ export function useWatchHistory(sceneId: string, _playerRef = { current: null })
     currentQualityRef.current = quality;
   }, []);
 
-  /**
-   * Increment O counter
-   */
-  const incrementOCounter = useCallback(async () => {
-    if (!sceneId || !isAuthenticated) {
-      return null;
-    }
-
-    try {
-      const response = await apiPost<IncrementOResponse>("/watch-history/increment-o", { sceneId });
-
-      if (response.success) {
-        // Update local state
-        setWatchHistory((prev) => prev ? ({
-          ...prev,
-          oCount: response.oCount,
-        }) : prev);
-
-        return response;
-      }
-    } catch (err) {
-      console.error("Error incrementing O counter:", err);
-      throw err;
-    }
-  }, [sceneId, isAuthenticated]);
-
   // Fetch watch history on mount
   useEffect(() => {
     fetchWatchHistory();
@@ -102,7 +70,6 @@ export function useWatchHistory(sceneId: string, _playerRef = { current: null })
 
     // Methods
     updateQuality,
-    incrementOCounter,
     refresh: fetchWatchHistory,
   };
 }

--- a/client/tests/components/ui/SceneCardSettings.test.tsx
+++ b/client/tests/components/ui/SceneCardSettings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Use vi.hoisted to create mock functions that can be accessed in vi.mock
 const { mockGetSettings } = vi.hoisted(() => ({
@@ -60,8 +61,11 @@ describe("SceneCard respects card display settings", () => {
     details: "This is a test scene description that should be visible.",
   } as any;
 
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter>{children}</MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
   );
 
   beforeEach(() => {

--- a/client/tests/contexts/ScenePlayerContext.test.tsx
+++ b/client/tests/contexts/ScenePlayerContext.test.tsx
@@ -118,7 +118,6 @@ describe("ScenePlayerContext", () => {
 
       // Action creators
       expect(typeof result.current.loadScene).toBe("function");
-      expect(typeof result.current.incrementOCounter).toBe("function");
       expect(typeof result.current.nextScene).toBe("function");
       expect(typeof result.current.prevScene).toBe("function");
       expect(typeof result.current.gotoSceneIndex).toBe("function");
@@ -363,103 +362,6 @@ describe("ScenePlayerContext", () => {
         ids: ["playlist-scene-1"],
         scene_filter: { instance_id: "pl-inst-1" },
       });
-    });
-  });
-
-  // =========================================================================
-  // incrementOCounter
-  // =========================================================================
-
-  describe("incrementOCounter", () => {
-    it("sends increment request and updates counter on success", async () => {
-      mockPost.mockImplementation((url) => {
-        if (url === "/library/scenes") {
-          return Promise.resolve(mockApiResponse());
-        }
-        if (url === "/watch-history/increment-o") {
-          return Promise.resolve({});
-        }
-        return Promise.resolve({});
-      });
-
-      const { result } = renderHook(() => useScenePlayer(), {
-        wrapper: createWrapper(),
-      });
-
-      // Wait for scene to load
-      await waitFor(() => {
-        expect(result.current.scene).not.toBeNull();
-      });
-
-      const prevCounter = result.current.oCounter;
-
-      await act(async () => {
-        await result.current.incrementOCounter();
-      });
-
-      expect(mockPost).toHaveBeenCalledWith("/watch-history/increment-o", {
-        sceneId: "scene-42",
-      });
-      expect(result.current.oCounter).toBe(prevCounter + 1);
-      expect(result.current.oCounterLoading).toBe(false);
-    });
-
-    it("handles increment error gracefully", async () => {
-      mockPost.mockImplementation((url) => {
-        if (url === "/library/scenes") {
-          return Promise.resolve(mockApiResponse());
-        }
-        if (url === "/watch-history/increment-o") {
-          return Promise.reject(new Error("Server error"));
-        }
-        return Promise.resolve({});
-      });
-
-      const { result } = renderHook(() => useScenePlayer(), {
-        wrapper: createWrapper(),
-      });
-
-      // Wait for scene to load
-      await waitFor(() => {
-        expect(result.current.scene).not.toBeNull();
-      });
-
-      const prevCounter = result.current.oCounter;
-
-      await act(async () => {
-        await result.current.incrementOCounter();
-      });
-
-      // Counter should not change on error
-      expect(result.current.oCounter).toBe(prevCounter);
-      expect(result.current.oCounterLoading).toBe(false);
-    });
-
-    it("does not call API when scene is null", async () => {
-      mockPost.mockResolvedValue({
-        findScenes: { scenes: [] },
-      });
-
-      const { result } = renderHook(() => useScenePlayer(), {
-        wrapper: createWrapper({ sceneId: null }),
-      });
-
-      // Wait for any effects to settle
-      await waitFor(() => {
-        expect(result.current.sceneLoading).toBe(false);
-      });
-
-      mockPost.mockClear();
-
-      await act(async () => {
-        await result.current.incrementOCounter();
-      });
-
-      // Should not have called any API since scene is null
-      expect(mockPost).not.toHaveBeenCalledWith(
-        "/watch-history/increment-o",
-        expect.anything()
-      );
     });
   });
 

--- a/client/tests/contexts/scenePlayerReducer.test.ts
+++ b/client/tests/contexts/scenePlayerReducer.test.ts
@@ -63,7 +63,6 @@ describe("scenePlayerReducer", () => {
         compatibility: null,
 
         oCounter: 0,
-        oCounterLoading: false,
       });
     });
   });
@@ -428,53 +427,15 @@ describe("scenePlayerReducer", () => {
   });
 
   // -------------------------------------------------------------------------
-  // O Counter lifecycle
+  // O Counter
   // -------------------------------------------------------------------------
-  describe("O Counter lifecycle", () => {
-    it("INCREMENT_O_COUNTER_START sets oCounterLoading true", () => {
+  describe("O Counter", () => {
+    it("SET_O_COUNTER sets the counter value", () => {
       const result = scenePlayerReducer(initialState, {
-        type: "INCREMENT_O_COUNTER_START",
+        type: "SET_O_COUNTER",
+        payload: 42,
       });
-      expect(result.oCounterLoading).toBe(true);
-    });
-
-    it("INCREMENT_O_COUNTER_SUCCESS increments oCounter by 1 and clears loading", () => {
-      const state = { ...initialState, oCounter: 3, oCounterLoading: true };
-      const result = scenePlayerReducer(state, {
-        type: "INCREMENT_O_COUNTER_SUCCESS",
-      });
-
-      expect(result.oCounter).toBe(4);
-      expect(result.oCounterLoading).toBe(false);
-    });
-
-    it("INCREMENT_O_COUNTER_ERROR clears loading without changing counter", () => {
-      const state = { ...initialState, oCounter: 3, oCounterLoading: true };
-      const result = scenePlayerReducer(state, {
-        type: "INCREMENT_O_COUNTER_ERROR",
-      });
-
-      expect(result.oCounter).toBe(3);
-      expect(result.oCounterLoading).toBe(false);
-    });
-
-    it("full cycle: START -> SUCCESS increments correctly", () => {
-      let state: any = { ...initialState, oCounter: 0 };
-
-      state = scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_START" });
-      expect(state.oCounterLoading).toBe(true);
-
-      state = scenePlayerReducer(state, {
-        type: "INCREMENT_O_COUNTER_SUCCESS",
-      });
-      expect(state.oCounter).toBe(1);
-      expect(state.oCounterLoading).toBe(false);
-
-      state = scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_START" });
-      state = scenePlayerReducer(state, {
-        type: "INCREMENT_O_COUNTER_SUCCESS",
-      });
-      expect(state.oCounter).toBe(2);
+      expect(result.oCounter).toBe(42);
     });
   });
 
@@ -1403,13 +1364,6 @@ describe("scenePlayerReducer", () => {
           initialQuality: "1080p",
         },
       });
-      expect(snapshot(state)).toEqual(frozen);
-    });
-
-    it("does not mutate state on INCREMENT_O_COUNTER_SUCCESS", () => {
-      const state = { ...initialState, oCounter: 5, oCounterLoading: true };
-      const frozen = snapshot(state);
-      scenePlayerReducer(state, { type: "INCREMENT_O_COUNTER_SUCCESS" });
       expect(snapshot(state)).toEqual(frozen);
     });
 

--- a/client/tests/hooks/useWatchHistory.test.tsx
+++ b/client/tests/hooks/useWatchHistory.test.tsx
@@ -12,15 +12,13 @@ vi.mock("../../src/hooks/useAuth", () => ({
 
 vi.mock("../../src/api", () => ({
   apiGet: vi.fn(),
-  apiPost: vi.fn(),
 }));
 
 import { useAuth } from "../../src/hooks/useAuth";
-import { apiGet, apiPost } from "../../src/api";
+import { apiGet } from "../../src/api";
 
 const useAuthMock = useAuth as unknown as Mock;
 const apiGetMock = apiGet as unknown as Mock;
-const apiPostMock = apiPost as unknown as Mock;
 
 describe("useWatchHistory", () => {
   beforeEach(() => {
@@ -77,65 +75,6 @@ describe("useWatchHistory", () => {
       });
 
       expect(apiGet).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("incrementOCounter", () => {
-    it("increments O counter and updates local state", async () => {
-      apiGetMock.mockResolvedValue({ resumeTime: 0, oCount: 1 });
-      apiPostMock.mockResolvedValue({ success: true, oCount: 2 });
-
-      const { result } = renderHook(() => useWatchHistory("scene-1"));
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      let response;
-      await act(async () => {
-        response = await result.current.incrementOCounter();
-      });
-
-      expect(apiPost).toHaveBeenCalledWith("/watch-history/increment-o", {
-        sceneId: "scene-1",
-      });
-      expect(response).toEqual({ success: true, oCount: 2 });
-      expect(result.current.watchHistory!.oCount).toBe(2);
-    });
-
-    it("returns null when not authenticated", async () => {
-      useAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: false });
-
-      const { result } = renderHook(() => useWatchHistory("scene-1"));
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      let response;
-      await act(async () => {
-        response = await result.current.incrementOCounter();
-      });
-
-      expect(response).toBeNull();
-      expect(apiPost).not.toHaveBeenCalled();
-    });
-
-    it("throws on API error", async () => {
-      apiGetMock.mockResolvedValue({ oCount: 1 });
-      apiPostMock.mockRejectedValue(new Error("Server error"));
-
-      const { result } = renderHook(() => useWatchHistory("scene-1"));
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      await expect(
-        act(async () => {
-          await result.current.incrementOCounter();
-        })
-      ).rejects.toThrow("Server error");
     });
   });
 

--- a/client/tests/testUtils.tsx
+++ b/client/tests/testUtils.tsx
@@ -122,7 +122,6 @@ export const createMockApi = () => ({
     getScene: vi.fn().mockResolvedValue(null),
     updateRating: vi.fn().mockResolvedValue({}),
     updateFavorite: vi.fn().mockResolvedValue({}),
-    incrementOCounter: vi.fn().mockResolvedValue({}),
   },
 });
 


### PR DESCRIPTION
## Summary
- Migrate OCounterButton from raw `apiPost` calls to `useIncrementOCounter` mutation hook, gaining automatic query cache invalidation
- Remove dead `incrementOCounter` methods from ScenePlayerContext and useWatchHistory (zero consumers found)
- Remove associated reducer actions (`INCREMENT_O_COUNTER_START/SUCCESS/ERROR`) and `oCounterLoading` state
- Fix stale closure bug in OCounterButton error revert path (was using `count` instead of captured `previousCount`)

Net: **-303 lines**, +25 lines

## Test plan
- [x] All 1761 client tests pass
- [x] All 2090 server tests pass
- [x] Client lint clean
- [x] Client build succeeds
- [x] OCounterButton still functions (uses same API endpoints via mutation hook)
- [x] No consumers of removed dead code (verified via grep)

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)