### PR TITLE
refactor(client): eliminate as-any casts across hooks, pages, and theme system

### DIFF
--- a/client/src/components/pages/Home.tsx
+++ b/client/src/components/pages/Home.tsx
@@ -18,6 +18,7 @@ import { ApiError } from "../../api/client";
 import {
   carouselRulesToFilterState,
   SCENE_FILTER_OPTIONS,
+  type FilterOption,
 } from "../../utils/filterConfig";
 import { buildSearchParams } from "../../utils/urlParams";
 import type { NormalizedScene } from "@peek/shared-types";
@@ -85,7 +86,7 @@ const buildCustomCarouselUrl = (rules: Record<string, unknown> | null | undefine
     currentPage: 1,
     perPage: 24,
     filters: filterState as Record<string, unknown>,
-    filterOptions: SCENE_FILTER_OPTIONS as any,
+    filterOptions: SCENE_FILTER_OPTIONS as FilterOption[],
     viewMode: "grid",
     zoomLevel: "medium",
     gridDensity: "medium",

--- a/client/src/components/pages/PerformerDetail.tsx
+++ b/client/src/components/pages/PerformerDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
+import type { NormalizedImage } from "@peek/shared-types";
 import { useImagesPagination } from "../../hooks/useImagesPagination";
 import { useNavigationState } from "../../hooks/useNavigationState";
 import { usePageTitle } from "../../hooks/usePageTitle";
@@ -782,7 +783,7 @@ const ImagesTab = ({ performerId, instanceId, performerName }: ImagesTabProps) =
             modifier: "INCLUDES",
           },
         },
-      }) as Record<string, any>;
+      }) as { findImages?: { images?: NormalizedImage[]; count?: number } };
       return {
         images: data.findImages?.images || [],
         count: data.findImages?.count || 0,
@@ -791,7 +792,7 @@ const ImagesTab = ({ performerId, instanceId, performerName }: ImagesTabProps) =
     [performerId, instanceId]
   );
 
-  const { images, totalCount, isLoading, lightbox, setImages } = (useImagesPagination as any)({
+  const { images, totalCount, isLoading, lightbox, setImages } = useImagesPagination<NormalizedImage>({
     fetchImages,
     dependencies: [performerId, instanceId],
     externalPage: urlPage,

--- a/client/src/components/pages/SceneDetails.tsx
+++ b/client/src/components/pages/SceneDetails.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import type { NormalizedScene } from "@peek/shared-types";
 import { useScenePlayer } from "../../contexts/ScenePlayerContext";
 import { useCardDisplaySettings } from "../../contexts/CardDisplaySettingsContext";
 import { useConfig } from "../../contexts/ConfigContext";
@@ -34,17 +35,19 @@ const formatDuration = (seconds: number | undefined | null): string => {
  * Merge and deduplicate tags from scene direct tags and inherited tags
  * (inherited tags are pre-computed on server from performers, studio, groups)
  */
-const mergeAllTags = (scene: Record<string, any>) => {
-  const tagMap = new Map();
+const mergeAllTags = (scene: NormalizedScene) => {
+  const tagMap = new Map<string, { id: string; name: string }>();
 
   // Add direct scene tags
-  if (scene.tags) {
-    (scene.tags as any[]).forEach((tag: any) => tagMap.set(tag.id, tag));
+  for (const tag of scene.tags) {
+    tagMap.set(tag.id, tag);
   }
 
   // Add inherited tags (pre-computed from performers, studio, groups)
   if (scene.inheritedTags) {
-    (scene.inheritedTags as any[]).forEach((tag: any) => tagMap.set(tag.id, tag));
+    for (const tag of scene.inheritedTags) {
+      tagMap.set(tag.id, tag);
+    }
   }
 
   return Array.from(tagMap.values());
@@ -56,10 +59,9 @@ const SceneDetails = ({
   showTechnicalDetails,
   setShowTechnicalDetails,
 }: SceneDetailsProps) => {
-  const { scene: rawScene, sceneLoading, compatibility } = useScenePlayer();
-  const scene = rawScene as Record<string, any> | null;
+  const { scene, sceneLoading, compatibility } = useScenePlayer();
   const { getSettings } = useCardDisplaySettings();
-  const sceneSettings = getSettings("scene");
+  const sceneSettings = getSettings("scene") as Record<string, boolean>;
   const { hasMultipleInstances } = useConfig();
 
   // Clips state
@@ -73,8 +75,8 @@ const SceneDetails = ({
       if (!scene?.id) return;
       setClipsLoading(true);
       try {
-        const response = await getClipsForScene(scene.id as string, scene.instanceId as string, true);
-        setClips((response as any).clips || []);
+        const response = await getClipsForScene(scene.id, scene.instanceId, true) as { clips?: Record<string, unknown>[] };
+        setClips(response.clips || []);
       } catch (err) {
         console.error("Failed to fetch clips", err);
         setClips([]);
@@ -183,24 +185,6 @@ const SceneDetails = ({
                   )}
                 </div>
 
-                {/* Director */}
-                {scene.director && (
-                  <div className="mb-4">
-                    <h3
-                      className="text-sm font-medium mb-1"
-                      style={{ color: "var(--text-secondary)" }}
-                    >
-                      Director
-                    </h3>
-                    <p
-                      className="text-base"
-                      style={{ color: "var(--text-primary)" }}
-                    >
-                      {scene.director}
-                    </p>
-                  </div>
-                )}
-
                 {/* Description - Full Width */}
                 {sceneSettings.showDescriptionOnDetail && scene.details && (
                   <div className="mb-6">
@@ -248,7 +232,7 @@ const SceneDetails = ({
                       className="flex gap-4 overflow-x-auto pb-2 scroll-smooth"
                       style={{ scrollbarWidth: "thin" }}
                     >
-                      {scene.performers.map((performer: any) => (
+                      {scene.performers.map((performer) => (
                         <Link
                           key={performer.id}
                           to={getEntityPath('performer', performer, hasMultipleInstances)}
@@ -472,24 +456,13 @@ const SceneDetails = ({
                       <div className="space-y-3">
                         <div className="flex justify-between">
                           <span style={{ color: "var(--text-secondary)" }}>
-                            Format:
-                          </span>
-                          <span
-                            className="font-medium"
-                            style={{ color: "var(--text-primary)" }}
-                          >
-                            {firstFile.format?.toUpperCase() || "Unknown"}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span style={{ color: "var(--text-secondary)" }}>
                             File Size:
                           </span>
                           <span
                             className="font-medium"
                             style={{ color: "var(--text-primary)" }}
                           >
-                            {formatFileSize(firstFile.size)}
+                            {firstFile.size ? formatFileSize(firstFile.size) : "Unknown"}
                           </span>
                         </div>
                       </div>

--- a/client/src/components/pages/StudioDetail.tsx
+++ b/client/src/components/pages/StudioDetail.tsx
@@ -720,29 +720,29 @@ const ImagesTab = ({ studioId, instanceId, studioName, includeSubStudios = false
             ...(includeSubStudios && { depth: -1 }),
           },
         },
-      }) as Record<string, Record<string, unknown>>;
+      }) as { findImages?: { images?: NormalizedImage[]; count?: number } };
       return {
-        images: (data.findImages?.images || []) as NormalizedImage[],
-        count: (data.findImages?.count || 0) as number,
+        images: data.findImages?.images || [],
+        count: data.findImages?.count || 0,
       };
     },
     [studioId, instanceId, includeSubStudios]
   );
 
-  const paginationResult = useImagesPagination({
-    fetchImages: fetchImages as unknown as Parameters<typeof useImagesPagination>[0]['fetchImages'],
-    dependencies: [studioId, instanceId, includeSubStudios] as never[],
+  const paginationResult = useImagesPagination<NormalizedImage>({
+    fetchImages,
+    dependencies: [studioId, instanceId, includeSubStudios],
     externalPage: urlPage,
     onExternalPageChange: handleImagePageChange,
   });
 
   return (
     <PaginatedImageGrid
-      images={paginationResult.images as unknown as NormalizedImage[]}
-      totalCount={paginationResult.totalCount as number}
-      isLoading={paginationResult.isLoading as boolean}
-      lightbox={paginationResult.lightbox as Parameters<typeof PaginatedImageGrid>[0]['lightbox']}
-      setImages={paginationResult.setImages as unknown as (images: NormalizedImage[]) => void}
+      images={paginationResult.images}
+      totalCount={paginationResult.totalCount}
+      isLoading={paginationResult.isLoading}
+      lightbox={paginationResult.lightbox}
+      setImages={paginationResult.setImages}
       emptyMessage={`No images found for ${studioName}`}
       className="mt-6"
     />

--- a/client/src/components/pages/TagDetail.tsx
+++ b/client/src/components/pages/TagDetail.tsx
@@ -664,29 +664,29 @@ const ImagesTab = ({ tagId, instanceId, tagName, includeSubTags = false }: TagIm
             ...(includeSubTags && { depth: -1 }),
           },
         },
-      }) as Record<string, Record<string, unknown>>;
+      }) as { findImages?: { images?: NormalizedImage[]; count?: number } };
       return {
-        images: (data.findImages?.images || []) as NormalizedImage[],
-        count: (data.findImages?.count || 0) as number,
+        images: data.findImages?.images || [],
+        count: data.findImages?.count || 0,
       };
     },
     [tagId, instanceId, includeSubTags]
   );
 
-  const paginationResult = useImagesPagination({
-    fetchImages: fetchImages as unknown as Parameters<typeof useImagesPagination>[0]['fetchImages'],
-    dependencies: [tagId, instanceId, includeSubTags] as never[],
+  const paginationResult = useImagesPagination<NormalizedImage>({
+    fetchImages,
+    dependencies: [tagId, instanceId, includeSubTags],
     externalPage: urlPage,
     onExternalPageChange: handleImagePageChange,
   });
 
   return (
     <PaginatedImageGrid
-      images={paginationResult.images as unknown as NormalizedImage[]}
-      totalCount={paginationResult.totalCount as number}
-      isLoading={paginationResult.isLoading as boolean}
-      lightbox={paginationResult.lightbox as Parameters<typeof PaginatedImageGrid>[0]['lightbox']}
-      setImages={paginationResult.setImages as unknown as (images: NormalizedImage[]) => void}
+      images={paginationResult.images}
+      totalCount={paginationResult.totalCount}
+      isLoading={paginationResult.isLoading}
+      lightbox={paginationResult.lightbox}
+      setImages={paginationResult.setImages}
       emptyMessage={`No images found with tag "${tagName}"`}
       className="mt-6"
     />

--- a/client/src/components/settings/CustomThemeManager.tsx
+++ b/client/src/components/settings/CustomThemeManager.tsx
@@ -190,14 +190,14 @@ const CustomThemeManager = () => {
                         <div
                           className="w-8 h-8 rounded"
                           style={{
-                            backgroundColor: (themeWithDates.config.accents as Record<string, any>)?.primary,
+                            backgroundColor: themeWithDates.config.accents?.primary,
                           }}
                           title="Primary Accent"
                         />
                         <div
                           className="w-8 h-8 rounded"
                           style={{
-                            backgroundColor: (themeWithDates.config.accents as Record<string, any>)?.secondary,
+                            backgroundColor: themeWithDates.config.accents?.secondary,
                           }}
                           title="Secondary Accent"
                         />

--- a/client/src/components/ui/ActiveFilterChips.tsx
+++ b/client/src/components/ui/ActiveFilterChips.tsx
@@ -1,12 +1,6 @@
 import { LucideX } from "lucide-react";
+import type { FilterOption } from "../../utils/filterConfig";
 import Button from "./Button";
-
-interface FilterOption {
-  key: string;
-  label: string;
-  type: string;
-  options?: Array<{ value: string; label: string }>;
-}
 
 interface PermanentFiltersMetadata {
   performers?: Array<{ id: string; name: string }>;

--- a/client/src/components/ui/ScenesLikeThis.tsx
+++ b/client/src/components/ui/ScenesLikeThis.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import type { NormalizedScene } from "@peek/shared-types";
 import { apiGet } from "../../api";
 import SceneGrid from "../scene-search/SceneGrid";
 import Pagination from "./Pagination";
@@ -11,7 +12,7 @@ interface Props {
 
 const ScenesLikeThis = ({ sceneId, onCountChange }: Props) => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [scenes, setScenes] = useState<Array<{ id: string; [key: string]: unknown }>>([]);
+  const [scenes, setScenes] = useState<NormalizedScene[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [totalCount, setTotalCount] = useState(0);
@@ -31,7 +32,7 @@ const ScenesLikeThis = ({ sceneId, onCountChange }: Props) => {
         `/library/scenes/${currentSceneId}/similar?page=${pageNum}`,
       );
 
-      const { scenes: newScenes, count } = data as { scenes: Array<{ id: string; [key: string]: unknown }>; count: number };
+      const { scenes: newScenes, count } = data as { scenes: NormalizedScene[]; count: number };
       setScenes(newScenes);
       setTotalCount(count);
       // Notify parent of count change for tab badge
@@ -118,7 +119,7 @@ const ScenesLikeThis = ({ sceneId, onCountChange }: Props) => {
 
       {/* Scene Grid - reuse existing component */}
       <SceneGrid
-        scenes={scenes as any}
+        scenes={scenes}
         loading={loading}
         error={null}
         currentPage={page}

--- a/client/src/components/ui/SearchControls.tsx
+++ b/client/src/components/ui/SearchControls.tsx
@@ -32,6 +32,7 @@ import {
   buildSceneFilter,
   buildStudioFilter,
   buildTagFilter,
+  type FilterOption,
 } from "../../utils/filterConfig";
 // Note: parseSearchParams and buildSearchParams now handled by useFilterState hook
 import {
@@ -218,11 +219,11 @@ const SearchControls = ({
   });
 
   // Get filter options for this artifact type
-  const filterOptions = useMemo(() => {
+  const filterOptions: FilterOption[] = useMemo(() => {
     // Transform filter options based on unit preference
-    const transformForUnits = (options: Record<string, any>[]) => {
+    const transformForUnits = (options: FilterOption[]) => {
       if (unitPreference !== "imperial") return options;
-      return options.map((opt: Record<string, any>) => {
+      return options.map((opt) => {
         // Transform height filter for imperial
         if (opt.key === "height") {
           return {
@@ -278,7 +279,7 @@ const SearchControls = ({
   // Track collapsed state for each filter section
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>(() => {
     const initial: Record<string, boolean> = {};
-    filterOptions.forEach((opt: Record<string, any>) => {
+    filterOptions.forEach((opt) => {
       if (opt.type === "section-header" && opt.collapsible) {
         initial[opt.key] = !opt.defaultOpen;
       }
@@ -988,7 +989,7 @@ const SearchControls = ({
             {/* Active Filter Chips */}
             <ActiveFilterChips
               filters={filters}
-              filterOptions={filterOptions as any}
+              filterOptions={filterOptions}
               onRemoveFilter={handleRemoveFilter}
               onChipClick={handleFilterChipClick}
               permanentFilters={permanentFilters}
@@ -1034,7 +1035,7 @@ const SearchControls = ({
         highlightedFilterKey={highlightedFilterKey}
         filterRefs={filterRefs}
       >
-        {filterOptions.map((opt: Record<string, any>, index: number) => {
+        {filterOptions.map((opt, index) => {
           const { defaultValue, key, type, ...rest } = opt;
 
           // Render section header
@@ -1128,10 +1129,10 @@ const SearchControls = ({
               isHighlighted={highlightedFilterKey === key}
               onChange={(value: unknown) => handleFilterChange(key, value)}
               value={(localFilters as Record<string, any>)[key] || defaultValue}
-              type={type}
-              label={filterProps.label}
+              type={type as "select" | "searchable-select" | "checkbox" | "number" | "text" | "date" | "range" | "imperial-height-range" | "date-range" | "time-range"}
+              label={filterProps.label!}
               modifierOptions={modifierOptions}
-              modifierValue={(localFilters as Record<string, any>)[modifierKey] || defaultModifier}
+              modifierValue={modifierKey ? (localFilters as Record<string, any>)[modifierKey] : defaultModifier}
               onModifierChange={(value: unknown) =>
                 modifierKey && handleFilterChange(modifierKey, value)
               }

--- a/client/src/components/ui/TagChips.tsx
+++ b/client/src/components/ui/TagChips.tsx
@@ -1,10 +1,15 @@
 import { Link } from "react-router-dom";
 import { useConfig } from "../../contexts/ConfigContext";
 import { getEntityPath } from "../../utils/entityLinks";
-import type { TagRef } from "@peek/shared-types";
+
+interface TagLike {
+  id: string;
+  name: string;
+  instanceId?: string;
+}
 
 interface Props {
-  tags: TagRef[] | null | undefined;
+  tags: TagLike[] | null | undefined;
 }
 
 /**

--- a/client/src/hooks/useImagesPagination.ts
+++ b/client/src/hooks/useImagesPagination.ts
@@ -15,25 +15,24 @@ import { usePaginatedLightbox } from "./usePaginatedLightbox";
  */
 interface ImageItem {
   id: string;
-  [key: string]: unknown;
 }
 
-interface UseImagesPaginationOptions {
-  fetchImages: (page: number, perPage: number) => Promise<{ images?: ImageItem[]; count?: number }>;
+interface UseImagesPaginationOptions<T extends ImageItem = ImageItem> {
+  fetchImages: (page: number, perPage: number) => Promise<{ images?: T[]; count?: number }>;
   dependencies?: unknown[];
   perPage?: number;
   externalPage: number;
   onExternalPageChange: (page: number) => void;
 }
 
-export function useImagesPagination({
+export function useImagesPagination<T extends ImageItem = ImageItem>({
   fetchImages,
   dependencies = [],
   perPage = 100,
   externalPage,
   onExternalPageChange,
-}: UseImagesPaginationOptions) {
-  const [images, setImages] = useState<ImageItem[]>([]);
+}: UseImagesPaginationOptions<T>) {
+  const [images, setImages] = useState<T[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
@@ -84,7 +83,7 @@ export function useImagesPagination({
   }, [lightbox.currentPage, ...dependencies]);
 
   // Wrapper to update images (for lightbox modifications like rating changes)
-  const handleImagesUpdate = useCallback((updatedImages: ImageItem[]) => {
+  const handleImagesUpdate = useCallback((updatedImages: T[]) => {
     setImages(updatedImages);
   }, []);
 

--- a/client/src/hooks/usePaginatedLightbox.ts
+++ b/client/src/hooks/usePaginatedLightbox.ts
@@ -214,7 +214,7 @@ export function usePaginatedLightbox({
     // Lightbox handlers
     openLightbox,
     closeLightbox: handleLightboxClose,
-    onPageBoundary: totalPages > 1 ? handlePageBoundary : undefined,
+    onPageBoundary: totalPages > 1 ? handlePageBoundary : () => false,
     onIndexChange: handleLightboxIndexChange,
 
     // For consuming pending navigation after page load

--- a/client/src/themes/ThemeContext.ts
+++ b/client/src/themes/ThemeContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from "react";
+import type { ThemeConfig } from "./themes";
 
 export interface ThemeDefinition {
   name: string;
@@ -10,7 +11,7 @@ export interface ThemeDefinition {
 export interface CustomTheme {
   id: number;
   name: string;
-  config: Record<string, unknown>;
+  config: ThemeConfig;
 }
 
 export interface AvailableTheme {

--- a/client/src/themes/ThemeProvider.tsx
+++ b/client/src/themes/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { apiGet } from "../api";
-import { ThemeContext } from "./ThemeContext";
+import { ThemeContext, type CustomTheme, type ThemeDefinition } from "./ThemeContext";
 import {
   themes as builtInThemes,
   defaultTheme,
@@ -8,8 +8,8 @@ import {
 } from "./themes";
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
-  const [customThemes, setCustomThemes] = useState<any[]>([]);
-  const [allThemes, setAllThemes] = useState<Record<string, any>>(builtInThemes as Record<string, any>);
+  const [customThemes, setCustomThemes] = useState<CustomTheme[]>([]);
+  const [allThemes, setAllThemes] = useState<Record<string, ThemeDefinition>>(builtInThemes as Record<string, ThemeDefinition>);
 
   const [currentTheme, setCurrentTheme] = useState(() => {
     // Load theme from localStorage or use default
@@ -21,13 +21,13 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     const loadCustomThemes = async () => {
       try {
-        const data = await apiGet("/themes/custom") as any;
+        const data = await apiGet("/themes/custom") as { themes?: CustomTheme[] };
         const themes = data.themes || [];
         setCustomThemes(themes);
 
         // Merge built-in themes with custom themes
-        const merged: Record<string, any> = { ...builtInThemes };
-        themes.forEach((customTheme: any) => {
+        const merged: Record<string, ThemeDefinition> = { ...(builtInThemes as Record<string, ThemeDefinition>) };
+        themes.forEach((customTheme) => {
           const key = `custom-${customTheme.id}`;
           merged[key] = {
             name: customTheme.name,
@@ -40,7 +40,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
       } catch (error) {
         // If API call fails (not authenticated, etc.), just use built-in themes
         console.error("Failed to load custom themes:", error);
-        setAllThemes(builtInThemes as Record<string, any>);
+        setAllThemes(builtInThemes as Record<string, ThemeDefinition>);
       }
     };
 
@@ -56,13 +56,13 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
   const refreshCustomThemes = async () => {
     try {
-      const data = await apiGet("/themes/custom") as any;
+      const data = await apiGet("/themes/custom") as { themes?: CustomTheme[] };
       const themes = data.themes || [];
       setCustomThemes(themes);
 
       // Merge built-in themes with custom themes
-      const merged: Record<string, any> = { ...builtInThemes };
-      themes.forEach((customTheme: any) => {
+      const merged: Record<string, ThemeDefinition> = { ...(builtInThemes as Record<string, ThemeDefinition>) };
+      themes.forEach((customTheme) => {
         const key = `custom-${customTheme.id}`;
         merged[key] = {
           name: customTheme.name,
@@ -85,15 +85,16 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     if (theme) {
       // Apply all theme properties to CSS custom properties
       Object.entries(theme.properties).forEach(([property, value]) => {
-        root.style.setProperty(property, value as string);
+        root.style.setProperty(property, value);
       });
-    } else if ((builtInThemes as Record<string, any>)[currentTheme]) {
+    } else {
       // Fallback to built-in theme if custom theme not loaded yet
-      Object.entries((builtInThemes as Record<string, any>)[currentTheme].properties).forEach(
-        ([property, value]) => {
-          root.style.setProperty(property, value as string);
-        }
-      );
+      const builtIn = (builtInThemes as Record<string, ThemeDefinition>)[currentTheme];
+      if (builtIn) {
+        Object.entries(builtIn.properties).forEach(([property, value]) => {
+          root.style.setProperty(property, value);
+        });
+      }
     }
   }, [currentTheme, allThemes]);
 

--- a/client/src/themes/themes.ts
+++ b/client/src/themes/themes.ts
@@ -8,7 +8,7 @@ import {
   generateToastColors,
 } from "../utils/colorScale";
 
-interface ThemeConfig {
+export interface ThemeConfig {
   mode: string;
   fonts: { brand: string; heading: string; body: string; mono: string };
   colors: { background: string; backgroundSecondary: string; backgroundCard: string; text: string; border: string };

--- a/client/src/utils/filterConfig.ts
+++ b/client/src/utils/filterConfig.ts
@@ -9,6 +9,31 @@ import {
   inchesToCm,
 } from "./unitConversions";
 
+/** Shared type for filter configuration objects used across filter UI, URL serialization, and filter chips */
+export interface FilterOption {
+  key: string;
+  type: string;
+  label?: string;
+  multi?: boolean;
+  defaultValue?: unknown;
+  placeholder?: string;
+  entityType?: string;
+  options?: Array<{ value: string; label: string }>;
+  modifierKey?: string;
+  modifierOptions?: Array<{ value: string; label: string }>;
+  defaultModifier?: string;
+  hierarchyKey?: string;
+  supportsHierarchy?: boolean;
+  hierarchyLabel?: string;
+  countFilterContext?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  valueUnit?: string;
+  collapsible?: boolean;
+  defaultOpen?: boolean;
+}
+
 // Scene sorting options (alphabetically organized by label)
 // Note: scene_index is added dynamically when group filter is active
 export const SCENE_SORT_OPTIONS_BASE = [

--- a/client/src/utils/urlParams.ts
+++ b/client/src/utils/urlParams.ts
@@ -2,22 +2,7 @@
  * Utility functions for persisting filter/sort state to URL query parameters
  */
 import { makeCompositeKey } from "./compositeKey";
-
-/**
- * Serialize filter state to URL query parameters
- *
- * @param {Object} filters - Filter state object
- * @param {Array} filterOptions - Filter configuration from filterConfig.js
- * @returns {URLSearchParams} URL search params object
- */
-interface FilterOption {
-  key: string;
-  type: string;
-  multi?: boolean;
-  modifierKey?: string;
-  hierarchyKey?: string;
-  options?: Array<{ value: string; label: string }>;
-}
+import type { FilterOption } from "./filterConfig";
 
 interface SearchState {
   searchText: string;

--- a/client/tests/hooks/usePaginatedLightbox.test.tsx
+++ b/client/tests/hooks/usePaginatedLightbox.test.tsx
@@ -198,7 +198,8 @@ describe("usePaginatedLightbox", () => {
         } as any)
       );
 
-      expect(result.current.onPageBoundary).toBeUndefined();
+      // With only 1 page, onPageBoundary is a no-op that returns false
+      expect(result.current.onPageBoundary("next")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace `as any` casts with proper TypeScript generics (`useImagesPagination<T>`), shared interfaces (`FilterOption`), and structural typing (`TagLike`)
- Export `ThemeConfig` type and use it to properly type `CustomTheme.config` and `ThemeProvider` internals
- Remove dead code: `scene.director` section (director is a Group field), `firstFile.format` (never populated by API)

## Test Plan
- [x] All 1761 client tests pass
- [x] TypeScript compiles with zero source file errors
- [x] Client lint clean
- [x] Production build succeeds
- [x] Updated `usePaginatedLightbox` test to match new `onPageBoundary` return type

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)