### PR TITLE
feat: use marker screenshots as clip card covers

### DIFF
--- a/client/src/components/cards/ClipCard.tsx
+++ b/client/src/components/cards/ClipCard.tsx
@@ -17,6 +17,7 @@ export interface Clip {
   seconds?: number | null;
   endSeconds?: number | null;
   isGenerated?: boolean;
+  screenshotUrl?: string | null;
   primaryTag?: { id: string; name: string } | null;
   tags?: Array<{ id: string; name: string }>;
   scene?: {

--- a/client/src/components/cards/ClipCardPreview.tsx
+++ b/client/src/components/cards/ClipCardPreview.tsx
@@ -15,8 +15,8 @@ const ClipCardPreview = ({ clip, objectFit = "cover" }: Props) => {
 
   // Get preview URLs
   const previewUrl = clip.isGenerated ? getClipPreviewUrl(clip.id) : null;
-  // pathScreenshot is already transformed to a proxy URL by the server
-  const screenshotUrl = clip.scene?.pathScreenshot || null;
+  // Prefer the marker's own screenshot over the scene cover
+  const screenshotUrl = clip.screenshotUrl || clip.scene?.pathScreenshot || null;
 
   // Detect hover capability (mouse/trackpad vs touch-only)
   useEffect(() => {

--- a/client/tests/components/cards/ClipCardPreview.test.tsx
+++ b/client/tests/components/cards/ClipCardPreview.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { act } from "react";
+import ClipCardPreview from "../../../src/components/cards/ClipCardPreview";
+import type { Clip } from "../../../src/components/cards/ClipCard";
+
+vi.mock("../../../src/api", () => ({
+  getClipPreviewUrl: (id: string) => `/api/proxy/clip/${id}/preview`,
+}));
+
+// Mock IntersectionObserver — triggers on observe() to avoid TDZ issue
+let intersectionCallback: IntersectionObserverCallback;
+beforeEach(() => {
+  const mockIntersectionObserver = vi.fn((callback: IntersectionObserverCallback) => {
+    intersectionCallback = callback;
+    return {
+      observe: vi.fn(() => {
+        // Trigger intersection asynchronously after observer is assigned
+        queueMicrotask(() => {
+          intersectionCallback(
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            {} as IntersectionObserver
+          );
+        });
+      }),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    };
+  });
+  vi.stubGlobal("IntersectionObserver", mockIntersectionObserver);
+});
+
+const baseClip: Clip = {
+  id: "1",
+  title: "Test Clip",
+  seconds: 120,
+  endSeconds: 180,
+  sceneId: "scene-1",
+  isGenerated: true,
+  primaryTag: { id: "tag-1", name: "Action" },
+  tags: [],
+  scene: { title: "Test Scene", pathScreenshot: "/scene-cover.jpg" },
+};
+
+describe("ClipCardPreview", () => {
+  it("uses marker screenshot when available", async () => {
+    const clip: Clip = {
+      ...baseClip,
+      screenshotUrl: "/api/proxy/stash?path=%2Fmarker-screenshot.jpg",
+    };
+    const { container } = render(<ClipCardPreview clip={clip} />);
+    // Flush microtask for IntersectionObserver
+    await act(() => Promise.resolve());
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("src", "/api/proxy/stash?path=%2Fmarker-screenshot.jpg");
+  });
+
+  it("falls back to scene cover when no marker screenshot", async () => {
+    const clip: Clip = { ...baseClip, screenshotUrl: null };
+    const { container } = render(<ClipCardPreview clip={clip} />);
+    await act(() => Promise.resolve());
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("src", "/scene-cover.jpg");
+  });
+
+  it("falls back to scene cover when screenshotUrl is undefined", async () => {
+    const clip: Clip = { ...baseClip };
+    const { container } = render(<ClipCardPreview clip={clip} />);
+    await act(() => Promise.resolve());
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("src", "/scene-cover.jpg");
+  });
+
+  it("shows no preview placeholder when neither screenshot exists", async () => {
+    const clip: Clip = {
+      ...baseClip,
+      screenshotUrl: null,
+      scene: { title: "Test Scene", pathScreenshot: null },
+    };
+    const { container } = render(<ClipCardPreview clip={clip} />);
+    await act(() => Promise.resolve());
+    const img = container.querySelector("img");
+    expect(img).toBeNull();
+    expect(container.textContent).toContain("No preview");
+  });
+});

--- a/server/services/ClipQueryBuilder.ts
+++ b/server/services/ClipQueryBuilder.ts
@@ -40,6 +40,7 @@ export interface ClipWithRelations {
   seconds: number;
   endSeconds: number | null;
   primaryTagId: string | null;
+  screenshotPath: string | null;
   isGenerated: boolean;
   stashCreatedAt: Date | null;
   stashUpdatedAt: Date | null;
@@ -65,6 +66,7 @@ interface ClipRow {
   endSeconds: number | null;
   primaryTagId: string | null;
   primaryTagInstanceId: string | null;
+  screenshotPath: string | null;
   isGenerated: number; // SQLite returns 0/1
   stashCreatedAt: string | null;
   stashUpdatedAt: string | null;
@@ -85,6 +87,7 @@ class ClipQueryBuilder {
     c.id, c.stashInstanceId, c.sceneId, c.sceneInstanceId,
     c.title, c.seconds, c.endSeconds,
     c.primaryTagId, c.primaryTagInstanceId,
+    c.screenshotPath,
     c.isGenerated, c.stashCreatedAt, c.stashUpdatedAt,
     s.title AS sceneTitle, s.pathScreenshot AS scenePathScreenshot,
     s.studioId AS sceneStudioId,
@@ -419,6 +422,7 @@ class ClipQueryBuilder {
         seconds: row.seconds,
         endSeconds: row.endSeconds,
         primaryTagId: row.primaryTagId,
+        screenshotPath: row.screenshotPath,
         // SQLite via Prisma raw queries may return number or string for boolean columns
         isGenerated: Number(row.isGenerated) === 1,
         stashCreatedAt: row.stashCreatedAt ? new Date(row.stashCreatedAt) : null,

--- a/server/services/ClipService.ts
+++ b/server/services/ClipService.ts
@@ -28,6 +28,7 @@ export interface ClipWithRelations {
   seconds: number;
   endSeconds: number | null;
   primaryTagId: string | null;
+  screenshotUrl: string | null;
   isGenerated: boolean;
   stashCreatedAt: Date | null;
   stashUpdatedAt: Date | null;
@@ -85,13 +86,15 @@ export class ClipService {
    * Transform clip from query builder to client-safe format with proxy URLs
    */
   private transformClip(clip: RawClipWithRelations): ClipWithRelations {
+    const { screenshotPath, scene, ...rest } = clip;
     return {
-      ...clip,
+      ...rest,
+      screenshotUrl: this.transformUrl(screenshotPath, scene.stashInstanceId),
       scene: {
-        id: clip.scene.id,
-        title: clip.scene.title,
-        pathScreenshot: this.transformUrl(clip.scene.pathScreenshot, clip.scene.stashInstanceId),
-        studioId: clip.scene.studioId,
+        id: scene.id,
+        title: scene.title,
+        pathScreenshot: this.transformUrl(scene.pathScreenshot, scene.stashInstanceId),
+        studioId: scene.studioId,
       },
     };
   }

--- a/server/tests/services/ClipService.test.ts
+++ b/server/tests/services/ClipService.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ClipService } from "../../services/ClipService.js";
+import { clipQueryBuilder } from "../../services/ClipQueryBuilder.js";
 
 describe("ClipService", () => {
   const clipService = new ClipService();
@@ -28,6 +29,107 @@ describe("ClipService", () => {
     it("should return null for non-existent clip", async () => {
       const clip = await clipService.getClipById("nonexistent-clip", 1);
       expect(clip).toBeNull();
+    });
+  });
+
+  describe("screenshot URL transformation", () => {
+    it("should transform screenshotPath to proxy URL", async () => {
+      const rawClip = {
+        id: "marker-1",
+        sceneId: "scene-1",
+        title: "Test Marker",
+        seconds: 30,
+        endSeconds: 60,
+        primaryTagId: "tag-1",
+        screenshotPath: "/scene/1/marker/42/screenshot",
+        isGenerated: true,
+        stashCreatedAt: new Date(),
+        stashUpdatedAt: new Date(),
+        primaryTag: { id: "tag-1", name: "Action", color: "#ff0000" },
+        tags: [],
+        scene: {
+          id: "scene-1",
+          title: "Test Scene",
+          pathScreenshot: "/scene/1/screenshot",
+          studioId: null,
+          stashInstanceId: "default",
+        },
+      };
+
+      vi.spyOn(clipQueryBuilder, "getClipById").mockResolvedValueOnce(rawClip);
+
+      const clip = await clipService.getClipById("marker-1", 1);
+
+      expect(clip).not.toBeNull();
+      expect(clip!.screenshotUrl).toBe(
+        `/api/proxy/stash?path=${encodeURIComponent("/scene/1/marker/42/screenshot")}`
+      );
+      // Raw screenshotPath should not be exposed
+      expect((clip as Record<string, unknown>).screenshotPath).toBeUndefined();
+    });
+
+    it("should return null screenshotUrl when screenshotPath is null", async () => {
+      const rawClip = {
+        id: "marker-2",
+        sceneId: "scene-1",
+        title: "No Screenshot Marker",
+        seconds: 10,
+        endSeconds: null,
+        primaryTagId: null,
+        screenshotPath: null,
+        isGenerated: false,
+        stashCreatedAt: null,
+        stashUpdatedAt: null,
+        primaryTag: null,
+        tags: [],
+        scene: {
+          id: "scene-1",
+          title: "Test Scene",
+          pathScreenshot: "/scene/1/screenshot",
+          studioId: null,
+          stashInstanceId: "default",
+        },
+      };
+
+      vi.spyOn(clipQueryBuilder, "getClipById").mockResolvedValueOnce(rawClip);
+
+      const clip = await clipService.getClipById("marker-2", 1);
+
+      expect(clip).not.toBeNull();
+      expect(clip!.screenshotUrl).toBeNull();
+    });
+
+    it("should include instanceId in screenshot proxy URL for non-default instances", async () => {
+      const rawClip = {
+        id: "marker-3",
+        sceneId: "scene-1",
+        title: "Multi-Instance Marker",
+        seconds: 0,
+        endSeconds: null,
+        primaryTagId: null,
+        screenshotPath: "/scene/1/marker/99/screenshot",
+        isGenerated: true,
+        stashCreatedAt: null,
+        stashUpdatedAt: null,
+        primaryTag: null,
+        tags: [],
+        scene: {
+          id: "scene-1",
+          title: "Test Scene",
+          pathScreenshot: null,
+          studioId: null,
+          stashInstanceId: "instance-2",
+        },
+      };
+
+      vi.spyOn(clipQueryBuilder, "getClipById").mockResolvedValueOnce(rawClip);
+
+      const clip = await clipService.getClipById("marker-3", 1);
+
+      expect(clip).not.toBeNull();
+      expect(clip!.screenshotUrl).toBe(
+        `/api/proxy/stash?path=${encodeURIComponent("/scene/1/marker/99/screenshot")}&instanceId=${encodeURIComponent("instance-2")}`
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Prefer the marker's own screenshot as the static cover image on clip cards instead of the parent scene's cover
- Falls back to scene cover when no marker screenshot exists
- Raw `screenshotPath` is stripped from the API response (only the proxy URL `screenshotUrl` is exposed)

Closes #497

## Changes
- **ClipQueryBuilder**: Added `c.screenshotPath` to SELECT columns and type interfaces
- **ClipService**: Transforms `screenshotPath` → `screenshotUrl` proxy URL, strips raw path from response
- **ClipCard**: Added `screenshotUrl` to `Clip` interface
- **ClipCardPreview**: Prefers `clip.screenshotUrl` over `clip.scene.pathScreenshot`

## Test plan
- [x] ClipService: screenshot proxy URL transformation (3 tests)
- [x] ClipCardPreview: marker screenshot preferred, scene cover fallback, no preview placeholder (4 tests)
- [x] Full server suite passes (2093 tests)
- [x] Full client suite passes (1765 tests)
- [x] Lint clean (server + client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)