### PR TITLE
fix(client): resolve TypeScript errors in 16 test files

### DIFF
--- a/client/tests/api/hooks/useGalleries.test.tsx
+++ b/client/tests/api/hooks/useGalleries.test.tsx
@@ -62,7 +62,7 @@ describe("useGalleryList", () => {
     const mockData = { galleries: [], total: 0 };
     (libraryApi.findGalleries as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useGalleryList(params), {
       wrapper: createWrapper(),
     });
@@ -76,7 +76,7 @@ describe("useGalleryList", () => {
     const mockData = { galleries: [], total: 0 };
     (libraryApi.findGalleries as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useGalleryList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findGalleries).toHaveBeenCalled());

--- a/client/tests/api/hooks/useGroups.test.tsx
+++ b/client/tests/api/hooks/useGroups.test.tsx
@@ -59,7 +59,7 @@ describe("useGroupList", () => {
     const mockData = { groups: [], total: 0 };
     (libraryApi.findGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useGroupList(params), {
       wrapper: createWrapper(),
     });
@@ -73,7 +73,7 @@ describe("useGroupList", () => {
     const mockData = { groups: [], total: 0 };
     (libraryApi.findGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useGroupList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findGroups).toHaveBeenCalled());

--- a/client/tests/api/hooks/useImages.test.tsx
+++ b/client/tests/api/hooks/useImages.test.tsx
@@ -58,7 +58,7 @@ describe("useImageList", () => {
     const mockData = { images: [], total: 0 };
     (libraryApi.findImages as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useImageList(params), {
       wrapper: createWrapper(),
     });
@@ -72,7 +72,7 @@ describe("useImageList", () => {
     const mockData = { images: [], total: 0 };
     (libraryApi.findImages as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useImageList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findImages).toHaveBeenCalled());

--- a/client/tests/api/hooks/usePerformers.test.tsx
+++ b/client/tests/api/hooks/usePerformers.test.tsx
@@ -62,7 +62,7 @@ describe("usePerformerList", () => {
     const mockData = { performers: [], total: 0 };
     (libraryApi.findPerformers as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => usePerformerList(params), {
       wrapper: createWrapper(),
     });
@@ -76,7 +76,7 @@ describe("usePerformerList", () => {
     const mockData = { performers: [], total: 0 };
     (libraryApi.findPerformers as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => usePerformerList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findPerformers).toHaveBeenCalled());
@@ -88,7 +88,7 @@ describe("usePerformerList", () => {
     const mockData = { performers: [], total: 0 };
     (libraryApi.findPerformers as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => usePerformerList(params, "instance-1"), {
       wrapper: createWrapper(),
     });

--- a/client/tests/api/hooks/useScenes.test.tsx
+++ b/client/tests/api/hooks/useScenes.test.tsx
@@ -59,7 +59,7 @@ describe("useSceneList", () => {
     const mockData = { scenes: [], total: 0 };
     (libraryApi.findScenes as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useSceneList(params), {
       wrapper: createWrapper(),
     });
@@ -73,7 +73,7 @@ describe("useSceneList", () => {
     const mockData = { scenes: [], total: 0 };
     (libraryApi.findScenes as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useSceneList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findScenes).toHaveBeenCalled());
@@ -85,7 +85,7 @@ describe("useSceneList", () => {
     const mockData = { scenes: [], total: 0 };
     (libraryApi.findScenes as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useSceneList(params, "instance-1"), {
       wrapper: createWrapper(),
     });

--- a/client/tests/api/hooks/useStudios.test.tsx
+++ b/client/tests/api/hooks/useStudios.test.tsx
@@ -59,7 +59,7 @@ describe("useStudioList", () => {
     const mockData = { studios: [], total: 0 };
     (libraryApi.findStudios as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useStudioList(params), {
       wrapper: createWrapper(),
     });
@@ -73,7 +73,7 @@ describe("useStudioList", () => {
     const mockData = { studios: [], total: 0 };
     (libraryApi.findStudios as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useStudioList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findStudios).toHaveBeenCalled());

--- a/client/tests/api/hooks/useTags.test.tsx
+++ b/client/tests/api/hooks/useTags.test.tsx
@@ -59,7 +59,7 @@ describe("useTagList", () => {
     const mockData = { tags: [], total: 0 };
     (libraryApi.findTags as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     const { result } = renderHook(() => useTagList(params), {
       wrapper: createWrapper(),
     });
@@ -73,7 +73,7 @@ describe("useTagList", () => {
     const mockData = { tags: [], total: 0 };
     (libraryApi.findTags as ReturnType<typeof vi.fn>).mockResolvedValue(mockData);
 
-    const params = { page: 1, perPage: 24 };
+    const params = { filter: { page: 1, per_page: 24 } };
     renderHook(() => useTagList(params), { wrapper: createWrapper() });
 
     await waitFor(() => expect(libraryApi.findTags).toHaveBeenCalled());

--- a/client/tests/components/pages/Galleries.test.tsx
+++ b/client/tests/components/pages/Galleries.test.tsx
@@ -56,23 +56,23 @@ vi.mock("@/utils/entityLinks", () => ({
 
 // Mock API
 const mockUseGalleryList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  useGalleryList: (...args: unknown[]) => mockUseGalleryList(...args),
+  useGalleryList: (..._args: unknown[]) => mockUseGalleryList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
     status: number;
-    constructor(message: string, isInitializing = false) {
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      if (typeof isInitializing === "boolean") {
-        this.isInitializing = isInitializing;
-      }
-      this.status = 500;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -115,13 +115,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -194,8 +194,7 @@ describe("Galleries", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUseGalleryList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -209,8 +208,7 @@ describe("Galleries", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUseGalleryList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/components/pages/Groups.test.tsx
+++ b/client/tests/components/pages/Groups.test.tsx
@@ -50,19 +50,23 @@ vi.mock("@/utils/entityLinks", () => ({
 
 // Mock API
 const mockUseGroupList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  useGroupList: (...args: unknown[]) => mockUseGroupList(...args),
+  useGroupList: (..._args: unknown[]) => mockUseGroupList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
-    constructor(message: string, isInitializing = false) {
+    status: number;
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      this.isInitializing = isInitializing;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -92,13 +96,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -161,8 +165,7 @@ describe("Groups", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUseGroupList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -176,8 +179,7 @@ describe("Groups", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUseGroupList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/components/pages/Home.test.tsx
+++ b/client/tests/components/pages/Home.test.tsx
@@ -39,9 +39,9 @@ const mockApiGet = vi.fn().mockResolvedValue({
 });
 const mockGetCarousels = vi.fn().mockResolvedValue({ carousels: [] });
 vi.mock("@/api", () => ({
-  apiGet: (...args: unknown[]) => mockApiGet(...args),
+  apiGet: (endpoint: string) => mockApiGet(endpoint),
   libraryApi: {
-    getCarousels: (...args: unknown[]) => mockGetCarousels(...args),
+    getCarousels: () => mockGetCarousels(),
     executeCarousel: vi.fn(),
   },
 }));
@@ -60,8 +60,8 @@ vi.mock("@/api/client", () => ({
 const mockMigrateCarouselPreferences = vi.fn((prefs: unknown) => prefs || []);
 vi.mock("@/constants/carousels", () => ({
   CAROUSEL_DEFINITIONS: [],
-  migrateCarouselPreferences: (...args: unknown[]) =>
-    mockMigrateCarouselPreferences(...args),
+  migrateCarouselPreferences: (prefs: unknown) =>
+    mockMigrateCarouselPreferences(prefs),
 }));
 
 vi.mock("@/utils/entityLinks", () => ({
@@ -115,11 +115,11 @@ vi.mock("@/components/ui/index", () => ({
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       <h1>{title as string}</h1>
-      {subtitle && <p>{subtitle as string}</p>}
+      {subtitle ? <p>{subtitle as string}</p> : null}
     </div>
   ),
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   SceneCarousel: ({ title }: Record<string, unknown>) => (
     <div data-testid="scene-carousel">{title as string}</div>

--- a/client/tests/components/pages/Images.test.tsx
+++ b/client/tests/components/pages/Images.test.tsx
@@ -74,23 +74,23 @@ vi.mock("@tanstack/react-query", async () => {
 
 // Mock API
 const mockUseImageList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  useImageList: (...args: unknown[]) => mockUseImageList(...args),
+  useImageList: (..._args: unknown[]) => mockUseImageList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
     status: number;
-    constructor(message: string, isInitializing = false) {
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      if (typeof isInitializing === "boolean") {
-        this.isInitializing = isInitializing;
-      }
-      this.status = 500;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -146,13 +146,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -223,8 +223,7 @@ describe("Images", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUseImageList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -238,8 +237,7 @@ describe("Images", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUseImageList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/components/pages/Performers.test.tsx
+++ b/client/tests/components/pages/Performers.test.tsx
@@ -50,19 +50,23 @@ vi.mock("@/utils/entityLinks", () => ({
 
 // Mock API
 const mockUsePerformerList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  usePerformerList: (...args: unknown[]) => mockUsePerformerList(...args),
+  usePerformerList: (..._args: unknown[]) => mockUsePerformerList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
-    constructor(message: string, isInitializing = false) {
+    status: number;
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      this.isInitializing = isInitializing;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -93,13 +97,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -160,8 +164,7 @@ describe("Performers", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUsePerformerList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -175,8 +178,7 @@ describe("Performers", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUsePerformerList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/components/pages/Studios.test.tsx
+++ b/client/tests/components/pages/Studios.test.tsx
@@ -49,19 +49,23 @@ vi.mock("@/utils/entityLinks", () => ({
 
 // Mock API
 const mockUseStudioList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  useStudioList: (...args: unknown[]) => mockUseStudioList(...args),
+  useStudioList: (..._args: unknown[]) => mockUseStudioList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
-    constructor(message: string, isInitializing = false) {
+    status: number;
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      this.isInitializing = isInitializing;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -91,13 +95,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -160,8 +164,7 @@ describe("Studios", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUseStudioList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -175,8 +178,7 @@ describe("Studios", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUseStudioList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/components/pages/Tags.test.tsx
+++ b/client/tests/components/pages/Tags.test.tsx
@@ -50,19 +50,23 @@ vi.mock("@/utils/entityLinks", () => ({
 
 // Mock API
 const mockUseTagList = vi.fn(() => ({
-  data: null,
+  data: null as Record<string, unknown> | null,
   isLoading: false,
-  error: null,
+  error: null as Error | null,
 }));
 vi.mock("@/api/hooks", () => ({
-  useTagList: (...args: unknown[]) => mockUseTagList(...args),
+  useTagList: (..._args: unknown[]) => mockUseTagList(),
 }));
 vi.mock("@/api/client", () => ({
   ApiError: class ApiError extends Error {
     isInitializing = false;
-    constructor(message: string, isInitializing = false) {
+    status: number;
+    data: Record<string, unknown>;
+    constructor(message: string, status = 500, data: Record<string, unknown> = {}) {
       super(message);
-      this.isInitializing = isInitializing;
+      this.status = status;
+      this.data = data;
+      this.isInitializing = status === 503 && data.ready === false;
     }
   },
 }));
@@ -104,13 +108,13 @@ vi.mock("@/components/ui/index", () => ({
       </div>
     );
   },
-  PageLayout: ({ children }: Record<string, unknown>) => (
-    <div data-testid="page-layout">{children as React.ReactNode}</div>
+  PageLayout: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="page-layout">{children}</div>
   ),
   PageHeader: ({ title, subtitle }: Record<string, unknown>) => (
     <div data-testid="page-header">
       {title as string}
-      {subtitle && <span>{subtitle as string}</span>}
+      {subtitle ? <span>{subtitle as string}</span> : null}
     </div>
   ),
   ErrorMessage: ({ error }: Record<string, unknown>) => (
@@ -176,8 +180,7 @@ describe("Tags", () => {
 
   describe("Error State", () => {
     it("shows ErrorMessage when error is present and not initializing", () => {
-      const error = new ApiError("Something went wrong");
-      error.isInitializing = false;
+      const error = new ApiError("Something went wrong", 500);
       mockUseTagList.mockReturnValue({
         data: null,
         isLoading: false,
@@ -191,8 +194,7 @@ describe("Tags", () => {
     });
 
     it("shows SyncProgressBanner when error is initializing", () => {
-      const error = new ApiError("init", true);
-      error.isInitializing = true;
+      const error = new ApiError("init", 503, { ready: false });
       mockUseTagList.mockReturnValue({
         data: null,
         isLoading: false,

--- a/client/tests/contexts/scenePlayerReducer.test.ts
+++ b/client/tests/contexts/scenePlayerReducer.test.ts
@@ -3,6 +3,7 @@ import {
   scenePlayerReducer,
   initialState,
 } from "@/contexts/scenePlayerReducer";
+import type { ScenePlayerReducerState } from "@/contexts/scenePlayerReducer";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1209,7 +1210,7 @@ describe("scenePlayerReducer", () => {
     it("preserves other state fields not set by INITIALIZE", () => {
       const state = {
         ...initialState,
-        scene: { id: "existing" },
+        scene: { id: "existing" } as unknown as ScenePlayerReducerState["scene"],
         video: { url: "existing" },
         sessionId: "existing-sess",
         oCounter: 5,

--- a/client/tests/hooks/useGridPageTVNavigation.test.tsx
+++ b/client/tests/hooks/useGridPageTVNavigation.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/hooks/useTVNavigation", () => ({
 }));
 
 const mockSetItemRef = vi.fn();
-const mockIsFocused = vi.fn(() => false);
+const mockIsFocused = vi.fn((_index: number) => false);
 
 vi.mock("@/hooks/useSpatialNavigation", () => ({
   useSpatialNavigation: vi.fn(() => ({


### PR DESCRIPTION
## Summary
- Fix all 64 TypeScript compilation errors across 16 client test files
- Client now compiles with **zero** TypeScript errors (`npx tsc --noEmit` exits 0)

## Error patterns fixed

| Pattern | Count | Fix |
|---------|-------|-----|
| `LibrarySearchParams` type mismatch | 16 | Use `{ filter: { page, per_page } }` instead of `{ page, perPage }` |
| `ApiError` not assignable to `null` | 12 | Type mock return values with union types |
| Spread argument tuple type | 7 | Remove unused spread args or type params explicitly |
| `unknown` not assignable to `ReactNode` | 7 | Type `PageLayout` mock props with `{ children?: ReactNode }` |
| Wrong `ApiError` constructor args | 6 | Use `new ApiError("msg", 500)` matching real constructor |
| `boolean` not assignable to `number` | 6 | Use `new ApiError("init", 503, { ready: false })` for initializing state |
| Partial scene type mismatch | 1 | Cast through `unknown` for stub-only test |
| Callback signature mismatch | 2 | Add `_index` param to match expected signature |

## Test plan
- [x] All 1761 client tests pass
- [x] `npx tsc --noEmit` exits 0 (was 64 errors)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)